### PR TITLE
Durably set the GH Pages domain to `dotnet.temporal.io`.

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+dotnet.temporal.io


### PR DESCRIPTION
This change sets the CNAME file in the `master` branch.
The necessary DNS settings are complete, so we can use the intended domain name going forward.
See <https://dotnet.temporal.io/>.