### PR TITLE
Renaming Activity and Workflow packages to Activities and Workflows

### DIFF
--- a/src/Temporalio.ApiDoc/api/index.md
+++ b/src/Temporalio.ApiDoc/api/index.md
@@ -1,9 +1,13 @@
 
 # API Documentation
 
-Namespaces:
+Commonly used namespaces:
 
-* [Temporalio](/api/Temporalio.html)
-* [Temporalio.Client](/api/Temporalio.Client.html)
-* [Temporalio.Testing](/api/Temporalio.Testing.html)
-* [Temporalio.Worker](/api/Temporalio.Worker.html)
+* [Temporalio](/api/Temporalio.html) - General purpose types
+* [Temporalio.Activities](/api/Temporalio.Activities.html) - Types for developing activities
+* [Temporalio.Client](/api/Temporalio.Client.html) - Client for accessing Temporal
+* [Temporalio.Converters](/api/Temporalio.Converters.html) - Data converters including support for custom conversion
+* [Temporalio.Exceptions](/api/Temporalio.Exceptions.html) - Well-known exceptions for cleints, activities, and workflows
+* [Temporalio.Testing](/api/Temporalio.Testing.html) - Testing environments and utilities
+* [Temporalio.Worker](/api/Temporalio.Worker.html) - Worker for running workflows and/or activities
+* [Temporalio.Workflows](/api/Temporalio.Workflows.html) - Types for developing workflows

--- a/src/Temporalio/Activities/ActivityAttribute.cs
+++ b/src/Temporalio/Activities/ActivityAttribute.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Threading.Tasks;
 
-namespace Temporalio.Activity
+namespace Temporalio.Activities
 {
     /// <summary>
     /// Designate a method as an activity.

--- a/src/Temporalio/Activities/ActivityCancelReason.cs
+++ b/src/Temporalio/Activities/ActivityCancelReason.cs
@@ -1,4 +1,4 @@
-namespace Temporalio.Activity
+namespace Temporalio.Activities
 {
     /// <summary>
     /// Reason for why an activity may be cancelled.

--- a/src/Temporalio/Activities/ActivityCancelReasonRef.cs
+++ b/src/Temporalio/Activities/ActivityCancelReasonRef.cs
@@ -1,4 +1,4 @@
-namespace Temporalio.Activity
+namespace Temporalio.Activities
 {
     /// <summary>
     /// Boxed reference wrapper for <see cref="ActivityCancelReason" />.

--- a/src/Temporalio/Activities/ActivityContext.cs
+++ b/src/Temporalio/Activities/ActivityContext.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 
-namespace Temporalio.Activity
+namespace Temporalio.Activities
 {
     /// <summary>
     /// Context that is available during activity executions. Use <see cref="Current" /> to get the

--- a/src/Temporalio/Activities/ActivityInfo.cs
+++ b/src/Temporalio/Activities/ActivityInfo.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Temporalio.Api.Common.V1;
 using Temporalio.Converters;
 
-namespace Temporalio.Activity
+namespace Temporalio.Activities
 {
     /// <summary>
     /// Information about an activity.

--- a/src/Temporalio/Activities/CompleteAsyncException.cs
+++ b/src/Temporalio/Activities/CompleteAsyncException.cs
@@ -1,4 +1,4 @@
-namespace Temporalio.Activity
+namespace Temporalio.Activities
 {
     /// <summary>
     /// Exception the user should throw to inform the worker that this activity will be completed

--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -25,7 +25,7 @@ namespace Temporalio.Client
             Func<Task<TResult>> workflow, WorkflowStartOptions options)
         {
             return StartWorkflowAsync<TResult>(
-                Workflow.WorkflowAttribute.Definition.FromRunMethod(workflow.Method).Name,
+                Workflows.WorkflowAttribute.Definition.FromRunMethod(workflow.Method).Name,
                 Array.Empty<object?>(),
                 options);
         }
@@ -35,7 +35,7 @@ namespace Temporalio.Client
             Func<T, Task<TResult>> workflow, T arg, WorkflowStartOptions options)
         {
             return StartWorkflowAsync<TResult>(
-                Workflow.WorkflowAttribute.Definition.FromRunMethod(workflow.Method).Name,
+                Workflows.WorkflowAttribute.Definition.FromRunMethod(workflow.Method).Name,
                 new object?[] { arg },
                 options);
         }
@@ -45,7 +45,7 @@ namespace Temporalio.Client
             Func<Task> workflow, WorkflowStartOptions options)
         {
             return StartWorkflowAsync(
-                Workflow.WorkflowAttribute.Definition.FromRunMethod(workflow.Method).Name,
+                Workflows.WorkflowAttribute.Definition.FromRunMethod(workflow.Method).Name,
                 Array.Empty<object?>(),
                 options);
         }
@@ -55,7 +55,7 @@ namespace Temporalio.Client
             Func<T, Task> workflow, T arg, WorkflowStartOptions options)
         {
             return StartWorkflowAsync(
-                Workflow.WorkflowAttribute.Definition.FromRunMethod(workflow.Method).Name,
+                Workflows.WorkflowAttribute.Definition.FromRunMethod(workflow.Method).Name,
                 new object?[] { arg },
                 options);
         }

--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -208,7 +208,7 @@ namespace Temporalio.Client
         public Task SignalAsync(Func<Task> signal, WorkflowSignalOptions? options = null)
         {
             return SignalAsync(
-                Workflow.WorkflowSignalAttribute.Definition.FromMethod(signal.Method).Name,
+                Workflows.WorkflowSignalAttribute.Definition.FromMethod(signal.Method).Name,
                 Array.Empty<object?>(),
                 options);
         }
@@ -229,7 +229,7 @@ namespace Temporalio.Client
             Func<T, Task> signal, T arg, WorkflowSignalOptions? options = null)
         {
             return SignalAsync(
-                Workflow.WorkflowSignalAttribute.Definition.FromMethod(signal.Method).Name,
+                Workflows.WorkflowSignalAttribute.Definition.FromMethod(signal.Method).Name,
                 new object?[] { arg },
                 options);
         }
@@ -273,7 +273,7 @@ namespace Temporalio.Client
             Func<TQueryResult> query, WorkflowQueryOptions? options = null)
         {
             return QueryAsync<TQueryResult>(
-                Workflow.WorkflowQueryAttribute.Definition.FromMethod(query.Method).Name,
+                Workflows.WorkflowQueryAttribute.Definition.FromMethod(query.Method).Name,
                 Array.Empty<object?>(),
                 options);
         }
@@ -296,7 +296,7 @@ namespace Temporalio.Client
             Func<T, TQueryResult> query, T arg, WorkflowQueryOptions? options = null)
         {
             return QueryAsync<TQueryResult>(
-                Workflow.WorkflowQueryAttribute.Definition.FromMethod(query.Method).Name,
+                Workflows.WorkflowQueryAttribute.Definition.FromMethod(query.Method).Name,
                 new object?[] { arg },
                 options);
         }

--- a/src/Temporalio/Testing/ActivityEnvironment.cs
+++ b/src/Temporalio/Testing/ActivityEnvironment.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Temporalio.Activity;
+using Temporalio.Activities;
 using Temporalio.Api.Common.V1;
 using Temporalio.Converters;
 

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
-using Temporalio.Activity;
+using Temporalio.Activities;
 using Temporalio.Converters;
 using Temporalio.Exceptions;
 using Temporalio.Worker.Interceptors;

--- a/src/Temporalio/Workflows/WorkflowAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowAttribute.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
-namespace Temporalio.Workflow
+namespace Temporalio.Workflows
 {
     /// <summary>
     /// Designate a type as a workflow.

--- a/src/Temporalio/Workflows/WorkflowInitAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowInitAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Temporalio.Workflow
+namespace Temporalio.Workflows
 {
     /// <summary>
     /// Designates a constructor as receiving the same arguments as the method with

--- a/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Threading.Tasks;
 
-namespace Temporalio.Workflow
+namespace Temporalio.Workflows
 {
     /// <summary>
     /// Designate a method as a query handler.

--- a/src/Temporalio/Workflows/WorkflowRunAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowRunAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Temporalio.Workflow
+namespace Temporalio.Workflows
 {
     /// <summary>
     /// Designate a method as the entry point to a workflow.

--- a/src/Temporalio/Workflows/WorkflowSignalAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowSignalAttribute.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Threading.Tasks;
 
-namespace Temporalio.Workflow
+namespace Temporalio.Workflows
 {
     /// <summary>
     /// Designate a method as a signal handler.

--- a/tests/Temporalio.Tests/Activities/ActivityAttributeTests.cs
+++ b/tests/Temporalio.Tests/Activities/ActivityAttributeTests.cs
@@ -1,7 +1,7 @@
-namespace Temporalio.Tests.Activity;
+namespace Temporalio.Tests.Activities;
 
 using System.Threading.Tasks;
-using Temporalio.Activity;
+using Temporalio.Activities;
 using Xunit;
 
 public class ActivityAttributeTests

--- a/tests/Temporalio.Tests/IKitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/IKitchenSinkWorkflow.cs
@@ -1,7 +1,7 @@
 namespace Temporalio.Tests;
 
 using System.Text.Json.Serialization;
-using Temporalio.Workflow;
+using Temporalio.Workflows;
 
 [Workflow("kitchen_sink")]
 public interface IKitchenSinkWorkflow

--- a/tests/Temporalio.Tests/Testing/ActivityEnvironmentTests.cs
+++ b/tests/Temporalio.Tests/Testing/ActivityEnvironmentTests.cs
@@ -1,6 +1,6 @@
 namespace Temporalio.Tests.Testing;
 
-using Temporalio.Activity;
+using Temporalio.Activities;
 using Temporalio.Testing;
 using Xunit;
 

--- a/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
@@ -1,6 +1,6 @@
 namespace Temporalio.Tests.Worker;
 
-using Temporalio.Activity;
+using Temporalio.Activities;
 using Temporalio.Api.Enums.V1;
 using Temporalio.Client;
 using Temporalio.Converters;

--- a/tests/Temporalio.Tests/Workflows/WorkflowAttributeTests.cs
+++ b/tests/Temporalio.Tests/Workflows/WorkflowAttributeTests.cs
@@ -1,8 +1,8 @@
 #pragma warning disable CA1822 // We don't want to force workflow methods to be static
 
-namespace Temporalio.Tests.Workflow;
+namespace Temporalio.Tests.Workflows;
 
-using Temporalio.Workflow;
+using Temporalio.Workflows;
 using Xunit;
 
 public class WorkflowAttributeTests


### PR DESCRIPTION
## What was changed

Renamed `Temporalio.Activity` and `Temporalio.Workflow` packages to `Temporalio.Activities` and `Temporalio.Workflows` respectively. This is needed because we're gonna have a static class called `Workflow` in `Temporalio.Workflows`.