### PR TITLE
Added unit tests to cover Temporal.Sdk.Common

### DIFF
--- a/Src/SDK/Common/Temporal.Common.Payloads/public/PayloadContainers.Unnamed.Empty.cs
+++ b/Src/SDK/Common/Temporal.Common.Payloads/public/PayloadContainers.Unnamed.Empty.cs
@@ -29,7 +29,8 @@ namespace Temporal.Common.Payloads
 
                 public bool TryGetValue<TVal>(int index, out TVal value)
                 {
-                    throw CreateNoSuchIndexException(index);
+                    value = default;
+                    return false;
                 }
 
                 public IEnumerable<PayloadContainers.UnnamedEntry> Values

--- a/Src/SDK/Common/Temporal.Common.Payloads/public/PayloadContainers.Unnamed.InstanceBacked.cs
+++ b/Src/SDK/Common/Temporal.Common.Payloads/public/PayloadContainers.Unnamed.InstanceBacked.cs
@@ -45,7 +45,8 @@ namespace Temporal.Common.Payloads
                         return _values[index].TryCast<T, TVal>(out value);
                     }
 
-                    throw CreateNoSuchIndexException(index, Count);
+                    value = default;
+                    return false;
                 }
 
                 public Type GetValueType(int index)

--- a/Src/SDK/Common/Temporal.Common.Payloads/public/PayloadContainers.Unnamed.SerializedDataBacked.cs
+++ b/Src/SDK/Common/Temporal.Common.Payloads/public/PayloadContainers.Unnamed.SerializedDataBacked.cs
@@ -119,7 +119,8 @@ namespace Temporal.Common.Payloads
                         return canDeserialize;
                     }
 
-                    throw CreateNoSuchIndexException(index, Count);
+                    value = default;
+                    return false;
                 }
 
                 public IEnumerable<PayloadContainers.UnnamedEntry> Values

--- a/Src/SDK/Common/Temporal.Common/public/Payload.cs
+++ b/Src/SDK/Common/Temporal.Common/public/Payload.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Temporal.Util;
 

--- a/Src/SDK/Common/Temporal.Sdk.Common.csproj
+++ b/Src/SDK/Common/Temporal.Sdk.Common.csproj
@@ -9,14 +9,11 @@
   </ItemGroup>
   
   <ItemGroup>    
-    <Compile Include="$(SharedSrcBaseDir)\Temporal.Util\internal\Validate.cs"
-             Link="$(SharedSrcBaseLabel)\Temporal.Util\internal\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSrcBaseDir)\Temporal.Util\internal\Validate.cs" Link="$(SharedSrcBaseLabel)\Temporal.Util\internal\%(Filename)%(Extension)" />
 
-    <Compile Include="$(SharedSrcBaseDir)\Temporal.Util\internal\Converter.cs"
-             Link="$(SharedSrcBaseLabel)\Temporal.Util\internal\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSrcBaseDir)\Temporal.Util\internal\Converter.cs" Link="$(SharedSrcBaseLabel)\Temporal.Util\internal\%(Filename)%(Extension)" />
 
-    <Compile Include="$(SharedSrcBaseDir)\Temporal.Util\internal\Format.cs"
-             Link="$(SharedSrcBaseLabel)\Temporal.Util\internal\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSrcBaseDir)\Temporal.Util\internal\Format.cs" Link="$(SharedSrcBaseLabel)\Temporal.Util\internal\%(Filename)%(Extension)" />
   </ItemGroup>
   
 </Project>

--- a/Src/SDK/Common/Temporal.Serialization/public/VoidPayloadConverter.cs
+++ b/Src/SDK/Common/Temporal.Serialization/public/VoidPayloadConverter.cs
@@ -21,7 +21,7 @@ namespace Temporal.Serialization
             }
 
             item = default(T);
-            return true;
+            return false;
         }
 
         public bool TrySerialize<T>(T item, Payloads serializedDataAccumulator)

--- a/Src/SDK/WorkflowClient/Temporal.WorkflowClient/public/TemporalClient.cs
+++ b/Src/SDK/WorkflowClient/Temporal.WorkflowClient/public/TemporalClient.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Temporal.Util;
 using Grpc.Core;
+using Temporal.Api.WorkflowService.V1;
 using Temporal.Common;
 using Temporal.Serialization;
 using Temporal.WorkflowClient.Interceptors;
@@ -297,7 +298,6 @@ namespace Temporal.WorkflowClient
         private Task ConnectAndValidateAsync(CancellationToken cancelToken)
         {
             // @ToDo: Call server to get capabilities
-
             cancelToken.ThrowIfCancellationRequested();
             IsConnected = true;
             return Task.CompletedTask;

--- a/Src/Temporal.Sdk.sln
+++ b/Src/Temporal.Sdk.sln
@@ -56,6 +56,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Managed-Src", "Managed-Src"
 		Shared\Managed-Src\README.md = Shared\Managed-Src\README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{5AAE36A2-5DBE-49D4-AA42-E092B49526E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Temporal.Sdk.Common.Tests", "Tests\Temporal.Sdk.Common.Tests\Temporal.Sdk.Common.Tests.csproj", "{C5F0823D-D9AB-4C0A-97D2-F6292C50170C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +86,10 @@ Global
 		{914A1A6B-4330-4A53-9684-B6A03ADED9E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{914A1A6B-4330-4A53-9684-B6A03ADED9E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{914A1A6B-4330-4A53-9684-B6A03ADED9E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5F0823D-D9AB-4C0A-97D2-F6292C50170C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5F0823D-D9AB-4C0A-97D2-F6292C50170C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5F0823D-D9AB-4C0A-97D2-F6292C50170C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5F0823D-D9AB-4C0A-97D2-F6292C50170C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -97,6 +105,7 @@ Global
 		{914A1A6B-4330-4A53-9684-B6A03ADED9E1} = {23DB6A06-E0D0-4652-BA36-CB26DE6ABD5F}
 		{E3E0E0E6-1584-4548-99A8-36EB2AF2D734} = {FF933DEC-86A3-4061-B431-623D75560363}
 		{D5032D09-C116-4821-A17F-48A877FD2DF6} = {E3E0E0E6-1584-4548-99A8-36EB2AF2D734}
+		{C5F0823D-D9AB-4C0A-97D2-F6292C50170C} = {5AAE36A2-5DBE-49D4-AA42-E092B49526E0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E8142887-814F-45CE-9A2D-B4F6E5B752A8}

--- a/Src/Tests/Directory.Build.props
+++ b/Src/Tests/Directory.Build.props
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    
+    <Import Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')))"
+            Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+       
+    <PropertyGroup>    
+        <Product>Temporal SDK for .NET</Product>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
+        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Common/TestPayload.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Common/TestPayload.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Temporal.Common;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests
+{
+    public class TestPayload
+    {
+        [Fact]
+        public void Test_Payload_Unnamed_With_Null_Argument()
+        {
+            Assert.Throws<ArgumentNullException>(() => Payload.Unnamed(null));
+        }
+
+        [Fact]
+        public void Test_Payload_Unnamed_With_Variadic_Arguments()
+        {
+            Temporal.Common.Payloads.PayloadContainers.Unnamed.InstanceBacked<object> payload = Payload.Unnamed(new object(), new object());
+            AssertUnnamedCorrectness(2, payload);
+        }
+
+        [Fact]
+        public void Test_Payload_Unnamed_With_Array_Arguments()
+        {
+            Temporal.Common.Payloads.PayloadContainers.Unnamed.InstanceBacked<int> payload = Payload.Unnamed(new[] { 1, 2, 3});
+            AssertUnnamedCorrectness(3, payload);
+        }
+
+        [Fact]
+        public void Test_Payload_Unnamed_With_Enumerable_Arguments()
+        {
+            int length = 10;
+            Temporal.Common.Payloads.PayloadContainers.Unnamed.InstanceBacked<string> payload = Payload.Unnamed(Enumerable.Repeat("hello", length));
+            AssertUnnamedCorrectness(length, payload);
+        }
+
+        [Fact]
+        public void Test_Payload_Unnamed_With_List_Arguments()
+        {
+            int length = 10;
+            IReadOnlyList<string> lst = Enumerable.Repeat("hello", length).ToList();
+            Temporal.Common.Payloads.PayloadContainers.Unnamed.InstanceBacked<string> payload = Payload.Unnamed(lst);
+            AssertUnnamedCorrectness(length, payload);
+        }
+
+        private static void AssertUnnamedCorrectness<T>(
+            int length,
+            Temporal.Common.Payloads.PayloadContainers.Unnamed.InstanceBacked<T> payload)
+        {
+            Assert.Equal(length, payload.Count);
+            foreach (Temporal.Common.Payloads.PayloadContainers.UnnamedEntry entry in payload.Values)
+            {
+                T value = entry.GetValue<T>();
+                Assert.IsType<T>(value);
+            }
+
+            for (int i = 0; i < length; ++i)
+            {
+                Assert.True(payload.TryGetValue(i, out T _));
+                payload.GetValue<T>(i);
+            }
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => payload.GetValue<T>(length + 1));
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Enums/TestWorkflowExecutionStatusExtensions.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Enums/TestWorkflowExecutionStatusExtensions.cs
@@ -1,0 +1,23 @@
+using Temporal.Api.Enums.V1;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests
+{
+
+    public class TestWorkflowExecutionStatusExtensions
+    {
+        [Theory]
+        [InlineData(WorkflowExecutionStatus.Unspecified, false)]
+        [InlineData(WorkflowExecutionStatus.Running, false)]
+        [InlineData(WorkflowExecutionStatus.Completed, true)]
+        [InlineData(WorkflowExecutionStatus.Failed, true)]
+        [InlineData(WorkflowExecutionStatus.Canceled, true)]
+        [InlineData(WorkflowExecutionStatus.Terminated, true)]
+        [InlineData(WorkflowExecutionStatus.ContinuedAsNew, true)]
+        [InlineData(WorkflowExecutionStatus.TimedOut, true)]
+        public void Test_IsTerminal_Returns_Correct_Result(WorkflowExecutionStatus status, bool expected)
+        {
+            Assert.Equal(expected, status.IsTerminal());
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/JsonPayloadConverter.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/JsonPayloadConverter.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Text.Json;
+using Google.Protobuf;
+using Temporal.Serialization;
+using Payload = Temporal.Api.Common.V1.Payload;
+
+namespace Temporal.Sdk.Common.Tests
+{
+    internal class JsonPayloadConverter : IPayloadConverter
+    {
+        public bool TryDeserialize<T>(Api.Common.V1.Payloads serializedData, out T item)
+        {
+            item = JsonSerializer.Deserialize<T>(serializedData.Payloads_[0].Data.Span, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            });
+            return true;
+        }
+
+        public bool TrySerialize<T>(T item, Api.Common.V1.Payloads serializedDataAccumulator)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            serializedDataAccumulator.Payloads_.Add(
+                new Payload
+                {
+                    Data = ByteString.CopyFrom(JsonSerializer.SerializeToUtf8Bytes(item)),
+                });
+
+            return true;
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Payloads/AbstractUnnamedTest.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Payloads/AbstractUnnamedTest.cs
@@ -1,0 +1,48 @@
+using System;
+using Temporal.Common.Payloads;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests
+{
+    public abstract class AbstractUnnamedTest
+    {
+        private readonly PayloadContainers.IUnnamed _instance;
+        private readonly int _length;
+
+        protected AbstractUnnamedTest(PayloadContainers.IUnnamed instance, int length)
+        {
+            _instance = instance;
+            _length = length;
+        }
+
+        [Fact]
+        public void Test_IUnnamed_GetValue_Negative_Index()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _instance.GetValue<object>(-1));
+        }
+
+        [Fact]
+        public void Test_IUnnamed_GetValue_Index_Out_Of_Bounds()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _instance.GetValue<object>(_instance.Count + 1));
+        }
+
+        [Fact]
+        public void Test_IUnnamed_TryGetValue_Negative_Index()
+        {
+            Assert.False(_instance.TryGetValue<object>(-1, out _));
+        }
+
+        [Fact]
+        public void Test_IUnnamed_TryGetValue_Index_Out_Of_Bounds()
+        {
+            Assert.False(_instance.TryGetValue<object>(_instance.Count + 1, out _));
+        }
+
+        [Fact]
+        public void Test_IUnnamed_Length_Is_Expected_Value()
+        {
+            Assert.Equal(_length, _instance.Count);
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Payloads/TestPayloadContainersUnnamedEmpty.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Payloads/TestPayloadContainersUnnamedEmpty.cs
@@ -1,0 +1,23 @@
+using System;
+using Temporal.Common.Payloads;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests
+{
+    public class TestPayloadContainersUnnamedEmpty : AbstractUnnamedTest
+    {
+        public TestPayloadContainersUnnamedEmpty()
+            : base(new PayloadContainers.Unnamed.Empty(), 0)
+        {
+        }
+
+        [Fact]
+        public void Test_PayloadContainers_Unnamed_Empty()
+        {
+            var empty = new PayloadContainers.Unnamed.Empty();
+            Assert.Empty(empty);
+            Assert.Throws<ArgumentOutOfRangeException>(() => empty.GetValue<object>(0));
+            Assert.False(empty.TryGetValue<object>(0, out _));
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Payloads/TestPayloadContainersUnnamedInstanceBacked.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Payloads/TestPayloadContainersUnnamedInstanceBacked.cs
@@ -1,0 +1,24 @@
+using Temporal.Common.Payloads;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests
+{
+    public class TestPayloadContainersUnnamedInstanceBacked : AbstractUnnamedTest
+    {
+        private const string DefaultValue = "hello";
+        public TestPayloadContainersUnnamedInstanceBacked()
+            : base(new PayloadContainers.Unnamed.InstanceBacked<string>(new[] { DefaultValue }), 1)
+        {
+        }
+
+        [Fact]
+        public void Test_Payload_Containers_Unnamed_Instance_Backed_Type_Conversion()
+        {
+            var instance = new PayloadContainers.Unnamed.InstanceBacked<string>(new[] { DefaultValue });
+            string value = instance.GetValue<string>(0);
+            Assert.Equal(DefaultValue, value);
+            Assert.True(instance.TryGetValue(0, out value));
+            Assert.Equal(DefaultValue, value);
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Payloads/TestPayloadContainersUnnamedSerializedDataBacked.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Payloads/TestPayloadContainersUnnamedSerializedDataBacked.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Text.Json;
+using Google.Protobuf;
+using Temporal.Api.Common.V1;
+using Temporal.Common.Payloads;
+using Temporal.Serialization;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests
+{
+    public class TestPayloadContainersUnnamedSerializedDataBacked : AbstractUnnamedTest
+    {
+        public TestPayloadContainersUnnamedSerializedDataBacked()
+            : base(
+                new PayloadContainers.Unnamed.SerializedDataBacked(CreateDefaultPayloads(), new JsonPayloadConverter()),
+                1)
+        {
+        }
+
+        [Fact]
+        public void Test_Payload_Containers_Unnamed_Instance_Backed_Type_Conversion()
+        {
+            ConvertedClass defaultValue = ConvertedClass.Default;
+            var instance = new PayloadContainers.Unnamed.SerializedDataBacked(CreateDefaultPayloads(), new JsonPayloadConverter());
+            ConvertedClass value = instance.GetValue<ConvertedClass>(0);
+            AssertWellFormed(defaultValue, value);
+            Assert.True(instance.TryGetValue(0, out value));
+            AssertWellFormed(defaultValue, value);
+        }
+
+        private static void AssertWellFormed(ConvertedClass expected, ConvertedClass actual)
+        {
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.Value, actual.Value);
+        }
+
+        private static Payloads CreateDefaultPayloads()
+        {
+            return new Payloads
+            {
+                Payloads_ =
+                {
+                    new Payload
+                    {
+                        Data = ByteString.CopyFrom(JsonSerializer.SerializeToUtf8Bytes(ConvertedClass.Default)),
+                    },
+                },
+            };
+        }
+
+        private class ConvertedClass
+        {
+            public string Name { get; set; }
+
+            public int Value { get; set; }
+
+            public static ConvertedClass Default => new ConvertedClass { Name = "Test", Value = 1 };
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/SerializableClass.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/SerializableClass.cs
@@ -1,0 +1,17 @@
+namespace Temporal.Common.Payloads
+{
+    internal class SerializableClass
+    {
+        public static SerializableClass Default
+        {
+            get
+            {
+                return new SerializableClass { Name = "Test", Value = 1 };
+            }
+        }
+
+        public string Name { get; set; }
+
+        public int Value { get; set; }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestCatchAllPayloadConverter.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestCatchAllPayloadConverter.cs
@@ -1,0 +1,17 @@
+using Google.Protobuf.Reflection;
+
+namespace Temporal.Sdk.Common.Tests.Serialization
+{
+    // Currently used for debug/dev
+    public class TestCatchAllPayloadConverter
+    {
+    }
+
+    // Currently unused
+    public class TestCompositePayloadCodec
+    {
+    }
+
+    // Extension methods
+    public class TestPayloadConverter{}
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestCompositePayloadConverter.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestCompositePayloadConverter.cs
@@ -1,0 +1,66 @@
+using Temporal.Api.Common.V1;
+using Temporal.Common;
+using Temporal.Common.Payloads;
+using Temporal.Serialization;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests.Serialization
+{
+    public class TestCompositePayloadConverter
+    {
+        [Fact]
+        public void Test_CompositePayloadConverter_Void_Roundtrip()
+        {
+            var converter = new CompositePayloadConverter();
+            var p = new Payloads();
+            Assert.True(converter.TrySerialize(new IPayload.Void(), p));
+            Assert.Empty(p.Payloads_);
+            Assert.True(converter.TryDeserialize(p, out IPayload.Void item));
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_CompositePayloadConverter_Null_Roundtrip()
+        {
+            var converter = new CompositePayloadConverter();
+            var p = new Payloads();
+            Assert.True(converter.TrySerialize<string>(null, p));
+            Assert.Single(p.Payloads_);
+            Assert.True(converter.TryDeserialize(p, out string item));
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CompositePayloadConverter_Unnamed_Roundtrip()
+        {
+            var unnamed = new UnnamedContainerPayloadConverter();
+            unnamed.InitDelegates(new []{new JsonPayloadConverter()});
+            var instance = new CompositePayloadConverter(new IPayloadConverter[]
+            {
+                new VoidPayloadConverter(),
+                new NullPayloadConverter(),
+                new UnnamedContainerPayloadConverter(),
+                new JsonPayloadConverter(),
+            });
+            var p = new Payloads();
+            var data = new PayloadContainers.Unnamed.InstanceBacked<string>(new[] { "hello" });
+            Assert.True(instance.TrySerialize(data, p));
+            Assert.NotEmpty(p.Payloads_);
+            Assert.True(instance.TryDeserialize(p, out PayloadContainers.Unnamed.SerializedDataBacked cl));
+            Assert.NotEmpty(cl);
+            Assert.True(cl.TryGetValue(0, out string val));
+            Assert.Equal("hello", val);
+        }
+
+        [Fact]
+        public void Test_CompositePayloadConverter_Catchall_Roundtrip()
+        {
+            var converter = new CompositePayloadConverter();
+            var p = new Payloads();
+            Assert.True(converter.TrySerialize(new IPayload.Void(), p));
+            Assert.Empty(p.Payloads_);
+            Assert.True(converter.TryDeserialize(p, out IPayload.Void item));
+            Assert.NotNull(item);
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestNullPayloadConverter.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestNullPayloadConverter.cs
@@ -1,0 +1,78 @@
+using System;
+using Google.Protobuf;
+using Temporal.Api.Common.V1;
+using Temporal.Serialization;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests.Serialization
+{
+    public class TestNullPayloadConverter
+    {
+        [Fact]
+        public void Test_NullPayloadConverter_TryDeserialize_Nullable_Type()
+        {
+            ByteString bs = null;
+            var instance = new NullPayloadConverter();
+            ByteString b = PayloadConverter.GetOrCreateBytes(
+                NullPayloadConverter.PayloadMetadataEncodingValue,
+                ref bs);
+            var p = new Payload { Metadata = { { PayloadConverter.PayloadMetadataEncodingKey, b } } };
+            Assert.True(instance.TryDeserialize(
+                new Payloads { Payloads_ = { p }, },
+                out string s));
+            Assert.Null(s);
+        }
+
+        [Fact]
+        public void Test_NullPayloadConverter_TryDeserialize_Nonnullable_Type()
+        {
+            var instance = new NullPayloadConverter();
+            Assert.False(instance.TryDeserialize(
+                new Payloads { Payloads_ = { new Payload() }, },
+                out int _));
+        }
+
+        [Fact]
+        public void Test_NullPayloadConverter_TryDeserialize_MultiplePayloads()
+        {
+            var instance = new NullPayloadConverter();
+            Assert.False(instance.TryDeserialize(
+                new Payloads { Payloads_ = { new Payload(), new Payload() }, },
+                out string _));
+        }
+
+        [Fact]
+        public void Test_NullPayloadConverter_TryDeserialize_NoPayload()
+        {
+            var instance = new NullPayloadConverter();
+            Assert.False(instance.TryDeserialize(new Payloads(), out string _));
+        }
+
+        [Fact]
+        public void Test_NullPayloadConverter_TrySerialize_Null()
+        {
+            var instance = new NullPayloadConverter();
+            Payloads p = new Payloads();
+            Assert.True(instance.TrySerialize<string>(null, p));
+            Assert.NotEmpty(p.Payloads_);
+        }
+
+        [Fact]
+        public void Test_NullPayloadConverter_TrySerialize_ValueType_Null()
+        {
+            var instance = new NullPayloadConverter();
+            Payloads p = new Payloads();
+            Assert.False(instance.TrySerialize(0, p));
+            Assert.Empty(p.Payloads_);
+        }
+
+        [Fact]
+        public void Test_NullPayloadConverter_TrySerialize_Not_Null()
+        {
+            var instance = new NullPayloadConverter();
+            Payloads p = new Payloads();
+            Assert.False(instance.TrySerialize<string>(String.Empty, p));
+            Assert.Empty(p.Payloads_);
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestUnnamedContainerPayloadConverter.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestUnnamedContainerPayloadConverter.cs
@@ -1,0 +1,82 @@
+using System;
+using Google.Protobuf;
+using Temporal.Api.Common.V1;
+using Temporal.Common.Payloads;
+using Temporal.Serialization;
+using Xunit;
+
+namespace Temporal.Sdk.Common.Tests.Serialization
+{
+    public class TestUnnamedContainerPayloadConverter
+    {
+        [Fact]
+        public void Test_UnnamedContainerPayloadConverter_TrySerialize_String()
+        {
+            var instance = new UnnamedContainerPayloadConverter();
+            var p = new Payloads();
+            Assert.False(instance.TrySerialize(String.Empty, p));
+            Assert.Empty(p.Payloads_);
+        }
+
+        [Fact]
+        public void Test_UnnamedContainerPayloadConverter_TrySerialize_Null()
+        {
+            var instance = new UnnamedContainerPayloadConverter();
+            var p = new Payloads();
+            Assert.False(instance.TrySerialize<string>(null, p));
+            Assert.Empty(p.Payloads_);
+        }
+
+        [Fact]
+        public void Test_UnnamedContainerPayloadConverter_TrySerialize_Unnamed_SerializedDataBacked()
+        {
+            var instance = new UnnamedContainerPayloadConverter();
+            instance.InitDelegates(new[]{new JsonPayloadConverter()});
+            var p = new Payloads();
+            var data = new PayloadContainers.Unnamed.SerializedDataBacked(new Payloads
+            {
+                Payloads_ =
+                {
+                    new Payload
+                    {
+                        Data = ByteString.CopyFromUtf8("{\"name\": \"test\", \"value\": 2}"),
+                    }
+                }
+            }, new JsonPayloadConverter());
+            Assert.True(instance.TrySerialize(data, p));
+            Assert.NotEmpty(p.Payloads_);
+            Assert.True(instance.TryDeserialize(p, out PayloadContainers.Unnamed.SerializedDataBacked cl));
+            Assert.NotNull(cl);
+            SerializableClass deserializedData = cl.GetValue<SerializableClass>(0);
+            Assert.Equal("test", deserializedData.Name);
+            Assert.Equal(2, deserializedData.Value);
+        }
+
+        [Fact]
+        public void Test_UnnamedContainerPayloadConverter_TrySerialize_Unnamed_InstanceBacked()
+        {
+            var instance = new UnnamedContainerPayloadConverter();
+            instance.InitDelegates(new[]{new JsonPayloadConverter()});
+            var p = new Payloads();
+            var data = new PayloadContainers.Unnamed.InstanceBacked<string>(new[]{"hello"});
+            Assert.True(instance.TrySerialize(data, p));
+            Assert.NotEmpty(p.Payloads_);
+            Assert.False(instance.TryDeserialize(p, out PayloadContainers.Unnamed.InstanceBacked<string> _));
+            Assert.True(instance.TryDeserialize(p, out PayloadContainers.Unnamed.SerializedDataBacked cl));
+            Assert.NotEmpty(cl);
+            Assert.True(cl.TryGetValue(0, out string val));
+            Assert.Equal("hello", val);
+        }
+
+        [Fact]
+        public void Test_UnnamedContainerPayloadConverter_TrySerialize_Unnamed_Empty()
+        {
+            var instance = new UnnamedContainerPayloadConverter();
+            instance.InitDelegates(new[]{new JsonPayloadConverter()});
+            var p = new Payloads();
+            var data = new PayloadContainers.Unnamed.Empty();
+            Assert.True(instance.TrySerialize(data, p));
+            Assert.Empty(p.Payloads_);
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestVoidPayloadConverter.cs
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Serialization/TestVoidPayloadConverter.cs
@@ -1,0 +1,43 @@
+using Google.Protobuf;
+using Temporal.Api.Common.V1;
+using Temporal.Common;
+using Temporal.Serialization;
+using Xunit;
+using Payload = Temporal.Api.Common.V1.Payload;
+
+namespace Temporal.Sdk.Common.Tests.Serialization
+{
+    public class TestVoidPayloadConverter
+    {
+        [Fact]
+        public void Test_VoidPayloadConverter_Empty_Payload()
+        {
+            var converter = new VoidPayloadConverter();
+            Assert.True(converter.TryDeserialize<IPayload.Void>(new Payloads(), out IPayload.Void value));
+            Assert.NotNull(value);
+        }
+
+        [Fact]
+        public void Test_VoidPayloadConverter_Nonempty_Payload()
+        {
+            var converter = new VoidPayloadConverter();
+            var payloads = new Payloads
+            {
+                Payloads_ = { { new Payload { Data = ByteString.CopyFromUtf8("hello"), } } }
+            };
+            Assert.False(converter.TryDeserialize<string>(payloads, out string value));
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void Test_VoidPayloadConverter_Roundtrip()
+        {
+            var converter = new VoidPayloadConverter();
+            var p = new Payloads();
+            Assert.True(converter.TrySerialize(new IPayload.Void(), p));
+            Assert.Empty(p.Payloads_);
+            Assert.True(converter.TryDeserialize(p, out IPayload.Void item));
+            Assert.NotNull(item);
+        }
+    }
+}

--- a/Src/Tests/Temporal.Sdk.Common.Tests/Temporal.Sdk.Common.Tests.csproj
+++ b/Src/Tests/Temporal.Sdk.Common.Tests/Temporal.Sdk.Common.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\SDK\Common\Temporal.Sdk.Common.csproj" />
+    </ItemGroup>
+
+
+
+</Project>


### PR DESCRIPTION
**Summary**
This PR adds unit tests for the converters and classes in Temporal.SDK.Common. It uncovered what I believe to be an issue with the VoidPayloadConverter. It was returning true in all cases, so that meant the CompositePayloadConverter would never go through all of its options.

**Related Work Items**
#13 

## What was changed
Changed the VoidPayloadConverter to return false when its preconditions fails

## Why?
There are currently no tests within the project.
