### PR TITLE
Exclude static-class check on smoke test

### DIFF
--- a/tests/Temporalio.SmokeTest/.editorconfig
+++ b/tests/Temporalio.SmokeTest/.editorconfig
@@ -4,6 +4,9 @@
 
 # Please keep in alphabetical order by field.
 
+# Don't need to mark smoke test classes static
+dotnet_diagnostic.CA1812.severity = none
+
 # Don't need to mark smoke test classes sealed
 dotnet_diagnostic.CA1852.severity = none
 


### PR DESCRIPTION
## What was changed

Added exclusion to smoke test editorconfig. On ARM only, https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1812 is being erroneously tripped.