### PR TITLE
Fix Infinite Loop while redeploying GH Pages.

### DIFF
--- a/.github/workflows/deploy-api-ref-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-api-ref-docs-to-ghpages.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - GhPages
+    paths-ignore:
+      - 'docs/**'
   
 jobs:
   


### PR DESCRIPTION
We recently merged documentation improvements (https://github.com/temporalio/sdk-dotnet/pull/95). As a part of that, we started to include the version number of the assembly (binary) into our API Reference Docs. However, our "full" version id includes a suffix created based on the build timestamp.

As a result, the script that auto-updates and auto-deploys out GH Pages went into an infinite loop. :)
Every time it re-generates the pages, they differ from the previous version (by the version number). The script notices the difference and updates the pages again...
and again...
and again...
and . . .

Basically, this needs to stop and this change should do it.
We are excluding the directory that contains the auto-generated files from the trigger mechanism.