### PR TITLE
Int Tests install TemporalLite using multi-platform release files 

### DIFF
--- a/.github/workflows/build-and-test-client-sdk.yml
+++ b/.github/workflows/build-and-test-client-sdk.yml
@@ -211,7 +211,6 @@ jobs:
           - dotnet-moniker: 'NetFx4.6'
             os-moniker: 'MacOS'
 
-          # Temporarily disable INT tests on non-win until we know how to deploy Temporal Lite:
           - os-moniker: 'Linux'
           - os-moniker: 'MacOS'
 
@@ -232,15 +231,12 @@ jobs:
           - os-moniker: 'Win'
             os-specifier: 'windows-latest'
 
-          # Temporarily disable INT tests on non-win until we know how to deploy Temporal Lite:
-          #- os-moniker: 'Linux'
-          #  os-specifier: 'ubuntu-latest'
+          - os-moniker: 'Linux'
+            os-specifier: 'ubuntu-latest'
 
-          #- os-moniker: 'MacOS'
-          #  os-specifier: 'macos-latest'
+          - os-moniker: 'MacOS'
+            os-specifier: 'macos-latest'
 
-          
-          
     steps:
       - name: Clone this repo (sdk-dotnet)
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-test-client-sdk.yml
+++ b/.github/workflows/build-and-test-client-sdk.yml
@@ -211,14 +211,10 @@ jobs:
           - dotnet-moniker: 'NetFx4.6'
             os-moniker: 'MacOS'
 
-          - os-moniker: 'Linux'
-          - os-moniker: 'MacOS'
-
         include:
           - dotnet-moniker: 'NetCore3.1'
             dotnet-version: '3.1.x'
             framework: 'netcoreapp3.1'
-
 
           - dotnet-moniker: 'Net6'
             dotnet-version: '6.0.x'

--- a/.github/workflows/client-sdk-test-report.yml
+++ b/.github/workflows/client-sdk-test-report.yml
@@ -69,10 +69,6 @@ jobs:
     
     steps:
       - name: Generate report (${{matrix.testkind-moniker}}) ${{matrix.os-moniker}}/${{matrix.dotnet-moniker}}/${{matrix.build-config}}
-
-        # Temporarily disable INT tests on non-win until we know how to deploy Temporal Lite:
-        if: ${{ ((matrix.testkind-moniker == 'Int') && (matrix.testkind-moniker == 'Win')) || (matrix.testkind-moniker == 'Unit') }}
-
         uses: dorny/test-reporter@v1.5.0
         with:          
           artifact: TestResults_${{matrix.testkind-moniker}}_${{matrix.os-moniker}}_${{matrix.dotnet-moniker}}_${{matrix.build-config}}

--- a/Src/CodeAnalysis.props
+++ b/Src/CodeAnalysis.props
@@ -4,7 +4,7 @@
 
 	<!-- We use the NuGet package to detect and flag Code Style issues. -->
 	<ItemGroup Condition=" '$(MSBuildProjectExtension)' == '.csproj' ">
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.1.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.11.0" />
 	</ItemGroup>
 	
 	<!-- If we want to switch to the SDK build-in analyser, we will need to remove/comment the above block and use the one below. -->

--- a/Src/Test/Shared/Temporal.TestUtil/internal/ProcessManager.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/ProcessManager.cs
@@ -235,6 +235,22 @@ namespace Temporal.TestUtil
             return _process.HasExited;
         }
 
+        public bool WaitForExit(int timeout = Timeout.Infinite)
+        {
+            int startMillis = (timeout == Timeout.Infinite) ? 0 : Environment.TickCount;
+
+            _process.WaitForExit(timeout);
+
+            if (timeout != Timeout.Infinite)
+            {
+                int elapsedMillis = Environment.TickCount - startMillis;
+                timeout = Math.Max(1, timeout - elapsedMillis);
+            }
+
+            DrainOutput(timeout);
+            return _process.HasExited;
+        }
+
         public bool DrainOutput(int timeout = Timeout.Infinite)
         {
             _errorSignal = new ManualResetEventSlim();

--- a/Src/Test/Shared/Temporal.TestUtil/internal/ProcessManager.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/ProcessManager.cs
@@ -51,7 +51,7 @@ namespace Temporal.TestUtil
             proc.StartInfo.RedirectStandardError = true;
             proc.StartInfo.RedirectStandardInput = true;
 
-            cout?.WriteLine($"Starting proc."
+            cout?.WriteLine($"[ProcMan] Starting proc."
                           + $" (RedirectToCout={redirectToCout};"
                           + $" File=\"{proc.StartInfo.FileName}\";"
                           + $" Args={Format.QuoteOrNull(proc.StartInfo.Arguments)})");

--- a/Src/Test/Shared/Temporal.TestUtil/internal/ProcessManager.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/ProcessManager.cs
@@ -169,8 +169,21 @@ namespace Temporal.TestUtil
 
         public void SendCtrlC()
         {
+            // @ToDo: In the long-term we need to either make the Ctrl-C "signal" work on all
+            // OSes, or get rid of it altogether. However, at best this does tests a little
+            // neater, so we can get to it after we have collected some more maturity of running
+            // integration tests on different versions of Temporal and under different OSes.
+#if NETFRAMEWORK
             bool isSucc = GenerateConsoleCtrlEvent(CtrlEvent.CtrlC, _process.Id);
             _process.StandardInput.Flush();
+#else
+            bool isSucc = false;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                isSucc = GenerateConsoleCtrlEvent(CtrlEvent.CtrlC, _process.Id);
+                _process.StandardInput.Flush();
+            }
+#endif
 
             _process.CloseMainWindow();
             _process.StandardInput.Write("\x3");

--- a/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
@@ -193,7 +193,7 @@ namespace Temporal.TestUtil
 
                 string escapedTemporalLiteExePath = temporalLiteExePath.Replace("\"", "\\\"");
                 ProcessManager chmod = ProcessManager.Start(exePath: "/bin/bash",
-                                                            args: $"-c chmod -v +x \"{escapedTemporalLiteExePath}\"",
+                                                            args: $"-c chmod +x \"{escapedTemporalLiteExePath}\"",
                                                             waitForInitOptions: null,
                                                             redirectToCout: true,
                                                             coutProcNameMoniker: "bash",

--- a/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
@@ -189,11 +189,11 @@ namespace Temporal.TestUtil
                     || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 string temporalLiteExeName = Path.GetFileName(temporalLiteExePath);
-                CoutWriteLine($"Setting eXecutable mode for the TemporalLite binary ({temporalLiteExeName})...");
+                CoutWriteLine($"Setting eXecutable mode for the TemporalLite binary (\"{temporalLiteExeName}\")...");
 
                 string escapedTemporalLiteExePath = temporalLiteExePath.Replace("\"", "\\\"");
                 ProcessManager chmod = ProcessManager.Start(exePath: "/bin/bash",
-                                                            args: $"-v -c chmod +x \"{escapedTemporalLiteExePath}\"",
+                                                            args: $"-c chmod -v +x \"{escapedTemporalLiteExePath}\"",
                                                             waitForInitOptions: null,
                                                             redirectToCout: true,
                                                             coutProcNameMoniker: "bash",

--- a/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
@@ -177,11 +177,11 @@ namespace Temporal.TestUtil
 
         private string GetReleaseBinArchiveUrl()
         {
-            const string ReleaseBinBaseIUrl = @"https://github.com/macrogreg/temporalite/releases/download/v0.0.3/";
+            const string ReleaseBinBaseUrl = @"https://github.com/macrogreg/temporalite/releases/download/v0.0.3/";
             const string ReleaseBinArchiveName_Win_x86x64 = "temporalite_0.0.3_Windows_x86_64.zip";
 
 #if NETFRAMEWORK
-            return ReleaseBinBaseIUrl + ReleaseBinArchiveName_Win_x86x64;
+            return ReleaseBinBaseUrl + ReleaseBinArchiveName_Win_x86x64;
 #else
             const string ReleaseBinArchiveName_Linux_x86x64 = "temporalite_0.0.3_Linux_x86_64.zip";
             const string ReleaseBinArchiveName_Linux_Arm64 = "temporalite_0.0.3_Linux_arm64.zip";
@@ -192,33 +192,33 @@ namespace Temporal.TestUtil
                     && (RuntimeInformation.OSArchitecture == Architecture.X86
                         || RuntimeInformation.OSArchitecture == Architecture.X64))
             {
-                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_Win_x86x64;
+                return ReleaseBinBaseUrl + ReleaseBinArchiveName_Win_x86x64;
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
                     && (RuntimeInformation.OSArchitecture == Architecture.X86
                         || RuntimeInformation.OSArchitecture == Architecture.X64))
             {
-                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_Linux_x86x64;
+                return ReleaseBinBaseUrl + ReleaseBinArchiveName_Linux_x86x64;
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
                     && (RuntimeInformation.OSArchitecture == Architecture.Arm64))
             {
-                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_Linux_Arm64;
+                return ReleaseBinBaseUrl + ReleaseBinArchiveName_Linux_Arm64;
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
                     && (RuntimeInformation.OSArchitecture == Architecture.X86
                         || RuntimeInformation.OSArchitecture == Architecture.X64))
             {
-                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_MacOS_x86x64;
+                return ReleaseBinBaseUrl + ReleaseBinArchiveName_MacOS_x86x64;
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
                     && (RuntimeInformation.OSArchitecture == Architecture.Arm64))
             {
-                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_MacOS_Arm64;
+                return ReleaseBinBaseUrl + ReleaseBinArchiveName_MacOS_Arm64;
             }
 
             CoutWriteLine($"Unexpected OS/Architecture: {RuntimeInformation.OSDescription} / {RuntimeInformation.OSArchitecture}.");

--- a/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
@@ -193,7 +193,7 @@ namespace Temporal.TestUtil
 
                 string escapedTemporalLiteExePath = temporalLiteExePath.Replace("\"", "\\\"");
                 ProcessManager chmod = ProcessManager.Start(exePath: "/bin/bash",
-                                                            args: $"-c chmod +x \"{escapedTemporalLiteExePath}\"",
+                                                            args: $"-c \"chmod -v +x {escapedTemporalLiteExePath}\"",
                                                             waitForInitOptions: null,
                                                             redirectToCout: true,
                                                             coutProcNameMoniker: "bash",

--- a/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
@@ -215,7 +215,7 @@ namespace Temporal.TestUtil
                 return ReleaseBinBaseUrl + ReleaseBinArchiveName_MacOS_x86x64;
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
                     && (RuntimeInformation.OSArchitecture == Architecture.Arm64))
             {
                 return ReleaseBinBaseUrl + ReleaseBinArchiveName_MacOS_Arm64;

--- a/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
+using System.Net.Http;
 using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Temporal.Util;
@@ -12,6 +14,19 @@ namespace Temporal.TestUtil
 {
     internal sealed class TemporalLiteExeTestServerController : ITemporalTestServerController, IDisposable
     {
+        public enum ExeBinarySource
+        {
+            Unspecified = 0,
+            PrecompiledFromToolsRepo = 1,
+            ReleaseBinTemporalLiteRepo = 2
+        }
+
+        private static class Config
+        {
+            public const ExeBinarySource ExeBinarySource
+                                = TemporalLiteExeTestServerController.ExeBinarySource.ReleaseBinTemporalLiteRepo;
+        }
+
         private readonly ITestOutputHelper _cout;
         private readonly bool _redirectServerOutToCout;
 
@@ -24,9 +39,12 @@ namespace Temporal.TestUtil
             _redirectServerOutToCout = redirectServerOutToCout;
         }
 
-        public Task StartAsync()
+        public async Task StartAsync()
         {
-            EnsureRunningWindows();
+            if (Config.ExeBinarySource == ExeBinarySource.PrecompiledFromToolsRepo)
+            {
+                EnsureRunningWindows();
+            }
 
             const int TemporalServicePort = 7233;
             if (IsPortInUse(TemporalServicePort))
@@ -43,20 +61,171 @@ namespace Temporal.TestUtil
                             + CoutPrefix("WARNING!   You may not be running with a test-dedicated TemporalLite instance!"));
                 CoutWriteLine();
 
-                return Task.CompletedTask;
+                return;
             }
 
             string temporalLiteExePath = GetTemporalLiteExePath();
             if (!File.Exists(temporalLiteExePath))
             {
-                InstallTemporalLite(temporalLiteExePath);
+                await InstallTemporalLiteAsync(temporalLiteExePath);
             }
 
             Start(temporalLiteExePath);
-            return Task.CompletedTask;
         }
 
-        private void InstallTemporalLite(string temporalLiteExePath)
+#pragma warning disable CS0162 // Unreachable code detected: Using const bools for settings
+        private Task InstallTemporalLiteAsync(string temporalLiteExePath)
+        {
+            switch (Config.ExeBinarySource)
+            {
+                case ExeBinarySource.PrecompiledFromToolsRepo:
+                    InstallTemporalLite_PrecompiledFromToolsRepo(temporalLiteExePath);
+                    return Task.CompletedTask;
+
+                case ExeBinarySource.ReleaseBinTemporalLiteRepo:
+                    return InstallTemporalLite_ReleaseBinTemporalLiteRepo(temporalLiteExePath);
+
+
+                case ExeBinarySource.Unspecified:
+                default:
+                    throw new Exception($"Unexpected value of {nameof(Config)}.{nameof(Config.ExeBinarySource)}: {Config.ExeBinarySource}.");
+            }
+        }
+#pragma warning restore CS0162 // Unreachable code detected
+
+        private async Task InstallTemporalLite_ReleaseBinTemporalLiteRepo(string temporalLiteExePath)
+        {
+            const string DownloadedArchiveFileName = "Temporalite.Exe.Distro.zip";
+
+            CoutWriteLine();
+            CoutWriteLine($"TemporalLite executable not found at \"{temporalLiteExePath}\".");
+            CoutWriteLine($"Trying to install ({nameof(Config.ExeBinarySource)}=`{Config.ExeBinarySource}`)...");
+            CoutWriteLine();
+
+            string temporalLiteDirPath = Path.GetDirectoryName(temporalLiteExePath);
+            if (Directory.Exists(temporalLiteDirPath))
+            {
+                CoutWriteLine($"Destination dir exists ({temporalLiteDirPath}).");
+            }
+            else
+            {
+                CoutWriteLine($"Destination dir does not exist ({temporalLiteDirPath}). Creating...");
+                DirectoryInfo destDir = Directory.CreateDirectory(temporalLiteDirPath);
+
+                if (destDir.Exists)
+                {
+                    CoutWriteLine($"Destination dir successfully created (${temporalLiteDirPath}).");
+                }
+                else
+                {
+                    CoutWriteLine($"Cound not create destination dir (${temporalLiteDirPath}).");
+                    throw new Exception($"Cound not create destination dir for TemporalLite (${temporalLiteDirPath}).");
+                }
+            }
+
+            string releaseBinArchiveUrl = GetReleaseBinArchiveUrl();
+            string downloadedArchiveFilePath = Path.Combine(temporalLiteDirPath, DownloadedArchiveFileName);
+            CoutWriteLine($"RuntimeEnvironmentInfo: {RuntimeEnvironmentInfo.SingletonInstance}");
+            CoutWriteLine($"Downloading TemporalLite from \"{releaseBinArchiveUrl}\"...");
+
+            long dowloadedFileSize = 0;
+            using (FileStream downloadOutStream = new(downloadedArchiveFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None))
+            {
+                using (HttpClient client = new())
+                {
+                    using (HttpResponseMessage response = await client.GetAsync(releaseBinArchiveUrl))
+                    using (Stream downloadInStream = await response.Content.ReadAsStreamAsync())
+                    {
+                        await downloadInStream.CopyToAsync(downloadOutStream);
+                        dowloadedFileSize = downloadOutStream.Length;
+                    }
+                }
+            }
+
+            if (dowloadedFileSize < 1024)
+            {
+                CoutWriteLine($"Finished downloading TemporalLite distribution archive, but only `{dowloadedFileSize}` bytes were received.");
+                CoutWriteLine($"Most likely the remote file at the specified URL does not exist, or there was a network issue.");
+                CoutWriteLine($"Download URL: \"{releaseBinArchiveUrl}\".");
+                CoutWriteLine($"Downloaded data: \"{downloadedArchiveFilePath}\".");
+                CoutWriteLine($"Giving up.");
+                throw new Exception($"Cannot get TemporalLite distribution:"
+                                  + $" Only `{dowloadedFileSize}` bytes downloaded from"
+                                  + $" \"{releaseBinArchiveUrl}\" to \"{downloadedArchiveFilePath}\".");
+            }
+
+            CoutWriteLine($"Finished downloading TemporalLite to \"{downloadedArchiveFilePath}\". Unpacking...");
+
+            using (FileStream unpackInFileStream = new(downloadedArchiveFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (ZipArchive archive = new(unpackInFileStream, ZipArchiveMode.Read, leaveOpen: true))
+            {
+                foreach (ZipArchiveEntry entry in archive.Entries)
+                {
+                    string entryTargetFilePath = Path.Combine(temporalLiteDirPath, entry.FullName);
+                    CoutWriteLine($"  - \"{entryTargetFilePath}\".");
+                    entry.ExtractToFile(temporalLiteExePath, overwrite: true);
+                }
+            }
+
+            CoutWriteLine($"Unpacking completed.");
+            CoutWriteLine();
+            CoutWriteLine($"TemporalLite has been installed.");
+            CoutWriteLine();
+        }
+
+        private string GetReleaseBinArchiveUrl()
+        {
+            const string ReleaseBinBaseIUrl = @"https://github.com/macrogreg/temporalite/releases/download/v0.0.3/";
+            const string ReleaseBinArchiveName_Win_x86x64 = "temporalite_0.0.3_Windows_x86_64.zip";
+
+#if NETFRAMEWORK
+            return ReleaseBinBaseIUrl + ReleaseBinArchiveName_Win_x86x64;
+#else
+            const string ReleaseBinArchiveName_Linux_x86x64 = "temporalite_0.0.3_Linux_x86_64.zip";
+            const string ReleaseBinArchiveName_Linux_Arm64 = "temporalite_0.0.3_Linux_arm64.zip";
+            const string ReleaseBinArchiveName_MacOS_x86x64 = "temporalite_0.0.3_Darwin_x86_64.zip";
+            const string ReleaseBinArchiveName_MacOS_Arm64 = "temporalite_0.0.3_Darwin_arm64.zip";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    && (RuntimeInformation.OSArchitecture == Architecture.X86
+                        || RuntimeInformation.OSArchitecture == Architecture.X64))
+            {
+                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_Win_x86x64;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    && (RuntimeInformation.OSArchitecture == Architecture.X86
+                        || RuntimeInformation.OSArchitecture == Architecture.X64))
+            {
+                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_Linux_x86x64;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    && (RuntimeInformation.OSArchitecture == Architecture.Arm64))
+            {
+                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_Linux_Arm64;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    && (RuntimeInformation.OSArchitecture == Architecture.X86
+                        || RuntimeInformation.OSArchitecture == Architecture.X64))
+            {
+                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_MacOS_x86x64;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    && (RuntimeInformation.OSArchitecture == Architecture.Arm64))
+            {
+                return ReleaseBinBaseIUrl + ReleaseBinArchiveName_MacOS_Arm64;
+            }
+
+            CoutWriteLine($"Unexpected OS/Architecture: {RuntimeInformation.OSDescription} / {RuntimeInformation.OSArchitecture}.");
+            CoutWriteLine("Giving up.");
+            throw new Exception($"Unexpected OS/Architecture: {RuntimeInformation.OSDescription} / {RuntimeInformation.OSArchitecture}.");
+#endif
+        }
+
+        private void InstallTemporalLite_PrecompiledFromToolsRepo(string temporalLiteExePath)
         {
             const string BuildToolsRepoRootDirName = "temporal-dotnet-buildtools";
             const string TemporalLiteZipDirName = "TemporalLite";
@@ -64,9 +233,11 @@ namespace Temporal.TestUtil
 
             const string TemporalLiteExeZipEntryName = "temporalite-1.16.2.exe";
 
+            EnsureRunningWindows();
+
             CoutWriteLine();
             CoutWriteLine($"TemporalLite executable not found at \"{temporalLiteExePath}\".");
-            CoutWriteLine("Trying to install...");
+            CoutWriteLine($"Trying to install ({nameof(Config.ExeBinarySource)}=`{Config.ExeBinarySource}`)...");
             CoutWriteLine();
 
             string environmentRootDirPath = TestEnvironment.GetEnvironmentRootDirPath();
@@ -95,11 +266,11 @@ namespace Temporal.TestUtil
             string temporalLiteDirPath = Path.GetDirectoryName(temporalLiteExePath);
             if (Directory.Exists(temporalLiteDirPath))
             {
-                CoutWriteLine($"Destination dir exists (${temporalLiteDirPath}).");
+                CoutWriteLine($"Destination dir exists ({temporalLiteDirPath}).");
             }
             else
             {
-                CoutWriteLine($"Destination dir does not exist (${temporalLiteDirPath}). Creating...");
+                CoutWriteLine($"Destination dir does not exist ({temporalLiteDirPath}). Creating...");
                 DirectoryInfo destDir = Directory.CreateDirectory(temporalLiteDirPath);
 
                 if (destDir.Exists)
@@ -208,18 +379,51 @@ namespace Temporal.TestUtil
         {
             if (!TestEnvironment.IsWindows)
             {
-                throw new PlatformNotSupportedException($"{nameof(TemporalLiteExeTestServerController)} currently only supports Windows.");
+                throw new PlatformNotSupportedException($"With the currently specified {nameof(Config)} settings,"
+                                                      + $" {nameof(TemporalLiteExeTestServerController)} currently only supports Windows.");
             }
         }
 
-        private static string GetTemporalLiteExePath()
+#pragma warning disable CS0162 // Unreachable code detected: Using const bools for settings
+        private string GetTemporalLiteExePath()
         {
             const string TemporalLiteExeDirName = "TemporalLite";
-            const string TemporalLiteExeFileName = "temporalite-1.16.2.exe";
+
+            string temporalLiteExeFileName = null;
+
+            if (Config.ExeBinarySource == ExeBinarySource.PrecompiledFromToolsRepo)
+            {
+                temporalLiteExeFileName = "temporalite-1.16.2.exe";
+            }
+            else if (Config.ExeBinarySource == ExeBinarySource.ReleaseBinTemporalLiteRepo)
+
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    temporalLiteExeFileName = "temporalite.exe";
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                        || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    temporalLiteExeFileName = "temporalite";
+                }
+            }
+
+            if (temporalLiteExeFileName == null)
+            {
+                string errMsg = $"Could not decide on TemporalLite exe file name."
+                              + $" {nameof(Config)}.{nameof(Config.ExeBinarySource)}: {Config.ExeBinarySource}."
+                              + $" OSDescription: {RuntimeInformation.OSDescription}.";
+
+                CoutWriteLine(errMsg);
+                CoutWriteLine("Giving up.");
+                throw new Exception(errMsg);
+            }
 
             string binaryRootDirPath = TestEnvironment.GetBinaryRootDirPath();
-            return Path.Combine(binaryRootDirPath, TemporalLiteExeDirName, TemporalLiteExeFileName);
+            return Path.Combine(binaryRootDirPath, TemporalLiteExeDirName, temporalLiteExeFileName);
         }
+#pragma warning restore CS0162 // Unreachable code detected
 
         public void Dispose()
         {

--- a/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
@@ -170,6 +170,39 @@ namespace Temporal.TestUtil
             }
 
             CoutWriteLine($"Unpacking completed.");
+
+            if (File.Exists(temporalLiteExePath))
+            {
+                CoutWriteLine($"The expected TemporalLite executable is among the"
+                            + $" unpacked files ({temporalLiteExePath}).");
+            }
+            else
+            {
+                CoutWriteLine($"The expected TemporalLite executable is NOT among the unpacked"
+                            + $" files ({temporalLiteExePath}). Giving up.");
+                throw new Exception($"TemporalLite distributable downloaded and unpacked,"
+                                  + $" but the expected TemporalLite executable is NOT among"
+                                  + $" the unpacked files ({temporalLiteExePath}).");
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                string temporalLiteExeName = Path.GetFileName(temporalLiteExePath);
+                CoutWriteLine($"Setting eXecutable mode for the TemporalLite binary ({temporalLiteExeName})...");
+
+                string escapedTemporalLiteExePath = temporalLiteExePath.Replace("\"", "\\\"");
+                ProcessManager chmod = ProcessManager.Start(exePath: "/bin/bash",
+                                                            args: $"-v -c chmod +x \"{escapedTemporalLiteExePath}\"",
+                                                            waitForInitOptions: null,
+                                                            redirectToCout: true,
+                                                            coutProcNameMoniker: "bash",
+                                                            _cout);
+                chmod.WaitForExit(timeout: 2000);
+
+                CoutWriteLine($"TemporalLite binary set to be eXecutable.");
+            }
+
             CoutWriteLine();
             CoutWriteLine($"TemporalLite has been installed.");
             CoutWriteLine();

--- a/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
+++ b/Src/Test/Shared/Temporal.TestUtil/internal/TemporalLiteExeTestServerController.cs
@@ -41,10 +41,12 @@ namespace Temporal.TestUtil
 
         public async Task StartAsync()
         {
+#pragma warning disable CS0162 // Unreachable code detected: Using const bools for settings
             if (Config.ExeBinarySource == ExeBinarySource.PrecompiledFromToolsRepo)
             {
                 EnsureRunningWindows();
             }
+#pragma warning restore CS0162 // Unreachable code detected
 
             const int TemporalServicePort = 7233;
             if (IsPortInUse(TemporalServicePort))


### PR DESCRIPTION
### Summary

When running Integration tests, install Temporal Lite from the respective release files, instead of from a custom precompiled binary.

### Details

Before this change, Integration tests only run on Windows.
In order to run them on all supported OSes we want to install Temporal Lite using directly the distribution / release binaries on Temporal Lite. This change enables that.

Note that Temporal Lite does not actually have release binaries. To address that, we [cloned their repo](https://github.com/macrogreg/temporalite) and add that capability. We have a [open PR](https://github.com/DataDog/temporalite/pull/74) to merge the corresponding change into the main TemporalLite repo. Thank you, @mightyshazam, for adding that capability to TemporalLite.