### PR TITLE
Adding the ability to inject logging into the client configured by the consumer

### DIFF
--- a/Src/SDK/WorkflowClient/Temporal.WorkflowClient/internal/TemporalServiceInvoker.cs
+++ b/Src/SDK/WorkflowClient/Temporal.WorkflowClient/internal/TemporalServiceInvoker.cs
@@ -6,6 +6,7 @@ using Temporal.Util;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using Temporal.Api.Common.V1;
 using Temporal.Api.Enums.V1;
 using Temporal.Api.History.V1;
@@ -27,11 +28,13 @@ namespace Temporal.WorkflowClient
         private readonly string _clientIdentityMarker;
         private readonly IPayloadConverter _payloadConverter;
         private readonly IPayloadCodec _payloadCodec;
+        private readonly ILogger<TemporalServiceInvoker> _logger;
 
         public TemporalServiceInvoker(WorkflowServiceClientEnvelope grpcClientEnvelope,
                                       string clientIdentityMarker,
                                       IPayloadConverter payloadConverter,
-                                      IPayloadCodec payloadCodec)
+                                      IPayloadCodec payloadCodec,
+                                      ILogger<TemporalServiceInvoker> logger)
         {
             Validate.NotNull(grpcClientEnvelope);
             Validate.NotNullOrWhitespace(clientIdentityMarker);
@@ -44,6 +47,7 @@ namespace Temporal.WorkflowClient
             _clientIdentityMarker = clientIdentityMarker;
             _payloadConverter = payloadConverter;
             _payloadCodec = payloadCodec;
+            _logger = logger;
         }
 
         public void Init(ITemporalClientInterceptor _)

--- a/Src/SDK/WorkflowClient/Temporal.WorkflowClient/public/TemporalClient.cs
+++ b/Src/SDK/WorkflowClient/Temporal.WorkflowClient/public/TemporalClient.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Temporal.Common;
 using Temporal.Serialization;
 using Temporal.Util;
@@ -384,10 +385,12 @@ namespace Temporal.WorkflowClient
 
             WorkflowServiceClientEnvelope grpcClientEnvelope = GetOrCreateGrpcClientEnvelope();
 
+            ILogger<TemporalServiceInvoker> logger = (Configuration.LoggerFactory ?? Configuration.LoggerFactory).CreateLogger<TemporalServiceInvoker>();
             ITemporalClientInterceptor downstream = new TemporalServiceInvoker(grpcClientEnvelope,
                                                                                _identityMarker,
                                                                                payloadConverter,
-                                                                               payloadCodec);
+                                                                               payloadCodec,
+                                                                               logger);
 
             // Build the pipeline by creating the chain of interceptors ending with the sink:
 

--- a/Src/SDK/WorkflowClient/Temporal.WorkflowClient/public/TemporalClientConfiguration.cs
+++ b/Src/SDK/WorkflowClient/Temporal.WorkflowClient/public/TemporalClientConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 #if NETCOREAPP3_1_OR_GREATER
 using System.Security.Cryptography.X509Certificates;
@@ -48,7 +50,8 @@ namespace Temporal.WorkflowClient
                                 string ClientIdentityMarker,
                                 Func<ServiceInvocationPipelineItemFactoryArguments, IPayloadConverter> PayloadConverterFactory,
                                 Func<ServiceInvocationPipelineItemFactoryArguments, IPayloadCodec> PayloadCodecFactory,
-                                Action<ServiceInvocationPipelineItemFactoryArguments, IList<ITemporalClientInterceptor>> ClientInterceptorFactory)
+                                Action<ServiceInvocationPipelineItemFactoryArguments, IList<ITemporalClientInterceptor>> ClientInterceptorFactory,
+                                ILoggerFactory LoggerFactory)
     {
 
         #region Static APIs
@@ -60,7 +63,10 @@ namespace Temporal.WorkflowClient
         /// </summary>
         public static TemporalClientConfiguration ForLocalHost()
         {
-            return new TemporalClientConfiguration();
+            return new TemporalClientConfiguration
+            {
+                LoggerFactory = NullLoggerFactory.Instance,
+            };
         }
 
         /// <summary>
@@ -78,7 +84,8 @@ namespace Temporal.WorkflowClient
                                                                                             clientCertPemFilePath,
                                                                                             clientKeyPemFilePath),
                 Namespace = @namespace,
-                ClientIdentityMarker = null
+                ClientIdentityMarker = null,
+                LoggerFactory = NullLoggerFactory.Instance,
             };
         }
 
@@ -100,7 +107,8 @@ namespace Temporal.WorkflowClient
             {
                 ServiceConnection = TemporalClientConfiguration.Connection.ForTemporalCloud(@namespace, clientCert),
                 Namespace = @namespace,
-                ClientIdentityMarker = null
+                ClientIdentityMarker = null,
+                LoggerFactory = NullLoggerFactory.Instance,
             };
         }
 #endif
@@ -152,7 +160,8 @@ namespace Temporal.WorkflowClient
                    ClientIdentityMarker: null,
                    PayloadConverterFactory: null,
                    PayloadCodecFactory: null,
-                   ClientInterceptorFactory: null)
+                   ClientInterceptorFactory: null,
+                   LoggerFactory: NullLoggerFactory.Instance)
         {
         }
     }


### PR DESCRIPTION
<!--    *** Note to EXTERNAL Contributors: ***                                                 -->
<!-- Thanks for opening a PR!                                                                  -->
<!-- If it is a significant code change, please **make sure there is an open issue** for this. -->
<!-- We work best with you when we have accepted the idea first before you code.               -->

<!--- For ALL Contributors 👇 -->

### Summary

This PR adds an insertion point for ILoggerFactory in the temporal client configuration object. This allows the user of the library to configure logging as they wish for the library. Instead of creating a default console/debug logger, I used the nullloggerfactory to make logging an explicit opt in.

<!-- Include this note if this is an incremental and make sure to actually do what it says: -->
<!--
 * **PR is ready for review, but keeping it as a _draft_ for the reviewers' convenience. Reason:
This PR is incremental to the previous PR, thus the Delta includes changes from both. Once the previous PR is merged, the Delta will only reflect the relevant changes and the review will be easier.**
-->

### Related work items

* https://github.com/temporalio/sdk-dotnet/issues/30

### Details

<!-- Add or remove sections here as required. If you REALLY think that any of the sections are unnecessary, feel free to remove them. But please, make sure to provide a good amount of context
for this PR to make sense both now and when looking back at it in the future. -->
I believe the user should have control of the logging experience. However, adding the debug logger when none is specified can make sense. I think there is room for that discussion.
