### PR TITLE
Skip `CNAME` file while cleaning GHPages folder during deployment.

### DIFF
--- a/.github/scripts/CopyRefDocsToGHPagesDir.bat
+++ b/.github/scripts/CopyRefDocsToGHPagesDir.bat
@@ -3,13 +3,29 @@
 @SET DEPLDOC_DOCFX_SITE_DIR=%DEPLDOC_DOCFX_WORK_ROOT%\go.temporal.io\sdk-dotnet
 
 @ECHO\
-@ECHO  ** Deleting current contents of the GH Pages directory
+@ECHO  ** Deleting current contents of the GH Pages directory, except "CNAME".
+@ECHO  ** DEPLDOC_GHPAGES_DIR="%DEPLDOC_GHPAGES_DIR%"
 @ECHO\
 
-DEL /F /Q /S "%DEPLDOC_GHPAGES_DIR%"
+@REM Delete files directly in %DEPLDOC_GHPAGES_DIR%, except "CNAME".
+
+@FOR %%i IN ("%DEPLDOC_GHPAGES_DIR%\*") DO (
+    @IF "%%~nxi" EQU "CNAME" (
+        @ECHO Skiping "%%i" during deletion.
+    ) ELSE (
+        @ECHO Deleting "%%i".
+        DEL /F /Q "%%i"
+    )
+)
+
+@REM Delete subdirectories of %DEPLDOC_GHPAGES_DIR%.
+
+@FOR /D %%i IN ("%DEPLDOC_GHPAGES_DIR%\*") DO (
+    RMDIR /S /Q "%%i"
+)
 
 @ECHO\
-@ECHO  ** Copy static web site to the GH Pages directory
+@ECHO  ** Copying static web site to the GH Pages directory.
 @ECHO\
 
 XCOPY "%DEPLDOC_DOCFX_SITE_DIR%" "%DEPLDOC_GHPAGES_DIR%" /E /C /I /Q /R /K /Y


### PR DESCRIPTION
### Summary

Skip `CNAME` file while cleaning GHPages folder during deployment.
This is required to support custom domain working with the GH Pages site.

### Related work items

* https://github.com/temporalio/sdk-dotnet/issues/15
* https://github.com/temporalio/sdk-dotnet/issues/17

### Details

This just touches on some docs generation scripts. I may merge it without a detailed review to keep moving.