### PR TITLE
GH Action uses Auth Token for Git during updates to API Ref Doc site.

### DIFF
--- a/.github/workflows/deploy-api-ref-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-api-ref-docs-to-ghpages.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Clone this repo (sdk-dotnet)
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.GHPAGES_PUSH_TOKEN }}
           path: sdk-dotnet
 
       - name: Setup .NET        
@@ -40,7 +41,6 @@ jobs:
             _build/DocFx/go.temporal.io/
             _build/DocFx/ApiReference.ReadMe.md
             _build/DocFx/HostDocs.bat
-
 
       - name: Replace GitHub Pages dir in the repo
         run: sdk-dotnet\.github\scripts\CopyRefDocsToGHPagesDir.bat


### PR DESCRIPTION
### Summary

GH Action uses Auth Token for Git during updates to API Ref Doc site.

### Related work items

* https://github.com/temporalio/sdk-dotnet/issues/15
* https://github.com/temporalio/sdk-dotnet/issues/17

### Details

This is a trivial change in a GH Workflow spec. To test this in a hosted environment, I will proceed with merging this PR right away.