### PR TITLE
Workflow support for activities, children, and continue as new

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,7 @@ dotnet_diagnostic.CA1062.severity = none
 # dotnet_analyzer_diagnostic.category-Globalization.severity = none
 dotnet_diagnostic.CA1303.severity = none
 dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1305.severity = none
 dotnet_diagnostic.CA1307.severity = none
 dotnet_diagnostic.CA1310.severity = none
 dotnet_diagnostic.CA1311.severity = none
@@ -139,13 +140,15 @@ csharp_prefer_braces = true:suggestion
 #Style - expression bodied member options
 
 #prefer block bodies for accessors
-csharp_style_expression_bodied_accessors = false
+csharp_style_expression_bodied_accessors = true
 #prefer block bodies for constructors
-csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_constructors = true
 #prefer block bodies for methods
-csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_methods = true
 #prefer expression-bodied members for properties
-csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_properties = true
+#prefer expression-bodied members for local functions
+csharp_style_expression_bodied_local_functions = true
 
 #Style - expression level options
 

--- a/src/Temporalio/Activities/ActivityAttribute.cs
+++ b/src/Temporalio/Activities/ActivityAttribute.cs
@@ -25,10 +25,7 @@ namespace Temporalio.Activities
         /// name.
         /// </summary>
         /// <param name="name">Activity type name to use. See <see cref="Name" />.</param>
-        public ActivityAttribute(string name)
-        {
-            Name = name;
-        }
+        public ActivityAttribute(string name) => Name = name;
 
         /// <summary>
         /// Gets the activity type name. If this is unset, it defaults to the unqualified method

--- a/src/Temporalio/Activities/ActivityCancelReasonRef.cs
+++ b/src/Temporalio/Activities/ActivityCancelReasonRef.cs
@@ -6,7 +6,7 @@ namespace Temporalio.Activities
     internal class ActivityCancelReasonRef
     {
         /// <summary>
-        /// Gets or sets the cancel reason.
+        /// Gets or sets the cancel reason. Default is <see cref="ActivityCancelReason.None" />.
         /// </summary>
         public ActivityCancelReason CancelReason { get; set; } = ActivityCancelReason.None;
     }

--- a/src/Temporalio/Activities/ActivityDefinition.cs
+++ b/src/Temporalio/Activities/ActivityDefinition.cs
@@ -37,10 +37,8 @@ namespace Temporalio.Activities
         /// <remarks>
         /// Activity delegates cannot have any <c>ref</c> or <c>out</c> parameters.
         /// </remarks>
-        public static ActivityDefinition FromDelegate(Delegate del)
-        {
-            return Definitions.GetOrAdd(del, CreateFromDelegate);
-        }
+        public static ActivityDefinition FromDelegate(Delegate del) =>
+            Definitions.GetOrAdd(del, CreateFromDelegate);
 
         /// <summary>
         /// Creates an activity definition from an explicit name and delegate. Most users should use

--- a/src/Temporalio/Client/AsyncActivityHandle.cs
+++ b/src/Temporalio/Client/AsyncActivityHandle.cs
@@ -20,11 +20,9 @@ namespace Temporalio.Client
         /// If the server has requested that this activity be cancelled. Users should catch this and
         /// invoke <see cref="ReportCancellationAsync" /> for proper behavior.
         /// </exception>
-        public Task HeartbeatAsync(AsyncActivityHeartbeatOptions? options = null)
-        {
-            return Client.OutboundInterceptor.HeartbeatAsyncActivityAsync(new(
+        public Task HeartbeatAsync(AsyncActivityHeartbeatOptions? options = null) =>
+            Client.OutboundInterceptor.HeartbeatAsyncActivityAsync(new(
                 Activity: Activity, Options: options));
-        }
 
         /// <summary>
         /// Complete this activity.
@@ -33,11 +31,9 @@ namespace Temporalio.Client
         /// <param name="options">Completion options.</param>
         /// <returns>Completion task.</returns>
         public Task CompleteAsync(
-            object? result = null, AsyncActivityCompleteOptions? options = null)
-        {
-            return Client.OutboundInterceptor.CompleteAsyncActivityAsync(new(
+            object? result = null, AsyncActivityCompleteOptions? options = null) =>
+            Client.OutboundInterceptor.CompleteAsyncActivityAsync(new(
                 Activity: Activity, Result: result, Options: options));
-        }
 
         /// <summary>
         /// Fail this activity.
@@ -45,22 +41,19 @@ namespace Temporalio.Client
         /// <param name="exception">Exception for the activity.</param>
         /// <param name="options">Fail options.</param>
         /// <returns>Completion task.</returns>
-        public Task FailAsync(Exception exception, AsyncActivityFailOptions? options = null)
-        {
-            return Client.OutboundInterceptor.FailAsyncActivityAsync(new(
+        public Task FailAsync(Exception exception, AsyncActivityFailOptions? options = null) =>
+            Client.OutboundInterceptor.FailAsyncActivityAsync(new(
                 Activity: Activity, Exception: exception, Options: options));
-        }
 
         /// <summary>
         /// Report this activity as cancelled..
         /// </summary>
         /// <param name="options">Cancel options.</param>
         /// <returns>Completion task.</returns>
-        public Task ReportCancellationAsync(AsyncActivityReportCancellationOptions? options = null)
-        {
-            return Client.OutboundInterceptor.ReportCancellationAsyncActivityAsync(new(
+        public Task ReportCancellationAsync(
+            AsyncActivityReportCancellationOptions? options = null) =>
+            Client.OutboundInterceptor.ReportCancellationAsyncActivityAsync(new(
                 Activity: Activity, Options: options));
-        }
 
         /// <summary>
         /// Reference to an existing activity.

--- a/src/Temporalio/Client/ITemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/ITemporalClient.Workflow.cs
@@ -19,7 +19,7 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="Exceptions.RpcException">Server-side error.</exception>
         Task<WorkflowHandle<TResult>> StartWorkflowAsync<TResult>(
-            Func<Task<TResult>> workflow, WorkflowStartOptions options);
+            Func<Task<TResult>> workflow, WorkflowOptions options);
 
         /// <summary>
         /// Start a workflow with the given run method.
@@ -36,7 +36,7 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="Exceptions.RpcException">Server-side error.</exception>
         Task<WorkflowHandle<TResult>> StartWorkflowAsync<T, TResult>(
-            Func<T, Task<TResult>> workflow, T arg, WorkflowStartOptions options);
+            Func<T, Task<TResult>> workflow, T arg, WorkflowOptions options);
 
         /// <summary>
         /// Start a workflow with the given run method.
@@ -50,7 +50,7 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="Exceptions.RpcException">Server-side error.</exception>
         Task<WorkflowHandle> StartWorkflowAsync(
-            Func<Task> workflow, WorkflowStartOptions options);
+            Func<Task> workflow, WorkflowOptions options);
 
         /// <summary>
         /// Start a workflow with the given run method.
@@ -66,7 +66,7 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="Exceptions.RpcException">Server-side error.</exception>
         Task<WorkflowHandle> StartWorkflowAsync<T>(
-            Func<T, Task> workflow, T arg, WorkflowStartOptions options);
+            Func<T, Task> workflow, T arg, WorkflowOptions options);
 
         /// <summary>
         /// Start a workflow with the given run method.
@@ -81,7 +81,7 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="Exceptions.RpcException">Server-side error.</exception>
         Task<WorkflowHandle> StartWorkflowAsync(
-            string workflow, IReadOnlyCollection<object?> args, WorkflowStartOptions options);
+            string workflow, IReadOnlyCollection<object?> args, WorkflowOptions options);
 
         /// <summary>
         /// Start a workflow with the given run method.
@@ -97,7 +97,7 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="Exceptions.RpcException">Server-side error.</exception>
         Task<WorkflowHandle<TResult>> StartWorkflowAsync<TResult>(
-            string workflow, IReadOnlyCollection<object?> args, WorkflowStartOptions options);
+            string workflow, IReadOnlyCollection<object?> args, WorkflowOptions options);
 
         /// <summary>
         /// Get a workflow handle for an existing workflow with unknown return type.

--- a/src/Temporalio/Client/ITemporalClientExtensions.cs
+++ b/src/Temporalio/Client/ITemporalClientExtensions.cs
@@ -11,7 +11,7 @@ namespace Temporalio.Client
     {
         /// <summary>
         /// Shortcut for
-        /// <see cref="ITemporalClient.StartWorkflowAsync{TResult}(Func{Task{TResult}}, WorkflowStartOptions)" />
+        /// <see cref="ITemporalClient.StartWorkflowAsync{TResult}(Func{Task{TResult}}, WorkflowOptions)" />
         /// +
         /// <see cref="WorkflowHandle{TResult}.GetResultAsync(bool, RpcOptions?)" />.
         /// </summary>
@@ -31,7 +31,7 @@ namespace Temporalio.Client
         public static async Task<TResult> ExecuteWorkflowAsync<TResult>(
             this ITemporalClient client,
             Func<Task<TResult>> workflow,
-            WorkflowStartOptions options)
+            WorkflowOptions options)
         {
             var handle = await client.StartWorkflowAsync(workflow, options).ConfigureAwait(false);
             return await handle.GetResultAsync(rpcOptions: options.Rpc).ConfigureAwait(false);
@@ -39,7 +39,7 @@ namespace Temporalio.Client
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="ITemporalClient.StartWorkflowAsync{T, TResult}(Func{T, Task{TResult}}, T, WorkflowStartOptions)" />
+        /// <see cref="ITemporalClient.StartWorkflowAsync{T, TResult}(Func{T, Task{TResult}}, T, WorkflowOptions)" />
         /// +
         /// <see cref="WorkflowHandle{TResult}.GetResultAsync(bool, RpcOptions?)" />.
         /// </summary>
@@ -62,7 +62,7 @@ namespace Temporalio.Client
             this ITemporalClient client,
             Func<T, Task<TResult>> workflow,
             T arg,
-            WorkflowStartOptions options)
+            WorkflowOptions options)
         {
             var handle = await client.StartWorkflowAsync(
                 workflow, arg, options).ConfigureAwait(false);
@@ -71,7 +71,7 @@ namespace Temporalio.Client
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="ITemporalClient.StartWorkflowAsync(Func{Task}, WorkflowStartOptions)" />
+        /// <see cref="ITemporalClient.StartWorkflowAsync(Func{Task}, WorkflowOptions)" />
         /// +
         /// <see cref="WorkflowHandle.GetResultAsync(bool, RpcOptions?)" />.
         /// </summary>
@@ -90,7 +90,7 @@ namespace Temporalio.Client
         public static async Task ExecuteWorkflowAsync(
             this ITemporalClient client,
             Func<Task> workflow,
-            WorkflowStartOptions options)
+            WorkflowOptions options)
         {
             var handle = await client.StartWorkflowAsync(workflow, options).ConfigureAwait(false);
             await handle.GetResultAsync(rpcOptions: options.Rpc).ConfigureAwait(false);
@@ -98,7 +98,7 @@ namespace Temporalio.Client
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="ITemporalClient.StartWorkflowAsync{T}(Func{T, Task}, T, WorkflowStartOptions)" />
+        /// <see cref="ITemporalClient.StartWorkflowAsync{T}(Func{T, Task}, T, WorkflowOptions)" />
         /// +
         /// <see cref="WorkflowHandle.GetResultAsync(bool, RpcOptions?)" />.
         /// </summary>
@@ -120,7 +120,7 @@ namespace Temporalio.Client
             this ITemporalClient client,
             Func<T, Task> workflow,
             T arg,
-            WorkflowStartOptions options)
+            WorkflowOptions options)
         {
             var handle = await client.StartWorkflowAsync(
                 workflow, arg, options).ConfigureAwait(false);
@@ -129,7 +129,7 @@ namespace Temporalio.Client
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="ITemporalClient.StartWorkflowAsync(string, IReadOnlyCollection{object?}, WorkflowStartOptions)" />
+        /// <see cref="ITemporalClient.StartWorkflowAsync(string, IReadOnlyCollection{object?}, WorkflowOptions)" />
         /// +
         /// <see cref="WorkflowHandle.GetResultAsync(bool, RpcOptions?)" />.
         /// </summary>
@@ -150,7 +150,7 @@ namespace Temporalio.Client
             this ITemporalClient client,
             string workflow,
             IReadOnlyCollection<object?> args,
-            WorkflowStartOptions options)
+            WorkflowOptions options)
         {
             var handle = await client.StartWorkflowAsync(
                 workflow, args, options).ConfigureAwait(false);
@@ -159,7 +159,7 @@ namespace Temporalio.Client
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="ITemporalClient.StartWorkflowAsync{TResult}(string, IReadOnlyCollection{object?}, WorkflowStartOptions)" />
+        /// <see cref="ITemporalClient.StartWorkflowAsync{TResult}(string, IReadOnlyCollection{object?}, WorkflowOptions)" />
         /// +
         /// <see cref="WorkflowHandle{TResult}.GetResultAsync(bool, RpcOptions?)" />.
         /// </summary>
@@ -181,7 +181,7 @@ namespace Temporalio.Client
             this ITemporalClient client,
             string workflow,
             IReadOnlyCollection<object?> args,
-            WorkflowStartOptions options)
+            WorkflowOptions options)
         {
             var handle = await client.StartWorkflowAsync<TResult>(workflow, args, options).
                 ConfigureAwait(false);

--- a/src/Temporalio/Client/Interceptors/ClientOutboundInterceptor.cs
+++ b/src/Temporalio/Client/Interceptors/ClientOutboundInterceptor.cs
@@ -46,20 +46,16 @@ namespace Temporalio.Client.Interceptors
         /// <param name="input">Input details of the call.</param>
         /// <returns>Handle for the workflow.</returns>
         public virtual Task<WorkflowHandle<TResult>> StartWorkflowAsync<TResult>(
-            StartWorkflowInput input)
-        {
-            return Next.StartWorkflowAsync<TResult>(input);
-        }
+            StartWorkflowInput input) =>
+            Next.StartWorkflowAsync<TResult>(input);
 
         /// <summary>
         /// Intercept signal workflow calls.
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Task for acceptance of the signal.</returns>
-        public virtual Task SignalWorkflowAsync(SignalWorkflowInput input)
-        {
-            return Next.SignalWorkflowAsync(input);
-        }
+        public virtual Task SignalWorkflowAsync(SignalWorkflowInput input) =>
+            Next.SignalWorkflowAsync(input);
 
         /// <summary>
         /// Intercept query workflow calls.
@@ -67,10 +63,8 @@ namespace Temporalio.Client.Interceptors
         /// <typeparam name="TResult">Return type of the query.</typeparam>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Result of the query.</returns>
-        public virtual Task<TResult> QueryWorkflowAsync<TResult>(QueryWorkflowInput input)
-        {
-            return Next.QueryWorkflowAsync<TResult>(input);
-        }
+        public virtual Task<TResult> QueryWorkflowAsync<TResult>(QueryWorkflowInput input) =>
+            Next.QueryWorkflowAsync<TResult>(input);
 
         /// <summary>
         /// Intercept describe workflow calls.
@@ -78,30 +72,24 @@ namespace Temporalio.Client.Interceptors
         /// <param name="input">Input details of the call.</param>
         /// <returns>Workflow execution description.</returns>
         public virtual Task<WorkflowExecutionDescription> DescribeWorkflowAsync(
-            DescribeWorkflowInput input)
-        {
-            return Next.DescribeWorkflowAsync(input);
-        }
+            DescribeWorkflowInput input) =>
+            Next.DescribeWorkflowAsync(input);
 
         /// <summary>
         /// Intercept cancel workflow calls.
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Task for acceptance of the cancel.</returns>
-        public virtual Task CancelWorkflowAsync(CancelWorkflowInput input)
-        {
-            return Next.CancelWorkflowAsync(input);
-        }
+        public virtual Task CancelWorkflowAsync(CancelWorkflowInput input) =>
+            Next.CancelWorkflowAsync(input);
 
         /// <summary>
         /// Intercept terminate workflow calls.
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Task for termination completion.</returns>
-        public virtual Task TerminateWorkflowAsync(TerminateWorkflowInput input)
-        {
-            return Next.TerminateWorkflowAsync(input);
-        }
+        public virtual Task TerminateWorkflowAsync(TerminateWorkflowInput input) =>
+            Next.TerminateWorkflowAsync(input);
 
         /// <summary>
         /// Intercept a history event page fetch.
@@ -111,10 +99,8 @@ namespace Temporalio.Client.Interceptors
         /// Event page. This will not return an empty event set and a next page token.
         /// </returns>
         public virtual Task<WorkflowHistoryEventPage> FetchWorkflowHistoryEventPageAsync(
-            FetchWorkflowHistoryEventPageInput input)
-        {
-            return Next.FetchWorkflowHistoryEventPageAsync(input);
-        }
+            FetchWorkflowHistoryEventPageInput input) =>
+            Next.FetchWorkflowHistoryEventPageAsync(input);
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>
@@ -123,10 +109,8 @@ namespace Temporalio.Client.Interceptors
         /// <param name="input">Input details of the call.</param>
         /// <returns>Async enumerator for the workflows.</returns>
         public virtual IAsyncEnumerable<WorkflowExecution> ListWorkflowsAsync(
-            ListWorkflowsInput input)
-        {
-            return Next.ListWorkflowsAsync(input);
-        }
+            ListWorkflowsInput input) =>
+            Next.ListWorkflowsAsync(input);
 #endif
 
         /// <summary>
@@ -134,30 +118,24 @@ namespace Temporalio.Client.Interceptors
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Task completion.</returns>
-        public virtual Task HeartbeatAsyncActivityAsync(HeartbeatAsyncActivityInput input)
-        {
-            return Next.HeartbeatAsyncActivityAsync(input);
-        }
+        public virtual Task HeartbeatAsyncActivityAsync(HeartbeatAsyncActivityInput input) =>
+            Next.HeartbeatAsyncActivityAsync(input);
 
         /// <summary>
         /// Intercept async activity complete calls.
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Task completion.</returns>
-        public virtual Task CompleteAsyncActivityAsync(CompleteAsyncActivityInput input)
-        {
-            return Next.CompleteAsyncActivityAsync(input);
-        }
+        public virtual Task CompleteAsyncActivityAsync(CompleteAsyncActivityInput input) =>
+            Next.CompleteAsyncActivityAsync(input);
 
         /// <summary>
         /// Intercept async activity fail calls.
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Task completion.</returns>
-        public virtual Task FailAsyncActivityAsync(FailAsyncActivityInput input)
-        {
-            return Next.FailAsyncActivityAsync(input);
-        }
+        public virtual Task FailAsyncActivityAsync(FailAsyncActivityInput input) =>
+            Next.FailAsyncActivityAsync(input);
 
         /// <summary>
         /// Intercept async activity report cancellation calls.
@@ -165,9 +143,7 @@ namespace Temporalio.Client.Interceptors
         /// <param name="input">Input details of the call.</param>
         /// <returns>Task completion.</returns>
         public virtual Task ReportCancellationAsyncActivityAsync(
-            ReportCancellationAsyncActivityInput input)
-        {
-            return Next.ReportCancellationAsyncActivityAsync(input);
-        }
+            ReportCancellationAsyncActivityInput input) =>
+            Next.ReportCancellationAsyncActivityAsync(input);
     }
 }

--- a/src/Temporalio/Client/Interceptors/IClientInterceptor.cs
+++ b/src/Temporalio/Client/Interceptors/IClientInterceptor.cs
@@ -11,10 +11,8 @@ namespace Temporalio.Client.Interceptors
         /// <param name="nextInterceptor">The next interceptor in the chain to call.</param>
         /// <returns>Created interceptor.</returns>
 #if NETCOREAPP3_0_OR_GREATER
-        ClientOutboundInterceptor InterceptClient(ClientOutboundInterceptor nextInterceptor)
-        {
-            return nextInterceptor;
-        }
+        ClientOutboundInterceptor InterceptClient(ClientOutboundInterceptor nextInterceptor) =>
+            nextInterceptor;
 #else
         ClientOutboundInterceptor InterceptClient(ClientOutboundInterceptor nextInterceptor);
 #endif

--- a/src/Temporalio/Client/Interceptors/StartWorkflowInput.cs
+++ b/src/Temporalio/Client/Interceptors/StartWorkflowInput.cs
@@ -13,6 +13,6 @@ namespace Temporalio.Client.Interceptors
     public record StartWorkflowInput(
         string Workflow,
         IReadOnlyCollection<object?> Args,
-        WorkflowStartOptions Options,
+        WorkflowOptions Options,
         IDictionary<string, Payload>? Headers);
 }

--- a/src/Temporalio/Client/OperatorService.cs
+++ b/src/Temporalio/Client/OperatorService.cs
@@ -24,20 +24,12 @@ namespace Temporalio.Client
             /// Initializes a new instance of the <see cref="Core"/> class.
             /// </summary>
             /// <param name="connection">Connection to use.</param>
-            public Core(TemporalConnection connection)
-            {
-                this.connection = connection;
-            }
+            public Core(TemporalConnection connection) => this.connection = connection;
 
             /// <inheritdoc />
             protected override Task<T> InvokeRpcAsync<T>(
-                string rpc,
-                IMessage req,
-                MessageParser<T> resp,
-                RpcOptions? options = null)
-            {
-                return connection.InvokeRpcAsync(this, rpc, req, resp, options);
-            }
+                string rpc, IMessage req, MessageParser<T> resp, RpcOptions? options = null) =>
+                connection.InvokeRpcAsync(this, rpc, req, resp, options);
         }
     }
 }

--- a/src/Temporalio/Client/RpcOptions.cs
+++ b/src/Temporalio/Client/RpcOptions.cs
@@ -41,10 +41,7 @@ namespace Temporalio.Client
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
         /// <remarks>Does not create copies of metadata or cancellation token.</remarks>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
 
         /// <summary>
         /// Return a potentially new RPC options with this cancellation token added if present.

--- a/src/Temporalio/Client/RpcRetryOptions.cs
+++ b/src/Temporalio/Client/RpcRetryOptions.cs
@@ -8,32 +8,32 @@ namespace Temporalio.Client
     public class RpcRetryOptions : ICloneable
     {
         /// <summary>
-        /// Gets or sets the initial retry interval.
+        /// Gets or sets the initial retry interval. Default is 100ms.
         /// </summary>
         public TimeSpan InitialInterval { get; set; } = TimeSpan.FromMilliseconds(100);
 
         /// <summary>
-        /// Gets or sets the randomization factor.
+        /// Gets or sets the randomization factor. Default is 0.2.
         /// </summary>
         public float RandomizationFactor { get; set; } = 0.2F;
 
         /// <summary>
-        /// Gets or sets the multiplier.
+        /// Gets or sets the multiplier. Default is 1.5.
         /// </summary>
         public float Multiplier { get; set; } = 1.5F;
 
         /// <summary>
-        /// Gets or sets the max interval.
+        /// Gets or sets the max interval. Default is 5s.
         /// </summary>
         public TimeSpan MaxInterval { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
-        /// Gets or sets the max elapsed time.
+        /// Gets or sets the max elapsed time (or null for none). Default is 10s.
         /// </summary>
         public TimeSpan? MaxElapsedTime { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        /// Gets or sets the max retries.
+        /// Gets or sets the max retries. Default is 10.
         /// </summary>
         public int MaxRetries { get; set; } = 10;
 
@@ -41,9 +41,6 @@ namespace Temporalio.Client
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Client/TemporalClient.AsyncActivity.cs
+++ b/src/Temporalio/Client/TemporalClient.AsyncActivity.cs
@@ -11,18 +11,14 @@ namespace Temporalio.Client
     public partial class TemporalClient
     {
         /// <inheritdoc />
-        public AsyncActivityHandle GetAsyncActivityHandle(byte[] taskToken)
-        {
-            return new(this, new AsyncActivityHandle.TaskTokenReference(taskToken));
-        }
+        public AsyncActivityHandle GetAsyncActivityHandle(byte[] taskToken) =>
+            new(this, new AsyncActivityHandle.TaskTokenReference(taskToken));
 
         /// <inheritdoc />
         public AsyncActivityHandle GetAsyncActivityHandle(
-            string workflowID, string runID, string activityID)
-        {
-            return new(this, new AsyncActivityHandle.IDReference(
+            string workflowID, string runID, string activityID) =>
+            new(this, new AsyncActivityHandle.IDReference(
                 WorkflowID: workflowID, RunID: runID, ActivityID: activityID));
-        }
 
         internal partial class Impl
         {

--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -22,86 +22,65 @@ namespace Temporalio.Client
     {
         /// <inheritdoc />
         public Task<WorkflowHandle<TResult>> StartWorkflowAsync<TResult>(
-            Func<Task<TResult>> workflow, WorkflowStartOptions options)
-        {
-            return StartWorkflowAsync<TResult>(
+            Func<Task<TResult>> workflow, WorkflowOptions options) =>
+            StartWorkflowAsync<TResult>(
                 Workflows.WorkflowDefinition.FromRunMethod(workflow.Method).Name,
                 Array.Empty<object?>(),
                 options);
-        }
 
         /// <inheritdoc />
         public Task<WorkflowHandle<TResult>> StartWorkflowAsync<T, TResult>(
-            Func<T, Task<TResult>> workflow, T arg, WorkflowStartOptions options)
-        {
-            return StartWorkflowAsync<TResult>(
+            Func<T, Task<TResult>> workflow, T arg, WorkflowOptions options) =>
+            StartWorkflowAsync<TResult>(
                 Workflows.WorkflowDefinition.FromRunMethod(workflow.Method).Name,
                 new object?[] { arg },
                 options);
-        }
 
         /// <inheritdoc />
         public Task<WorkflowHandle> StartWorkflowAsync(
-            Func<Task> workflow, WorkflowStartOptions options)
-        {
-            return StartWorkflowAsync(
+            Func<Task> workflow, WorkflowOptions options) =>
+            StartWorkflowAsync(
                 Workflows.WorkflowDefinition.FromRunMethod(workflow.Method).Name,
                 Array.Empty<object?>(),
                 options);
-        }
 
         /// <inheritdoc />
         public Task<WorkflowHandle> StartWorkflowAsync<T>(
-            Func<T, Task> workflow, T arg, WorkflowStartOptions options)
-        {
-            return StartWorkflowAsync(
+            Func<T, Task> workflow, T arg, WorkflowOptions options) =>
+            StartWorkflowAsync(
                 Workflows.WorkflowDefinition.FromRunMethod(workflow.Method).Name,
                 new object?[] { arg },
                 options);
-        }
 
         /// <inheritdoc />
         public async Task<WorkflowHandle> StartWorkflowAsync(
-            string workflow, IReadOnlyCollection<object?> args, WorkflowStartOptions options)
-        {
-            return await StartWorkflowAsync<ValueTuple>(
-                workflow, args, options).ConfigureAwait(false);
-        }
+            string workflow, IReadOnlyCollection<object?> args, WorkflowOptions options) =>
+            await StartWorkflowAsync<ValueTuple>(workflow, args, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         public Task<WorkflowHandle<TResult>> StartWorkflowAsync<TResult>(
-            string workflow, IReadOnlyCollection<object?> args, WorkflowStartOptions options)
-        {
-            return OutboundInterceptor.StartWorkflowAsync<TResult>(new(
+            string workflow, IReadOnlyCollection<object?> args, WorkflowOptions options) =>
+            OutboundInterceptor.StartWorkflowAsync<TResult>(new(
                 Workflow: workflow,
                 Args: args,
                 Options: options,
                 Headers: null));
-        }
 
         /// <inheritdoc />
         public WorkflowHandle GetWorkflowHandle(
-            string id, string? runID = null, string? firstExecutionRunID = null)
-        {
-            return new WorkflowHandle(
-                Client: this, ID: id, RunID: runID, FirstExecutionRunID: firstExecutionRunID);
-        }
+            string id, string? runID = null, string? firstExecutionRunID = null) =>
+            new(Client: this, ID: id, RunID: runID, FirstExecutionRunID: firstExecutionRunID);
 
         /// <inheritdoc />
         public WorkflowHandle<TResult> GetWorkflowHandle<TResult>(
-            string id, string? runID = null, string? firstExecutionRunID = null)
-        {
-            return new WorkflowHandle<TResult>(
-                Client: this, ID: id, RunID: runID, FirstExecutionRunID: firstExecutionRunID);
-        }
+            string id, string? runID = null, string? firstExecutionRunID = null) =>
+            new(Client: this, ID: id, RunID: runID, FirstExecutionRunID: firstExecutionRunID);
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <inheritdoc />
         public IAsyncEnumerable<WorkflowExecution> ListWorkflowsAsync(
-            string query, WorkflowListOptions? options = null)
-        {
-            return OutboundInterceptor.ListWorkflowsAsync(new(Query: query, Options: options));
-        }
+            string query, WorkflowListOptions? options = null) =>
+            OutboundInterceptor.ListWorkflowsAsync(new(Query: query, Options: options));
 #endif
 
         internal partial class Impl
@@ -332,10 +311,8 @@ namespace Temporalio.Client
 #if NETCOREAPP3_0_OR_GREATER
             /// <inheritdoc />
             public override IAsyncEnumerable<WorkflowExecution> ListWorkflowsAsync(
-                ListWorkflowsInput input)
-            {
-                return ListWorkflowsInternalAsync(input);
-            }
+                ListWorkflowsInput input) =>
+                ListWorkflowsInternalAsync(input);
 
             private async IAsyncEnumerable<WorkflowExecution> ListWorkflowsInternalAsync(
                 ListWorkflowsInput input,
@@ -410,7 +387,7 @@ namespace Temporalio.Client
                 }
                 if (input.Options.TaskTimeout != null)
                 {
-                    req.WorkflowExecutionTimeout = Duration.FromTimeSpan(
+                    req.WorkflowTaskTimeout = Duration.FromTimeSpan(
                         (TimeSpan)input.Options.TaskTimeout);
                 }
                 if (input.Options.CronSchedule != null)

--- a/src/Temporalio/Client/TemporalClient.cs
+++ b/src/Temporalio/Client/TemporalClient.cs
@@ -50,12 +50,11 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="options">Options for connecting.</param>
         /// <returns>The connected client.</returns>
-        public static async Task<TemporalClient> ConnectAsync(TemporalClientConnectOptions options)
-        {
-            return new TemporalClient(
+        public static async Task<TemporalClient> ConnectAsync(
+            TemporalClientConnectOptions options) =>
+            new(
                 await TemporalConnection.ConnectAsync(options).ConfigureAwait(false),
                 options.ToClientOptions());
-        }
 
         /// <summary>
         /// Get a default set of retry options given the optional options. This will not mutate the
@@ -86,10 +85,7 @@ namespace Temporalio.Client
             /// Initializes a new instance of the <see cref="Impl"/> class.
             /// </summary>
             /// <param name="client">Client to use.</param>
-            public Impl(TemporalClient client)
-            {
-                Client = client;
-            }
+            public Impl(TemporalClient client) => Client = client;
 
             /// <summary>
             /// Gets the client.

--- a/src/Temporalio/Client/TemporalClientConnectOptions.cs
+++ b/src/Temporalio/Client/TemporalClientConnectOptions.cs
@@ -35,7 +35,8 @@ namespace Temporalio.Client
         public string Namespace { get; set; } = "default";
 
         /// <summary>
-        /// Gets or sets the client data converter.
+        /// Gets or sets the client data converter. Default is
+        /// <see cref="Converters.DataConverter.Default" />.
         /// </summary>
         public Converters.DataConverter DataConverter { get; set; } =
             Converters.DataConverter.Default;
@@ -45,13 +46,11 @@ namespace Temporalio.Client
         /// <see cref="TemporalClient.TemporalClient" />.
         /// </summary>
         /// <returns>Client options.</returns>
-        public TemporalClientOptions ToClientOptions()
-        {
-            return new TemporalClientOptions()
+        public TemporalClientOptions ToClientOptions() =>
+            new()
             {
                 Namespace = Namespace,
                 DataConverter = DataConverter,
             };
-        }
     }
 }

--- a/src/Temporalio/Client/TemporalClientOptions.cs
+++ b/src/Temporalio/Client/TemporalClientOptions.cs
@@ -17,7 +17,8 @@ namespace Temporalio.Client
         public string Namespace { get; set; } = "default";
 
         /// <summary>
-        /// Gets or sets the data converter.
+        /// Gets or sets the data converter. Default is
+        /// <see cref="Converters.DataConverter.Default" />.
         /// </summary>
         public Converters.DataConverter DataConverter { get; set; } =
             Converters.DataConverter.Default;
@@ -46,9 +47,6 @@ namespace Temporalio.Client
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Client/TemporalConnection.cs
+++ b/src/Temporalio/Client/TemporalConnection.cs
@@ -55,10 +55,9 @@ namespace Temporalio.Client
         }
 
         /// <inheritdoc />
-        public Task<bool> CheckHealthAsync(RpcService? service = null, RpcOptions? options = null)
-        {
+        public Task<bool> CheckHealthAsync(
+            RpcService? service = null, RpcOptions? options = null) =>
             throw new NotImplementedException();
-        }
 
         /// <summary>
         /// Invoke RPC call on this connection.
@@ -76,9 +75,8 @@ namespace Temporalio.Client
             IMessage req,
             MessageParser<T> resp,
             RpcOptions? options = null)
-            where T : IMessage<T>
-        {
-            return client.CallAsync(
+            where T : IMessage<T> =>
+            client.CallAsync(
                 service.Service,
                 rpc,
                 req,
@@ -87,6 +85,5 @@ namespace Temporalio.Client
                 options?.Metadata,
                 options?.Timeout,
                 options?.CancellationToken);
-        }
     }
 }

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -24,10 +24,7 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="targetHost">Target host to connect to.</param>
         /// <seealso cref="TargetHost" />
-        public TemporalConnectionOptions(string targetHost)
-        {
-            TargetHost = targetHost;
-        }
+        public TemporalConnectionOptions(string targetHost) => TargetHost = targetHost;
 
         /// <summary>
         /// Gets or sets the Temporal server <c>host:port</c> to connect to.

--- a/src/Temporalio/Client/TestService.cs
+++ b/src/Temporalio/Client/TestService.cs
@@ -24,20 +24,12 @@ namespace Temporalio.Client
             /// Initializes a new instance of the <see cref="Core"/> class.
             /// </summary>
             /// <param name="connection">Connection to use.</param>
-            public Core(TemporalConnection connection)
-            {
-                this.connection = connection;
-            }
+            public Core(TemporalConnection connection) => this.connection = connection;
 
             /// <inheritdoc />
             protected override Task<T> InvokeRpcAsync<T>(
-                string rpc,
-                IMessage req,
-                MessageParser<T> resp,
-                RpcOptions? options = null)
-            {
-                return connection.InvokeRpcAsync(this, rpc, req, resp, options);
-            }
+                string rpc, IMessage req, MessageParser<T> resp, RpcOptions? options = null) =>
+                connection.InvokeRpcAsync(this, rpc, req, resp, options);
         }
     }
 }

--- a/src/Temporalio/Client/TlsOptions.cs
+++ b/src/Temporalio/Client/TlsOptions.cs
@@ -22,7 +22,7 @@ namespace Temporalio.Client
         /// Gets or sets the PEM-formatted client certificate for mTLS.
         /// </summary>
         /// <remarks>
-        /// This must be combined with <see cref="TlsOptions.ClientPrivateKey" />.
+        /// This must be combined with <see cref="ClientPrivateKey" />.
         /// </remarks>
         public byte[]? ClientCert { get; set; }
 
@@ -30,7 +30,7 @@ namespace Temporalio.Client
         /// Gets or sets the PEM-formatted client private key for mTLS.
         /// </summary>
         /// <remarks>
-        /// This must be combined with <see cref="TlsOptions.ClientCert" />.
+        /// This must be combined with <see cref="ClientCert" />.
         /// </remarks>
         public byte[]? ClientPrivateKey { get; set; }
 
@@ -39,9 +39,6 @@ namespace Temporalio.Client
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
         /// <remarks>Does not create copies of byte arrays.</remarks>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -54,11 +54,9 @@ namespace Temporalio.Client
         /// the workflow (usually an <see cref="ApplicationFailureException" />).
         /// </exception>
         /// <exception cref="RpcException">Server-side error.</exception>
-        public async Task GetResultAsync(
-            bool followRuns = true, RpcOptions? rpcOptions = null)
-        {
-            await GetResultAsync<ValueTuple>(followRuns, rpcOptions).ConfigureAwait(false);
-        }
+        public Task GetResultAsync(
+            bool followRuns = true, RpcOptions? rpcOptions = null) =>
+            GetResultAsync<ValueTuple>(followRuns, rpcOptions);
 
         /// <summary>
         /// Get the result of a workflow, deserializing into the given return type.
@@ -205,13 +203,11 @@ namespace Temporalio.Client
         /// the workflow yet.
         /// </returns>
         /// <exception cref="RpcException">Server-side error.</exception>
-        public Task SignalAsync(Func<Task> signal, WorkflowSignalOptions? options = null)
-        {
-            return SignalAsync(
+        public Task SignalAsync(Func<Task> signal, WorkflowSignalOptions? options = null) =>
+            SignalAsync(
                 Workflows.WorkflowSignalDefinition.FromMethod(signal.Method).Name,
                 Array.Empty<object?>(),
                 options);
-        }
 
         /// <summary>
         /// Signal a workflow with the given WorkflowSignal attributed method.
@@ -226,13 +222,11 @@ namespace Temporalio.Client
         /// </returns>
         /// <exception cref="RpcException">Server-side error.</exception>
         public Task SignalAsync<T>(
-            Func<T, Task> signal, T arg, WorkflowSignalOptions? options = null)
-        {
-            return SignalAsync(
+            Func<T, Task> signal, T arg, WorkflowSignalOptions? options = null) =>
+            SignalAsync(
                 Workflows.WorkflowSignalDefinition.FromMethod(signal.Method).Name,
                 new object?[] { arg },
                 options);
-        }
 
         /// <summary>
         /// Signal a workflow with the given signal name and args.
@@ -246,16 +240,14 @@ namespace Temporalio.Client
         /// </returns>
         /// <exception cref="RpcException">Server-side error.</exception>
         public Task SignalAsync(
-            string signal, IReadOnlyCollection<object?> args, WorkflowSignalOptions? options = null)
-        {
-            return Client.OutboundInterceptor.SignalWorkflowAsync(new(
+            string signal, IReadOnlyCollection<object?> args, WorkflowSignalOptions? options = null) =>
+            Client.OutboundInterceptor.SignalWorkflowAsync(new(
                 ID: ID,
                 RunID: RunID,
                 Signal: signal,
                 Args: args,
                 Options: options,
                 Headers: null));
-        }
 
         /// <summary>
         /// Query a workflow with the given WorkflowQuery attributed method.
@@ -270,13 +262,11 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="RpcException">Server-side error.</exception>
         public Task<TQueryResult> QueryAsync<TQueryResult>(
-            Func<TQueryResult> query, WorkflowQueryOptions? options = null)
-        {
-            return QueryAsync<TQueryResult>(
+            Func<TQueryResult> query, WorkflowQueryOptions? options = null) =>
+            QueryAsync<TQueryResult>(
                 Workflows.WorkflowQueryDefinition.FromMethod(query.Method).Name,
                 Array.Empty<object?>(),
                 options);
-        }
 
         /// <summary>
         /// Query a workflow with the given WorkflowQuery attributed method.
@@ -293,13 +283,11 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="RpcException">Server-side error.</exception>
         public Task<TQueryResult> QueryAsync<T, TQueryResult>(
-            Func<T, TQueryResult> query, T arg, WorkflowQueryOptions? options = null)
-        {
-            return QueryAsync<TQueryResult>(
+            Func<T, TQueryResult> query, T arg, WorkflowQueryOptions? options = null) =>
+            QueryAsync<TQueryResult>(
                 Workflows.WorkflowQueryDefinition.FromMethod(query.Method).Name,
                 new object?[] { arg },
                 options);
-        }
 
         /// <summary>
         /// Query a workflow with the given WorkflowQuery attributed method.
@@ -315,16 +303,14 @@ namespace Temporalio.Client
         /// </exception>
         /// <exception cref="RpcException">Server-side error.</exception>
         public Task<TQueryResult> QueryAsync<TQueryResult>(
-            string query, IReadOnlyCollection<object?> args, WorkflowQueryOptions? options = null)
-        {
-            return Client.OutboundInterceptor.QueryWorkflowAsync<TQueryResult>(new(
+            string query, IReadOnlyCollection<object?> args, WorkflowQueryOptions? options = null) =>
+            Client.OutboundInterceptor.QueryWorkflowAsync<TQueryResult>(new(
                 ID: ID,
                 RunID: RunID,
                 Query: query,
                 Args: args,
                 Options: options,
                 Headers: null));
-        }
 
         /// <summary>
         /// Get the current description of this workflow.
@@ -332,13 +318,11 @@ namespace Temporalio.Client
         /// <param name="options">Extra options.</param>
         /// <returns>Description for the workflow.</returns>
         public Task<WorkflowExecutionDescription> DescribeAsync(
-            WorkflowDescribeOptions? options = null)
-        {
-            return Client.OutboundInterceptor.DescribeWorkflowAsync(new(
+            WorkflowDescribeOptions? options = null) =>
+            Client.OutboundInterceptor.DescribeWorkflowAsync(new(
                 ID: ID,
                 RunID: RunID,
                 Options: options));
-        }
 
         /// <summary>
         /// Request cancellation of this workflow.
@@ -346,14 +330,12 @@ namespace Temporalio.Client
         /// <param name="options">Cancellation options.</param>
         /// <returns>Cancel accepted task.</returns>
         /// <exception cref="RpcException">Server-side error.</exception>
-        public Task CancelAsync(WorkflowCancelOptions? options = null)
-        {
-            return Client.OutboundInterceptor.CancelWorkflowAsync(new(
+        public Task CancelAsync(WorkflowCancelOptions? options = null) =>
+            Client.OutboundInterceptor.CancelWorkflowAsync(new(
                 ID: ID,
                 RunID: RunID,
                 FirstExecutionRunID: FirstExecutionRunID,
                 Options: options));
-        }
 
         /// <summary>
         /// Terminate this workflow.
@@ -362,15 +344,14 @@ namespace Temporalio.Client
         /// <param name="options">Termination options.</param>
         /// <returns>Terminate completed task.</returns>
         /// <exception cref="RpcException">Server-side error.</exception>
-        public Task TerminateAsync(string? reason = null, WorkflowTerminateOptions? options = null)
-        {
-            return Client.OutboundInterceptor.TerminateWorkflowAsync(new(
+        public Task TerminateAsync(
+            string? reason = null, WorkflowTerminateOptions? options = null) =>
+            Client.OutboundInterceptor.TerminateWorkflowAsync(new(
                 ID: ID,
                 RunID: RunID,
                 FirstExecutionRunID: FirstExecutionRunID,
                 Reason: reason,
                 Options: options));
-        }
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>
@@ -405,10 +386,8 @@ namespace Temporalio.Client
         /// <param name="options">History event fetch options.</param>
         /// <returns>Async enumerable to iterate events for.</returns>
         public IAsyncEnumerable<HistoryEvent> FetchHistoryEventsAsync(
-            WorkflowHistoryEventFetchOptions? options = null)
-        {
-            return FetchHistoryEventsInternalAsync(options);
-        }
+            WorkflowHistoryEventFetchOptions? options = null) =>
+            FetchHistoryEventsInternalAsync(options);
 
         private async IAsyncEnumerable<HistoryEvent> FetchHistoryEventsInternalAsync(
             WorkflowHistoryEventFetchOptions? options = null,
@@ -490,9 +469,7 @@ namespace Temporalio.Client
         /// the workflow (usually an <see cref="ApplicationFailureException" />).
         /// </exception>
         public new Task<TResult> GetResultAsync(
-            bool followRuns = true, RpcOptions? rpcOptions = null)
-        {
-            return GetResultAsync<TResult>(followRuns, rpcOptions);
-        }
+            bool followRuns = true, RpcOptions? rpcOptions = null) =>
+            GetResultAsync<TResult>(followRuns, rpcOptions);
     }
 }

--- a/src/Temporalio/Client/WorkflowHistoryEventFetchOptions.cs
+++ b/src/Temporalio/Client/WorkflowHistoryEventFetchOptions.cs
@@ -15,7 +15,8 @@ namespace Temporalio.Client
         public bool WaitNewEvent { get; set; }
 
         /// <summary>
-        /// Gets or sets which history events to fetch.
+        /// Gets or sets which history events to fetch. Default
+        /// <see cref="HistoryEventFilterType.AllEvent" />.
         /// </summary>
         public HistoryEventFilterType EventFilterType { get; set; } = HistoryEventFilterType.AllEvent;
 

--- a/src/Temporalio/Client/WorkflowHistoryFetchOptions.cs
+++ b/src/Temporalio/Client/WorkflowHistoryFetchOptions.cs
@@ -10,7 +10,8 @@ namespace Temporalio.Client
     public class WorkflowHistoryFetchOptions : ICloneable
     {
         /// <summary>
-        /// Gets or sets which history events to fetch.
+        /// Gets or sets which history events to fetch.  Default
+        /// <see cref="HistoryEventFilterType.AllEvent" />.
         /// </summary>
         public HistoryEventFilterType EventFilterType { get; set; } = HistoryEventFilterType.AllEvent;
 

--- a/src/Temporalio/Client/WorkflowOptions.cs
+++ b/src/Temporalio/Client/WorkflowOptions.cs
@@ -8,21 +8,21 @@ namespace Temporalio.Client
     /// Options for starting a workflow. <see cref="ID" /> and <see cref="TaskQueue" /> are
     /// required.
     /// </summary>
-    public class WorkflowStartOptions : ICloneable
+    public class WorkflowOptions : ICloneable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="WorkflowStartOptions"/> class.
+        /// Initializes a new instance of the <see cref="WorkflowOptions"/> class.
         /// </summary>
-        public WorkflowStartOptions()
+        public WorkflowOptions()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="WorkflowStartOptions"/> class.
+        /// Initializes a new instance of the <see cref="WorkflowOptions"/> class.
         /// </summary>
         /// <param name="id">Workflow ID.</param>
         /// <param name="taskQueue">Task queue to start workflow on.</param>
-        public WorkflowStartOptions(string id, string taskQueue)
+        public WorkflowOptions(string id, string taskQueue)
         {
             ID = id;
             TaskQueue = taskQueue;
@@ -54,12 +54,13 @@ namespace Temporalio.Client
         public TimeSpan? TaskTimeout { get; set; }
 
         /// <summary>
-        /// Gets or sets how already-existing IDs are treated.
+        /// Gets or sets how already-existing IDs are treated. Default is
+        /// <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
         /// </summary>
         public WorkflowIdReusePolicy IDReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
 
         /// <summary>
-        /// Gets or sets the retry policy for the workflow.
+        /// Gets or sets the retry policy for the workflow. If unset, workflow never retries.
         /// </summary>
         public RetryPolicy? RetryPolicy { get; set; }
 
@@ -102,7 +103,7 @@ namespace Temporalio.Client
         /// <returns>A shallow copy of these options and any transitive options fields.</returns>
         public virtual object Clone()
         {
-            var copy = (WorkflowStartOptions)MemberwiseClone();
+            var copy = (WorkflowOptions)MemberwiseClone();
             if (Rpc != null)
             {
                 copy.Rpc = (RpcOptions)Rpc.Clone();

--- a/src/Temporalio/Client/WorkflowService.cs
+++ b/src/Temporalio/Client/WorkflowService.cs
@@ -24,20 +24,12 @@ namespace Temporalio.Client
             /// Initializes a new instance of the <see cref="Core"/> class.
             /// </summary>
             /// <param name="connection">Connection to use.</param>
-            public Core(TemporalConnection connection)
-            {
-                this.connection = connection;
-            }
+            public Core(TemporalConnection connection) => this.connection = connection;
 
             /// <inheritdoc />
             protected override Task<T> InvokeRpcAsync<T>(
-                string rpc,
-                IMessage req,
-                MessageParser<T> resp,
-                RpcOptions? options = null)
-            {
-                return connection.InvokeRpcAsync(this, rpc, req, resp, options);
-            }
+                string rpc, IMessage req, MessageParser<T> resp, RpcOptions? options = null) =>
+                connection.InvokeRpcAsync(this, rpc, req, resp, options);
         }
     }
 }

--- a/src/Temporalio/Converters/BinaryPlainConverter.cs
+++ b/src/Temporalio/Converters/BinaryPlainConverter.cs
@@ -18,8 +18,7 @@ namespace Temporalio.Converters
         /// <inheritdoc />
         public bool TryToPayload(object? value, out Payload? payload)
         {
-            var bytes = value as byte[];
-            if (bytes == null)
+            if (value is not byte[] bytes)
             {
                 payload = null;
                 return false;

--- a/src/Temporalio/Converters/BinaryProtoConverter.cs
+++ b/src/Temporalio/Converters/BinaryProtoConverter.cs
@@ -20,8 +20,7 @@ namespace Temporalio.Converters
         /// <inheritdoc />
         public bool TryToPayload(object? value, out Payload? payload)
         {
-            var proto = value as IMessage;
-            if (proto == null)
+            if (value is not IMessage proto)
             {
                 payload = null;
                 return false;
@@ -56,10 +55,8 @@ namespace Temporalio.Converters
                 throw new ArgumentException($"Payload is protobuf message, but type is {type}");
             }
             // TODO(cretz): Can this be done better/cheaper?
-            var desc =
-                type.GetProperty("Descriptor", BindingFlags.Public | BindingFlags.Static)
-                    ?.GetValue(null) as MessageDescriptor;
-            if (desc == null)
+            if (type.GetProperty("Descriptor", BindingFlags.Public | BindingFlags.Static)
+                    ?.GetValue(null) is not MessageDescriptor desc)
             {
                 throw new ArgumentException(
                     $"Protobuf type {type} does not have expected Descriptor static field");

--- a/src/Temporalio/Converters/ConverterExtensions.cs
+++ b/src/Temporalio/Converters/ConverterExtensions.cs
@@ -62,10 +62,8 @@ namespace Temporalio.Converters
         /// <param name="converter">The converter to use.</param>
         /// <param name="payload">The payload to convert.</param>
         /// <returns>Decoded and converted value.</returns>
-        public static Task<T> ToValueAsync<T>(this DataConverter converter, Payload payload)
-        {
-            return converter.ToSingleValueAsync<T>(new Payload[] { payload });
-        }
+        public static Task<T> ToValueAsync<T>(this DataConverter converter, Payload payload) =>
+            converter.ToSingleValueAsync<T>(new Payload[] { payload });
 
         /// <summary>
         /// Decode and convert the given payload to a value of the given type.
@@ -80,10 +78,8 @@ namespace Temporalio.Converters
         /// <param name="type">Type to convert to.</param>
         /// <returns>Decoded and converted value.</returns>
         public static Task<object?> ToValueAsync(
-            this DataConverter converter, Payload payload, Type type)
-        {
-            return converter.ToSingleValueAsync(new Payload[] { payload }, type);
-        }
+            this DataConverter converter, Payload payload, Type type) =>
+            converter.ToSingleValueAsync(new Payload[] { payload }, type);
 
         /// <summary>
         /// Decode and convert the given payloads to a single value.
@@ -94,11 +90,8 @@ namespace Temporalio.Converters
         /// <returns>Decoded and converted value.</returns>
         /// <exception cref="ArgumentException">If there is not exactly one value.</exception>
         public static async Task<T> ToSingleValueAsync<T>(
-            this DataConverter converter, IReadOnlyCollection<Payload> payloads)
-        {
-            return (T)(await converter.ToSingleValueAsync(
-                payloads, typeof(T)).ConfigureAwait(false))!;
-        }
+            this DataConverter converter, IReadOnlyCollection<Payload> payloads) =>
+            (T)(await converter.ToSingleValueAsync(payloads, typeof(T)).ConfigureAwait(false))!;
 
         /// <summary>
         /// Decode and convert the given payloads to a single value.
@@ -159,6 +152,17 @@ namespace Temporalio.Converters
             }
             return failure;
         }
+
+        /// <summary>
+        /// Convert values to payloads only using the payload converter. Most users outside of a
+        /// workflow should instead use the data converter to convert.
+        /// </summary>
+        /// <param name="converter">Converter to use.</param>
+        /// <param name="values">Values to convert.</param>
+        /// <returns>Converted values.</returns>
+        public static IEnumerable<Payload> ToPayloads(
+            this IPayloadConverter converter, IReadOnlyCollection<object?> values) =>
+            values.Select(converter.ToPayload);
 
         /// <summary>
         /// Convert the given payload to a value of the given type.

--- a/src/Temporalio/Converters/DefaultFailureConverter.cs
+++ b/src/Temporalio/Converters/DefaultFailureConverter.cs
@@ -27,10 +27,8 @@ namespace Temporalio.Converters
         /// This is protected because payload converters are referenced as class types, not
         /// instances, so only subclasses would call this.
         /// </remarks>
-        protected DefaultFailureConverter(DefaultFailureConverterOptions options)
-        {
+        protected DefaultFailureConverter(DefaultFailureConverterOptions options) =>
             Options = options;
-        }
 
         /// <summary>
         /// Gets the options this converter was created with.
@@ -170,6 +168,10 @@ namespace Temporalio.Converters
                                 ? null
                                 : new() { Payloads_ = { canDet.Details.Select(conv.ToPayload) } },
                     };
+                    break;
+                case WorkflowAlreadyStartedException:
+                    // We don't need to do anything special for this, but we also don't require it
+                    // already have a faiure proto
                     break;
                 default:
                     throw new ArgumentException(

--- a/src/Temporalio/Converters/DefaultFailureConverterOptions.cs
+++ b/src/Temporalio/Converters/DefaultFailureConverterOptions.cs
@@ -17,9 +17,6 @@ namespace Temporalio.Converters
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Converters/JsonPlainConverter.cs
+++ b/src/Temporalio/Converters/JsonPlainConverter.cs
@@ -17,10 +17,8 @@ namespace Temporalio.Converters
         /// Initializes a new instance of the <see cref="JsonPlainConverter"/> class.
         /// </summary>
         /// <param name="serializerOptions">Serializer options.</param>
-        public JsonPlainConverter(JsonSerializerOptions serializerOptions)
-        {
+        public JsonPlainConverter(JsonSerializerOptions serializerOptions) =>
             SerializerOptions = serializerOptions;
-        }
 
         /// <inheritdoc />
         public string Encoding => "json/plain";
@@ -42,9 +40,7 @@ namespace Temporalio.Converters
         }
 
         /// <inheritdoc />
-        public object? ToValue(Payload payload, Type type)
-        {
-            return JsonSerializer.Deserialize(payload.Data.ToByteArray(), type, SerializerOptions);
-        }
+        public object? ToValue(Payload payload, Type type) =>
+            JsonSerializer.Deserialize(payload.Data.ToByteArray(), type, SerializerOptions);
     }
 }

--- a/src/Temporalio/Converters/JsonProtoConverter.cs
+++ b/src/Temporalio/Converters/JsonProtoConverter.cs
@@ -47,8 +47,7 @@ namespace Temporalio.Converters
         /// <inheritdoc />
         public bool TryToPayload(object? value, out Payload? payload)
         {
-            var proto = value as IMessage;
-            if (proto == null)
+            if (value is not IMessage proto)
             {
                 payload = null;
                 return false;

--- a/src/Temporalio/Converters/PayloadCodecExtensions.cs
+++ b/src/Temporalio/Converters/PayloadCodecExtensions.cs
@@ -18,10 +18,8 @@ namespace Temporalio.Converters
         /// <param name="codec">Codec to use.</param>
         /// <param name="failure">Failure to encode.</param>
         /// <returns>Task for completion.</returns>
-        public static Task EncodeFailureAsync(this IPayloadCodec codec, Failure failure)
-        {
-            return ApplyToFailurePayloadAsync(failure, codec.EncodeAsync);
-        }
+        public static Task EncodeFailureAsync(this IPayloadCodec codec, Failure failure) =>
+            ApplyToFailurePayloadAsync(failure, codec.EncodeAsync);
 
         /// <summary>
         /// Decode all payloads in the given failure in place.
@@ -29,10 +27,8 @@ namespace Temporalio.Converters
         /// <param name="codec">Codec to use.</param>
         /// <param name="failure">Failure to decode.</param>
         /// <returns>Task for completion.</returns>
-        public static Task DecodeFailureAsync(this IPayloadCodec codec, Failure failure)
-        {
-            return ApplyToFailurePayloadAsync(failure, codec.DecodeAsync);
-        }
+        public static Task DecodeFailureAsync(this IPayloadCodec codec, Failure failure) =>
+            ApplyToFailurePayloadAsync(failure, codec.DecodeAsync);
 
         private static async Task ApplyToFailurePayloadAsync(
             Failure failure,

--- a/src/Temporalio/Exceptions/CancelledFailureException.cs
+++ b/src/Temporalio/Exceptions/CancelledFailureException.cs
@@ -17,10 +17,8 @@ namespace Temporalio.Exceptions
         internal protected CancelledFailureException(
             string message,
             IReadOnlyCollection<object>? details = null)
-            : base(message)
-        {
+            : base(message) =>
             Details = new OutboundFailureDetails(details ?? Array.Empty<object>());
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CancelledFailureException"/> class.

--- a/src/Temporalio/Exceptions/FailureException.cs
+++ b/src/Temporalio/Exceptions/FailureException.cs
@@ -27,10 +27,8 @@ namespace Temporalio.Exceptions
         /// <param name="failure">Underlying proto failure.</param>
         /// <param name="inner">Inner exception if any.</param>
         internal protected FailureException(Failure failure, Exception? inner)
-            : base(failure.Message, inner)
-        {
+            : base(failure.Message, inner) =>
             Failure = failure;
-        }
 
         /// <summary>
         /// Gets the underlying protobuf failure object.

--- a/src/Temporalio/Exceptions/InvalidWorkflowOperationException.cs
+++ b/src/Temporalio/Exceptions/InvalidWorkflowOperationException.cs
@@ -13,10 +13,8 @@ namespace Temporalio.Exceptions
         /// <param name="message">Exception message.</param>
         /// <param name="stackTraceOverride">Override of stack trace.</param>
         internal InvalidWorkflowOperationException(string message, string? stackTraceOverride)
-            : base(message)
-        {
+            : base(message) =>
             this.stackTraceOverride = stackTraceOverride;
-        }
 
         /// <inheritdoc />
         public override string? StackTrace => stackTraceOverride ?? base.StackTrace;

--- a/src/Temporalio/Exceptions/WorkflowAlreadyStartedException.cs
+++ b/src/Temporalio/Exceptions/WorkflowAlreadyStartedException.cs
@@ -3,7 +3,7 @@ namespace Temporalio.Exceptions
     /// <summary>
     /// Exception thrown by client when attempting to start a workflow that was already started.
     /// </summary>
-    public class WorkflowAlreadyStartedException : TemporalException
+    public class WorkflowAlreadyStartedException : FailureException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkflowAlreadyStartedException"/> class.

--- a/src/Temporalio/Exceptions/WorkflowContinuedAsNewException.cs
+++ b/src/Temporalio/Exceptions/WorkflowContinuedAsNewException.cs
@@ -10,10 +10,8 @@ namespace Temporalio.Exceptions
         /// </summary>
         /// <param name="newRunID">New run ID.</param>
         public WorkflowContinuedAsNewException(string newRunID)
-            : base("Workflow continued as new")
-        {
+            : base("Workflow continued as new") =>
             NewRunID = newRunID;
-        }
 
         /// <summary>
         /// Gets the run ID of the new run.

--- a/src/Temporalio/Exceptions/WorkflowQueryRejectedException.cs
+++ b/src/Temporalio/Exceptions/WorkflowQueryRejectedException.cs
@@ -12,10 +12,8 @@ namespace Temporalio.Exceptions
         /// </summary>
         /// <param name="workflowStatus">Workflow status causing rejection.</param>
         public WorkflowQueryRejectedException(WorkflowExecutionStatus workflowStatus)
-            : base($"Query rejected, workflow status: {workflowStatus}")
-        {
+            : base($"Query rejected, workflow status: {workflowStatus}") =>
             WorkflowStatus = workflowStatus;
-        }
 
         /// <summary>
         /// Gets the workflow status causing this rejection.

--- a/src/Temporalio/Runtime/LoggingOptions.cs
+++ b/src/Temporalio/Runtime/LoggingOptions.cs
@@ -18,10 +18,7 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="LoggingOptions"/> class.
         /// </summary>
         /// <param name="filter">Filter options to set.</param>
-        public LoggingOptions(TelemetryFilterOptions filter)
-        {
-            Filter = filter;
-        }
+        public LoggingOptions(TelemetryFilterOptions filter) => Filter = filter;
 
         /// <summary>
         /// Gets or sets the logging filter options.

--- a/src/Temporalio/Runtime/MetricsOptions.cs
+++ b/src/Temporalio/Runtime/MetricsOptions.cs
@@ -20,19 +20,13 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="MetricsOptions"/> class.
         /// </summary>
         /// <param name="prometheus">Prometheus options.</param>
-        public MetricsOptions(PrometheusOptions prometheus)
-        {
-            Prometheus = prometheus;
-        }
+        public MetricsOptions(PrometheusOptions prometheus) => Prometheus = prometheus;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MetricsOptions"/> class.
         /// </summary>
         /// <param name="openTelemetry">OpenTelemetry options.</param>
-        public MetricsOptions(OpenTelemetryOptions openTelemetry)
-        {
-            OpenTelemetry = openTelemetry;
-        }
+        public MetricsOptions(OpenTelemetryOptions openTelemetry) => OpenTelemetry = openTelemetry;
 
         /// <summary>
         /// Gets or sets the Prometheus metrics options.

--- a/src/Temporalio/Runtime/OpenTelemetryOptions.cs
+++ b/src/Temporalio/Runtime/OpenTelemetryOptions.cs
@@ -29,10 +29,7 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="OpenTelemetryOptions"/> class.
         /// </summary>
         /// <param name="url"><see cref="Url" />.</param>
-        public OpenTelemetryOptions(Uri url)
-        {
-            Url = url;
-        }
+        public OpenTelemetryOptions(Uri url) => Url = url;
 
         /// <summary>
         /// Gets or sets the URL for the OpenTelemetry collector.
@@ -53,9 +50,6 @@ namespace Temporalio.Runtime
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Runtime/PrometheusOptions.cs
+++ b/src/Temporalio/Runtime/PrometheusOptions.cs
@@ -18,10 +18,7 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="PrometheusOptions"/> class.
         /// </summary>
         /// <param name="bindAddress"><see cref="BindAddress" />.</param>
-        public PrometheusOptions(string bindAddress)
-        {
-            BindAddress = bindAddress;
-        }
+        public PrometheusOptions(string bindAddress) => BindAddress = bindAddress;
 
         /// <summary>
         /// Gets or sets the address to expose Prometheus metrics on.
@@ -32,9 +29,6 @@ namespace Temporalio.Runtime
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Runtime/TelemetryFilterOptions.cs
+++ b/src/Temporalio/Runtime/TelemetryFilterOptions.cs
@@ -12,10 +12,7 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="TelemetryFilterOptions"/> class.
         /// </summary>
         /// <param name="filterString"><see cref="FilterString" />.</param>
-        public TelemetryFilterOptions(string filterString)
-        {
-            FilterString = filterString;
-        }
+        public TelemetryFilterOptions(string filterString) => FilterString = filterString;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryFilterOptions"/> class.
@@ -74,9 +71,6 @@ namespace Temporalio.Runtime
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Runtime/TemporalRuntime.cs
+++ b/src/Temporalio/Runtime/TemporalRuntime.cs
@@ -28,10 +28,7 @@ namespace Temporalio.Runtime
         {
         }
 
-        private TemporalRuntime(Bridge.Runtime runtime)
-        {
-            Runtime = runtime;
-        }
+        private TemporalRuntime(Bridge.Runtime runtime) => Runtime = runtime;
 
         /// <summary>
         /// Gets or creates the default runtime.

--- a/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
+++ b/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
@@ -18,10 +18,7 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="TemporalRuntimeOptions"/> class.
         /// </summary>
         /// <param name="telemetry"><see cref="Telemetry" />.</param>
-        public TemporalRuntimeOptions(TelemetryOptions telemetry)
-        {
-            Telemetry = telemetry;
-        }
+        public TemporalRuntimeOptions(TelemetryOptions telemetry) => Telemetry = telemetry;
 
         /// <summary>
         /// Gets or sets the telemetry options.

--- a/src/Temporalio/Testing/ActivityEnvironment.cs
+++ b/src/Temporalio/Testing/ActivityEnvironment.cs
@@ -82,10 +82,7 @@ namespace Temporalio.Testing
         /// </summary>
         /// <param name="activity">Activity to run.</param>
         /// <returns>Task for activity completion.</returns>
-        public Task RunAsync(Action activity)
-        {
-            return RunAsync(() => new Task(activity));
-        }
+        public Task RunAsync(Action activity) => RunAsync(() => new Task(activity));
 
         /// <summary>
         /// Run the given activity with a context.
@@ -93,24 +90,19 @@ namespace Temporalio.Testing
         /// <typeparam name="T">Return type.</typeparam>
         /// <param name="activity">Activity to run.</param>
         /// <returns>Activity result.</returns>
-        public Task<T> RunAsync<T>(Func<T> activity)
-        {
-            return RunAsync(() => Task.FromResult(activity()));
-        }
+        public Task<T> RunAsync<T>(Func<T> activity) => RunAsync(() => Task.FromResult(activity()));
 
         /// <summary>
         /// Run the given activity with a context.
         /// </summary>
         /// <param name="activity">Activity to run.</param>
         /// <returns>Task for activity completion.</returns>
-        public Task RunAsync(Func<Task> activity)
-        {
-            return RunAsync<object?>(async () =>
+        public Task RunAsync(Func<Task> activity) =>
+            RunAsync<object?>(async () =>
             {
                 await activity().ConfigureAwait(false);
                 return null;
             });
-        }
 
         /// <summary>
         /// Run the given activity with a context.

--- a/src/Temporalio/Testing/TemporaliteOptions.cs
+++ b/src/Temporalio/Testing/TemporaliteOptions.cs
@@ -25,17 +25,17 @@ namespace Temporalio.Testing
         public string? DatabaseFilename { get; set; }
 
         /// <summary>
-        /// Gets or sets the log format for Temporalite.
+        /// Gets or sets the log format for Temporalite. Default is "pretty".
         /// </summary>
         public string LogFormat { get; set; } = "pretty";
 
         /// <summary>
-        /// Gets or sets the log level for Temporalite.
+        /// Gets or sets the log level for Temporalite. Default is "warn".
         /// </summary>
         public string LogLevel { get; set; } = "warn";
 
         /// <summary>
-        /// Gets or sets the version to version of Temporalite to download.
+        /// Gets or sets the version to version of Temporalite to download. Default is "default".
         /// </summary>
         /// <remarks>
         /// By default, the best one for this SDK version is chosen. This can be a semantic version,
@@ -56,9 +56,6 @@ namespace Temporalio.Testing
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
         /// <remarks>Does not create a copy of the extra args.</remarks>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Testing/TestServerOptions.cs
+++ b/src/Temporalio/Testing/TestServerOptions.cs
@@ -17,7 +17,8 @@ namespace Temporalio.Testing
         public string? ExistingPath { get; set; }
 
         /// <summary>
-        /// Gets or sets the version to version of the test server to download.
+        /// Gets or sets the version to version of the test server to download. Default is
+        /// "default".
         /// </summary>
         /// <remarks>
         /// By default, the best one for this SDK version is chosen. This can be a semantic version,
@@ -38,9 +39,6 @@ namespace Temporalio.Testing
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
         /// <remarks>Does not create a copy of the extra args.</remarks>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Testing/WorkflowEnvironment.cs
+++ b/src/Temporalio/Testing/WorkflowEnvironment.cs
@@ -24,10 +24,7 @@ namespace Temporalio.Testing
         /// client that does not support time skipping.
         /// </summary>
         /// <param name="client">Client to use for this environment.</param>
-        public WorkflowEnvironment(ITemporalClient client)
-        {
-            Client = client;
-        }
+        public WorkflowEnvironment(ITemporalClient client) => Client = client;
 
         /// <summary>
         /// Gets the client for this workflow environment.
@@ -88,10 +85,9 @@ namespace Temporalio.Testing
         /// <see cref="Task.Delay(int, CancellationToken)" />, but in time-skipping environments
         /// this may simply fast forward time.
         /// </remarks>
-        public Task DelayAsync(int millisecondsDelay, CancellationToken? cancellationToken = null)
-        {
-            return DelayAsync(TimeSpan.FromMilliseconds(millisecondsDelay), cancellationToken);
-        }
+        public Task DelayAsync(
+            int millisecondsDelay, CancellationToken? cancellationToken = null) =>
+            DelayAsync(TimeSpan.FromMilliseconds(millisecondsDelay), cancellationToken);
 
         /// <summary>
         /// Sleep in this environment.
@@ -121,10 +117,7 @@ namespace Temporalio.Testing
         /// For non-time-skipping environments this is just <see cref="DateTime.Now" />, but in
         /// time-skipping environments this may be a different time.
         /// </remarks>
-        public virtual Task<DateTime> GetCurrentTimeAsync()
-        {
-            return Task.FromResult(DateTime.Now);
-        }
+        public virtual Task<DateTime> GetCurrentTimeAsync() => Task.FromResult(DateTime.Now);
 
         /// <summary>
         /// Disable automatic time skipping.
@@ -134,19 +127,14 @@ namespace Temporalio.Testing
         /// This has no effect if time skipping is already disabled (which is always the case in
         /// non-time-skipping environments).
         /// </remarks>
-        public virtual IDisposable AutoTimeSkippingDisabled()
-        {
+        public virtual IDisposable AutoTimeSkippingDisabled() =>
             throw new NotImplementedException();
-        }
 
         /// <summary>
         /// Shutdown this server.
         /// </summary>
         /// <returns>Completion task.</returns>
-        public virtual Task ShutdownAsync()
-        {
-            return Task.CompletedTask;
-        }
+        public virtual Task ShutdownAsync() => Task.CompletedTask;
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>
@@ -201,10 +189,8 @@ namespace Temporalio.Testing
             /// <param name="client">Client for the server.</param>
             /// <param name="server">The underlying bridge server.</param>
             public EphemeralServerBased(TemporalClient client, Bridge.EphemeralServer server)
-                : base(client)
-            {
+                : base(client) =>
                 this.server = server;
-            }
 
             /// <inheritdoc/>
             public override bool SupportsTimeSkipping => server.HasTestService;
@@ -244,10 +230,7 @@ namespace Temporalio.Testing
             }
 
             /// <inheritdoc/>
-            public async override Task ShutdownAsync()
-            {
-                await server.ShutdownAsync().ConfigureAwait(false);
-            }
+            public override Task ShutdownAsync() => server.ShutdownAsync();
         }
     }
 }

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -63,10 +63,7 @@ namespace Temporalio.Worker
         /// <summary>
         /// Finalizes an instance of the <see cref="ActivityWorker"/> class.
         /// </summary>
-        ~ActivityWorker()
-        {
-            Dispose(false);
-        }
+        ~ActivityWorker() => Dispose(false);
 
         /// <summary>
         /// Execute the activity until poller shutdown or failure.
@@ -662,9 +659,17 @@ namespace Temporalio.Worker
             /// <inheritdoc />
             public override void Init(ActivityOutboundInterceptor outbound)
             {
-                // Set the context heartbeater as the outbound heartbeat
-                ActivityContext.Current.Heartbeater =
-                    details => outbound.Heartbeat(new(Details: details));
+                // Set the context heartbeater as the outbound heartbeat if we're not local,
+                // otherwise no-op
+                if (ActivityContext.Current.Info.IsLocal)
+                {
+                    ActivityContext.Current.Heartbeater = details => { };
+                }
+                else
+                {
+                    ActivityContext.Current.Heartbeater =
+                        details => outbound.Heartbeat(new(Details: details));
+                }
             }
 
             /// <inheritdoc />
@@ -712,10 +717,7 @@ namespace Temporalio.Worker
             /// Initializes a new instance of the <see cref="OutboundImpl"/> class.
             /// </summary>
             /// <param name="worker">Activity worker.</param>
-            public OutboundImpl(ActivityWorker worker)
-            {
-                this.worker = worker;
-            }
+            public OutboundImpl(ActivityWorker worker) => this.worker = worker;
 
             /// <inheritdoc />
             public override void Heartbeat(HeartbeatInput input)

--- a/src/Temporalio/Worker/Interceptors/CreateContinueAsNewExceptionInput.cs
+++ b/src/Temporalio/Worker/Interceptors/CreateContinueAsNewExceptionInput.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Temporalio.Api.Common.V1;
+using Temporalio.Workflows;
+
+namespace Temporalio.Worker.Interceptors
+{
+    /// <summary>
+    /// Input for <see cref="WorkflowOutboundInterceptor.CreateContinueAsNewException" />.
+    /// </summary>
+    /// <param name="Workflow">Workflow to continue.</param>
+    /// <param name="Args">Arguments for the workflow.</param>
+    /// <param name="Options">Options passed in to continue as new.</param>
+    /// <param name="Headers">Headers to include.</param>
+    public record CreateContinueAsNewExceptionInput(
+        string Workflow,
+        IReadOnlyCollection<object?> Args,
+        ContinueAsNewOptions? Options,
+        IDictionary<string, Payload>? Headers);
+}

--- a/src/Temporalio/Worker/Interceptors/ScheduleActivityInput.cs
+++ b/src/Temporalio/Worker/Interceptors/ScheduleActivityInput.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Temporalio.Api.Common.V1;
+using Temporalio.Workflows;
+
+namespace Temporalio.Worker.Interceptors
+{
+    /// <summary>
+    /// Input for <see cref="WorkflowOutboundInterceptor.ScheduleActivityAsync" />.
+    /// </summary>
+    /// <param name="Activity">Activity type name.</param>
+    /// <param name="Args">Activity args.</param>
+    /// <param name="Options">Activity options.</param>
+    /// <param name="Headers">Headers.</param>
+    public record ScheduleActivityInput(
+        string Activity,
+        IReadOnlyCollection<object?> Args,
+        ActivityOptions Options,
+        IDictionary<string, Payload>? Headers);
+}

--- a/src/Temporalio/Worker/Interceptors/ScheduleLocalActivityInput.cs
+++ b/src/Temporalio/Worker/Interceptors/ScheduleLocalActivityInput.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Temporalio.Api.Common.V1;
+using Temporalio.Workflows;
+
+namespace Temporalio.Worker.Interceptors
+{
+    /// <summary>
+    /// Input for <see cref="WorkflowOutboundInterceptor.ScheduleLocalActivityAsync" />.
+    /// </summary>
+    /// <param name="Activity">Activity type name.</param>
+    /// <param name="Args">Activity args.</param>
+    /// <param name="Options">Activity options.</param>
+    /// <param name="Headers">Headers.</param>
+    public record ScheduleLocalActivityInput(
+        string Activity,
+        IReadOnlyCollection<object?> Args,
+        LocalActivityOptions Options,
+        IDictionary<string, Payload>? Headers);
+}

--- a/src/Temporalio/Worker/Interceptors/StartChildWorkflowInput.cs
+++ b/src/Temporalio/Worker/Interceptors/StartChildWorkflowInput.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Temporalio.Api.Common.V1;
+using Temporalio.Workflows;
+
+namespace Temporalio.Worker.Interceptors
+{
+    /// <summary>
+    /// Input for <see cref="WorkflowOutboundInterceptor.StartChildWorkflowAsync" />.
+    /// </summary>
+    /// <param name="Workflow">Workflow type name.</param>
+    /// <param name="Args">Workflow args.</param>
+    /// <param name="Options">Workflow options.</param>
+    /// <param name="Headers">Headers.</param>
+    public record StartChildWorkflowInput(
+        string Workflow,
+        IReadOnlyCollection<object?> Args,
+        ChildWorkflowOptions Options,
+        IDictionary<string, Payload>? Headers);
+}

--- a/src/Temporalio/Worker/Interceptors/WorkflowOutboundInterceptor.cs
+++ b/src/Temporalio/Worker/Interceptors/WorkflowOutboundInterceptor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Temporalio.Workflows;
 
 namespace Temporalio.Worker.Interceptors
 {
@@ -33,10 +34,46 @@ namespace Temporalio.Worker.Interceptors
         private protected WorkflowOutboundInterceptor? MaybeNext { get; init; }
 
         /// <summary>
+        /// Intercept continue as new exception creation.
+        /// </summary>
+        /// <param name="input">Input details of the call.</param>
+        /// <returns>Created exception.</returns>
+        public virtual ContinueAsNewException CreateContinueAsNewException(
+            CreateContinueAsNewExceptionInput input) => Next.CreateContinueAsNewException(input);
+
+        /// <summary>
         /// Intercept starting a new timer.
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Task for completion.</returns>
         public virtual Task DelayAsync(DelayAsyncInput input) => Next.DelayAsync(input);
+
+        /// <summary>
+        /// Intercept scheduling an activity.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="input">Input details of the call.</param>
+        /// <returns>Activity result.</returns>
+        public virtual Task<TResult> ScheduleActivityAsync<TResult>(
+            ScheduleActivityInput input) => Next.ScheduleActivityAsync<TResult>(input);
+
+        /// <summary>
+        /// Intercept scheduling a local activity.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="input">Input details of the call.</param>
+        /// <returns>Activity result.</returns>
+        public virtual Task<TResult> ScheduleLocalActivityAsync<TResult>(
+            ScheduleLocalActivityInput input) => Next.ScheduleLocalActivityAsync<TResult>(input);
+
+        /// <summary>
+        /// Intercept starting a child workflow. To intercept other child workflow calls, the handle
+        /// can be extended/customized.
+        /// </summary>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="input">Input details of the call.</param>
+        /// <returns>Child handle.</returns>
+        public virtual Task<ChildWorkflowHandle<TResult>> StartChildWorkflowAsync<TResult>(
+            StartChildWorkflowInput input) => Next.StartChildWorkflowAsync<TResult>(input);
     }
 }

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -85,10 +85,7 @@ namespace Temporalio.Worker
         /// <summary>
         /// Finalizes an instance of the <see cref="TemporalWorker"/> class.
         /// </summary>
-        ~TemporalWorker()
-        {
-            Dispose(false);
-        }
+        ~TemporalWorker() => Dispose(false);
 
         /// <summary>
         /// Gets the options this worker was created with.
@@ -138,10 +135,8 @@ namespace Temporalio.Worker
         /// <exception cref="InvalidOperationException">Already started.</exception>
         /// <exception cref="OperationCanceledException">Cancellation requested.</exception>
         /// <exception cref="Exception">Fatal worker failure.</exception>
-        public Task ExecuteAsync(CancellationToken stoppingToken)
-        {
-            return ExecuteInternalAsync(null, stoppingToken);
-        }
+        public Task ExecuteAsync(CancellationToken stoppingToken) =>
+            ExecuteInternalAsync(null, stoppingToken);
 
         /// <summary>
         /// Run this worker until failure, cancelled, or task from given function completes.
@@ -163,10 +158,8 @@ namespace Temporalio.Worker
         /// <exception cref="OperationCanceledException">Cancellation requested.</exception>
         /// <exception cref="Exception">Fatal worker failure.</exception>
         public Task ExecuteAsync(
-            Func<Task> untilComplete, CancellationToken stoppingToken = default)
-        {
-            return ExecuteInternalAsync(untilComplete, stoppingToken);
-        }
+            Func<Task> untilComplete, CancellationToken stoppingToken = default) =>
+            ExecuteInternalAsync(untilComplete, stoppingToken);
 
         /// <summary>
         /// Run this worker until failure, cancelled, or task from given function completes.

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -21,10 +21,7 @@ namespace Temporalio.Worker
         /// Initializes a new instance of the <see cref="TemporalWorkerOptions"/> class.
         /// </summary>
         /// <param name="taskQueue">Task queue for the worker.</param>
-        public TemporalWorkerOptions(string taskQueue)
-        {
-            TaskQueue = taskQueue;
-        }
+        public TemporalWorkerOptions(string taskQueue) => TaskQueue = taskQueue;
 
         /// <summary>
         /// Gets or sets the task queue for the worker.
@@ -86,19 +83,19 @@ namespace Temporalio.Worker
 
         /// <summary>
         /// Gets or sets the maximum number of activities that will ever be given to this worker
-        /// concurrently.
+        /// concurrently. Default is 100.
         /// </summary>
         public int MaxConcurrentActivities { get; set; } = 100;
 
         /// <summary>
-        /// Gets or sets the longest interval for throttling activity heartbeats.
+        /// Gets or sets the longest interval for throttling activity heartbeats. Default is 60s.
         /// </summary>
         public TimeSpan MaxHeartbeatThrottleInterval { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// Gets or sets the default interval for throttling activity heartbeats in case
         /// per-activity heartbeat timeout is unset. Otherwise, it's the per-activity heartbeat
-        /// timeout * 0.8.
+        /// timeout * 0.8. Default is 30s.
         /// </summary>
         public TimeSpan DefaultHeartbeatThrottleInterval { get; set; } = TimeSpan.FromSeconds(30);
 
@@ -125,19 +122,19 @@ namespace Temporalio.Worker
 
         /// <summary>
         /// Gets or sets the number of workflows cached for sticky task queue use. If this is 0,
-        /// sticky task queues are disabled and no caching occurs.
+        /// sticky task queues are disabled and no caching occurs. Default is 10000.
         /// </summary>
         public int MaxCachedWorkflows { get; set; } = 10000;
 
         /// <summary>
         /// Gets or sets the maximum allowed number of workflow tasks that will ever be given to
-        /// the worker at one time.
+        /// the worker at one time. Default is 100.
         /// </summary>
         public int MaxConcurrentWorkflowTasks { get; set; } = 100;
 
         /// <summary>
         /// Gets or sets the maximum number of local activities that will ever be given to this
-        /// worker concurrently.
+        /// worker concurrently. Default is 100.
         /// </summary>
         public int MaxConcurrentLocalActivities { get; set; } = 100;
 
@@ -150,6 +147,7 @@ namespace Temporalio.Worker
         /// <summary>
         /// Gets or sets how long a workflow task is allowed to sit on the sticky queue before it is
         /// timed out and moved to the non-sticky queue where it may be picked up by any worker.
+        /// Default is 10s.
         /// </summary>
         public TimeSpan StickyQueueScheduleToStartTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
@@ -213,9 +211,6 @@ namespace Temporalio.Worker
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options and any transitive options fields.</returns>
-        public virtual object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Worker/WorkflowTaskEventListener.cs
+++ b/src/Temporalio/Worker/WorkflowTaskEventListener.cs
@@ -122,8 +122,7 @@ namespace Temporalio.Worker
             }
         }
 
-        private static void DumpEvent(EventWrittenEventArgs evt)
-        {
+        private static void DumpEvent(EventWrittenEventArgs evt) =>
             Console.WriteLine("TPL Event: {0}", string.Join(" -- ", new List<object?>()
             {
                 evt.EventId,
@@ -134,14 +133,11 @@ namespace Temporalio.Worker
                 evt.PayloadNames == null ? "<none>" : string.Join(",", evt.PayloadNames),
                 evt.Payload == null ? "<none>" : string.Join(",", evt.Payload),
             }));
-        }
 
-        private void EnableNeededEvents(EventSource eventSource)
-        {
+        private void EnableNeededEvents(EventSource eventSource) =>
             EnableEvents(
                 eventSource,
                 EventLevel.Informational,
                 TaskTransferKeywords | AsyncCausalityOperationKeywords);
-        }
     }
 }

--- a/src/Temporalio/Workflows/ActivityCancellationType.cs
+++ b/src/Temporalio/Workflows/ActivityCancellationType.cs
@@ -1,0 +1,25 @@
+namespace Temporalio.Workflows
+{
+    /// <summary>
+    /// How an activity cancellation is treated by the workflow.
+    /// </summary>
+    public enum ActivityCancellationType
+    {
+        /// <summary>
+        /// Initiate a cancellation request and immediately report cancellation to the workflow.
+        /// </summary>
+        TryCancel = Bridge.Api.WorkflowCommands.ActivityCancellationType.TryCancel,
+
+        /// <summary>
+        /// Wait for activity cancellation completion. Note that activity must heartbeat to receive
+        /// a cancellation notification.
+        /// </summary>
+        WaitCancellationCompleted = Bridge.Api.WorkflowCommands.ActivityCancellationType.WaitCancellationCompleted,
+
+        /// <summary>
+        /// Do not request cancellation of the activity and immediately report cancellation to the
+        /// workflow.
+        /// </summary>
+        Abandon = Bridge.Api.WorkflowCommands.ActivityCancellationType.Abandon,
+    }
+}

--- a/src/Temporalio/Workflows/ActivityOptions.cs
+++ b/src/Temporalio/Workflows/ActivityOptions.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+
+namespace Temporalio.Workflows
+{
+    /// <summary>
+    /// Options for activity execution from a workflow. Either <see cref="ScheduleToCloseTimeout" />
+    /// or <see cref="StartToCloseTimeout" /> must be set. <see cref="HeartbeatTimeout" /> must be
+    /// set for the activity to receive cancellations and all but the most instantly completing
+    /// activities should set this.
+    /// </summary>
+    public class ActivityOptions : ICloneable
+    {
+        /// <summary>
+        /// Gets or sets the schedule to close timeout.
+        /// </summary>
+        /// <remarks>
+        /// This is the timeout from schedule to completion of the activity (all attempts,
+        /// including retries). Either this or <see cref="StartToCloseTimeout" /> must be set. If
+        /// unset, default is the workflow execution timeout.
+        /// </remarks>
+        public TimeSpan? ScheduleToCloseTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule to start timeout.
+        /// </summary>
+        /// <remarks>
+        /// This is the timeout from schedule to when the activity is picked up by a worker. If
+        /// unset, defaults to <see cref="ScheduleToCloseTimeout" />.
+        /// </remarks>
+        public TimeSpan? ScheduleToStartTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start to close timeout.
+        /// </summary>
+        /// <remarks>
+        /// This is the timeout for each separate retry attempt from start to completion of the
+        /// attempt. Either this or <see cref="ScheduleToCloseTimeout" /> must be set.
+        /// </remarks>
+        public TimeSpan? StartToCloseTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the heartbeat timeout.
+        /// </summary>
+        /// <remarks>
+        /// This must be set for an activity to receive cancellation. This should always be set for
+        /// all but the most instantly completing activities.
+        /// </remarks>
+        public TimeSpan? HeartbeatTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the retry policy. If unset, defaults to retrying forever.
+        /// </summary>
+        public RetryPolicy? RetryPolicy { get; set; }
+
+        /// <summary>
+        /// Gets or sets how the workflow will send/wait for cancellation of the activity. Default
+        /// is <see cref="ActivityCancellationType.TryCancel" />.
+        /// </summary>
+        public ActivityCancellationType CancellationType { get; set; } = ActivityCancellationType.TryCancel;
+
+        /// <summary>
+        /// Gets or sets the cancellation token for this activity. If unset, this defaults to the
+        /// workflow cancellation token.
+        /// </summary>
+        public CancellationToken? CancellationToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task queue for this activity. If unset, defaults to the workflow task
+        /// queue.
+        /// </summary>
+        public string? TaskQueue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier for the activity. This should never be set unless
+        /// users have a strong understanding of the system. Contact Temporal support to discuss the
+        /// use case before setting this value.
+        /// </summary>
+        public string? ActivityID { get; set; }
+
+        /// <summary>
+        /// Create a shallow copy of these options.
+        /// </summary>
+        /// <returns>A shallow copy of these options.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio/Workflows/ChildWorkflowCancellationType.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowCancellationType.cs
@@ -1,0 +1,29 @@
+namespace Temporalio.Workflows
+{
+    /// <summary>
+    /// How a child workflow cancellation is treated by the workflow.
+    /// </summary>
+    public enum ChildWorkflowCancellationType
+    {
+        /// <summary>
+        /// Do not request cancellation of the child workflow is already scheduled.
+        /// </summary>
+        Abandon = Bridge.Api.ChildWorkflow.ChildWorkflowCancellationType.Abandon,
+
+        /// <summary>
+        /// Initiate a cancellation request and immediately report cancellation to the parent.
+        /// </summary>
+        TryCancel = Bridge.Api.ChildWorkflow.ChildWorkflowCancellationType.TryCancel,
+
+        /// <summary>
+        /// Wait for child cancellation completion.
+        /// </summary>
+        WaitCancellationCompleted = Bridge.Api.ChildWorkflow.ChildWorkflowCancellationType.WaitCancellationCompleted,
+
+        /// <summary>
+        /// Request cancellation of the child and wait for confirmation that the request was
+        /// received.
+        /// </summary>
+        WaitCancellationRequested = Bridge.Api.ChildWorkflow.ChildWorkflowCancellationType.WaitCancellationRequested,
+    }
+}

--- a/src/Temporalio/Workflows/ChildWorkflowHandle.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowHandle.cs
@@ -1,0 +1,84 @@
+#pragma warning disable SA1402 // We allow multiple types of the same name
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Temporalio.Workflows
+{
+    /// <summary>
+    /// Handle representing a started child workflow.
+    /// </summary>
+    public abstract class ChildWorkflowHandle
+    {
+        /// <summary>
+        /// Gets the ID of the child workflow.
+        /// </summary>
+        public abstract string ID { get; }
+
+        /// <summary>
+        /// Gets the initial run ID of the child workflow.
+        /// </summary>
+        public abstract string FirstExecutionRunID { get; }
+
+        /// <summary>
+        /// Wait for result of the child workflow, ignoring the return value.
+        /// </summary>
+        /// <returns>Task representing completion.</returns>
+        /// <exception cref="Exceptions.ChildWorkflowFailureException">Any child workflow
+        /// failure.</exception>
+        public Task GetResultAsync() => GetResultAsync<ValueTuple>();
+
+        /// <summary>
+        /// Wait for the result of the child workflow.
+        /// </summary>
+        /// <typeparam name="TResult">Result type to convert to.</typeparam>
+        /// <returns>Task with result.</returns>
+        /// <exception cref="Exceptions.ChildWorkflowFailureException">Any child workflow
+        /// failure.</exception>
+        /// <exception cref="Exception">Failure converting to result type.</exception>
+        public abstract Task<TResult> GetResultAsync<TResult>();
+
+        /// <summary>
+        /// Signal a child workflow.
+        /// </summary>
+        /// <param name="signal">Signal to send.</param>
+        /// <returns>Task for completion of the signal send.</returns>
+        public Task SignalAsync(Func<Task> signal) =>
+            SignalAsync(
+                WorkflowSignalDefinition.FromMethod(signal.Method).Name,
+                Array.Empty<object?>());
+
+        /// <summary>
+        /// Signal a child workflow.
+        /// </summary>
+        /// <typeparam name="T">Signal arg type.</typeparam>
+        /// <param name="signal">Signal to send.</param>
+        /// <param name="arg">Signal argument.</param>
+        /// <returns>Task for completion of the signal send.</returns>
+        public Task SignalAsync<T>(Func<T, Task> signal, T arg) =>
+            SignalAsync(
+                WorkflowSignalDefinition.FromMethod(signal.Method).Name,
+                new object?[] { arg });
+
+        /// <summary>
+        /// Signal a child workflow.
+        /// </summary>
+        /// <param name="signal">Signal to send.</param>
+        /// <param name="args">Signal arguments.</param>
+        /// <returns>Task for completion of the signal send.</returns>
+        public abstract Task SignalAsync(string signal, IReadOnlyCollection<object?> args);
+    }
+
+    /// <inheritdoc />
+    public abstract class ChildWorkflowHandle<TResult> : ChildWorkflowHandle
+    {
+        /// <summary>
+        /// Get a result with the known result type.
+        /// </summary>
+        /// <returns>Task with result.</returns>
+        /// <exception cref="Exceptions.ChildWorkflowFailureException">Any child workflow
+        /// failure.</exception>
+        public new Task<TResult> GetResultAsync() => GetResultAsync<TResult>();
+    }
+}

--- a/src/Temporalio/Workflows/ChildWorkflowOptions.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowOptions.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Temporalio.Api.Enums.V1;
+
+namespace Temporalio.Workflows
+{
+    /// <summary>
+    /// Options for starting a child workflow.
+    /// </summary>
+    public class ChildWorkflowOptions : ICloneable
+    {
+        /// <summary>
+        /// Gets or sets the workflow ID. If unset, default will be a deterministic-random
+        /// identifier.
+        /// </summary>
+        public string? ID { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task queue. If unset, default will be the parent workflow task queue.
+        /// </summary>
+        public string? TaskQueue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the retry policy. Default is no retries.
+        /// </summary>
+        public RetryPolicy? RetryPolicy { get; set; }
+
+        /// <summary>
+        /// Gets or sets how the workflow will send/wait for cancellation of the child. Default is
+        /// <see cref="ChildWorkflowCancellationType.WaitCancellationCompleted" />.
+        /// </summary>
+        public ChildWorkflowCancellationType CancellationType { get; set; } = ChildWorkflowCancellationType.WaitCancellationCompleted;
+
+        /// <summary>
+        /// Gets or sets the cancellation token for this child. If unset, defaults to the workflow
+        /// cancellation token.
+        /// </summary>
+        public CancellationToken? CancellationToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets how the child is treated when the parent is closed. Default is
+        /// <see cref="ParentClosePolicy.Terminate" />.
+        /// </summary>
+        public ParentClosePolicy ParentClosePolicy { get; set; } = ParentClosePolicy.Terminate;
+
+        /// <summary>
+        /// Gets or sets the total workflow execution timeout including retries and continue as new.
+        /// </summary>
+        public TimeSpan? ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout of a single workflow run.
+        /// </summary>
+        public TimeSpan? RunTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout of a single workflow task.
+        /// </summary>
+        public TimeSpan? TaskTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets how already-existing IDs are treated. Default is
+        /// <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
+        /// </summary>
+        public WorkflowIdReusePolicy IDReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
+
+        /// <summary>
+        /// Gets or sets the cron schedule for the workflow.
+        /// </summary>
+        public string? CronSchedule { get; set; }
+
+        /// <summary>
+        /// Gets or sets the memo for the workflow. Values for the memo cannot be null.
+        /// </summary>
+        public IReadOnlyCollection<KeyValuePair<string, object>>? Memo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the search attributes for the workflow.
+        /// </summary>
+        public SearchAttributeCollection? TypedSearchAttributes { get; set; }
+
+        /// <summary>
+        /// Create a shallow copy of these options.
+        /// </summary>
+        /// <returns>A shallow copy of these options.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio/Workflows/ContinueAsNewException.cs
+++ b/src/Temporalio/Workflows/ContinueAsNewException.cs
@@ -1,116 +1,24 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Temporalio.Exceptions;
+using Temporalio.Worker.Interceptors;
 
 namespace Temporalio.Workflows
 {
     /// <summary>
-    /// Exception thrown by a workflow to continue as new. Use <c>Create</c> to create.
+    /// Exception thrown by a workflow to continue as new. Use
+    /// <c>Workflow.CreateContinueAsNewException</c> to create.
     /// </summary>
     public class ContinueAsNewException : TemporalException
     {
-        private ContinueAsNewException(
-            string workflow, IReadOnlyCollection<object?> args, ContinueAsNewOptions? options)
-            : base("Continue as new")
-        {
-            Workflow = workflow;
-            Args = args;
-            Options = options;
-        }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContinueAsNewException"/> class.
+        /// </summary>
+        /// <param name="input">Continue as new input.</param>
+        internal ContinueAsNewException(CreateContinueAsNewExceptionInput input)
+            : base("Continue as new") => Input = input;
 
         /// <summary>
-        /// Gets the workflow type name to continue as new with.
+        /// Gets the continue as new input.
         /// </summary>
-        public string Workflow { get; private init; }
-
-        /// <summary>
-        /// Gets the workflow arguments to continue as new with.
-        /// </summary>
-        public IReadOnlyCollection<object?> Args { get; private init; }
-
-        /// <summary>
-        /// Gets the continue as new options.
-        /// </summary>
-        public ContinueAsNewOptions? Options { get; private init; }
-
-        /// <summary>
-        /// Create a continue as new exception.
-        /// </summary>
-        /// <param name="workflow">Workflow run method reference.</param>
-        /// <param name="options">Continue as new options.</param>
-        /// <returns>Continue as new exception.</returns>
-        public static ContinueAsNewException Create(
-            Func<Task> workflow, ContinueAsNewOptions? options = null)
-        {
-            return new(
-                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
-                Array.Empty<object?>(),
-                options);
-        }
-
-        /// <summary>
-        /// Create a continue as new exception.
-        /// </summary>
-        /// <typeparam name="T">Type of the workflow argument.</typeparam>
-        /// <param name="workflow">Workflow run method reference.</param>
-        /// <param name="arg">Workflow argument.</param>
-        /// <param name="options">Continue as new options.</param>
-        /// <returns>Continue as new exception.</returns>
-        public static ContinueAsNewException Create<T>(
-            Func<T, Task> workflow, T arg, ContinueAsNewOptions? options = null)
-        {
-            return new(
-                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
-                new object?[] { arg },
-                options);
-        }
-
-        /// <summary>
-        /// Create a continue as new exception.
-        /// </summary>
-        /// <typeparam name="TResult">Type of the workflow result.</typeparam>
-        /// <param name="workflow">Workflow run method reference.</param>
-        /// <param name="options">Continue as new options.</param>
-        /// <returns>Continue as new exception.</returns>
-        public static ContinueAsNewException Create<TResult>(
-            Func<Task<TResult>> workflow, ContinueAsNewOptions? options = null)
-        {
-            return new(
-                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
-                Array.Empty<object?>(),
-                options);
-        }
-
-        /// <summary>
-        /// Create a continue as new exception.
-        /// </summary>
-        /// <typeparam name="T">Type of the workflow argument.</typeparam>
-        /// <typeparam name="TResult">Type of the workflow result.</typeparam>
-        /// <param name="workflow">Workflow run method reference.</param>
-        /// <param name="arg">Workflow argument.</param>
-        /// <param name="options">Continue as new options.</param>
-        /// <returns>Continue as new exception.</returns>
-        public static ContinueAsNewException Create<T, TResult>(
-            Func<T, Task<TResult>> workflow, T arg, ContinueAsNewOptions? options = null)
-        {
-            return new(
-                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
-                new object?[] { arg },
-                options);
-        }
-
-        /// <summary>
-        /// Create a continue as new exception.
-        /// </summary>
-        /// <param name="workflow">Workflow type name.</param>
-        /// <param name="args">Workflow arguments.</param>
-        /// <param name="options">Continue as new options.</param>
-        /// <returns>Continue as new exception.</returns>
-        public static ContinueAsNewException Create(
-            string workflow, object?[] args, ContinueAsNewOptions? options = null)
-        {
-            return new(workflow, args, options);
-        }
+        internal CreateContinueAsNewExceptionInput Input { get; private init; }
     }
 }

--- a/src/Temporalio/Workflows/ContinueAsNewOptions.cs
+++ b/src/Temporalio/Workflows/ContinueAsNewOptions.cs
@@ -1,18 +1,53 @@
 using System;
+using System.Collections.Generic;
 
 namespace Temporalio.Workflows
 {
     /// <summary>
-    /// Options for <see cref="ContinueAsNewException" />.
+    /// Options for continue as new.
     /// </summary>
     public class ContinueAsNewOptions : ICloneable
     {
-        // TODO(cretz): Options
+        /// <summary>
+        /// Gets or sets the task queue to continue as new. If unset, defaults to current workflow's
+        /// task queue.
+        /// </summary>
+        public string? TaskQueue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the run timeout for continue as new. If unset, defaults to current
+        /// workflow's run timeout.
+        /// </summary>
+        public TimeSpan? RunTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task timeout for continue as new. If unset, defaults to current
+        /// workflow's task timeout.
+        /// </summary>
+        public TimeSpan? TaskTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the retry policy for continue as new. If unset, defaults to the current
+        /// workflow's retry policy.
+        /// </summary>
+        public RetryPolicy? RetryPolicy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the memo for continue as new. If unset, default to the current workflow's
+        /// memo.
+        /// </summary>
+        public IReadOnlyCollection<KeyValuePair<string, object>>? Memo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the search attributes for continue as new. If unset, default to current
+        /// workflow's search attribute.
+        /// </summary>
+        public SearchAttributeCollection? TypedSearchAttributes { get; set; }
 
         /// <summary>
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>
-        public virtual object Clone() => (ContinueAsNewOptions)MemberwiseClone();
+        public virtual object Clone() => MemberwiseClone();
     }
 }

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -57,6 +57,17 @@ namespace Temporalio.Workflows
         DateTime UtcNow { get; }
 
         /// <summary>
+        /// Backing call for
+        /// <see cref="Workflow.CreateContinueAsNewException(string, IReadOnlyCollection{object?}, ContinueAsNewOptions?)" />.
+        /// </summary>
+        /// <param name="workflow">Workflow name.</param>
+        /// <param name="args">Workflow args.</param>
+        /// <param name="options">Options.</param>
+        /// <returns>Continue as new exception.</returns>
+        ContinueAsNewException CreateContinueAsNewException(
+            string workflow, IReadOnlyCollection<object?> args, ContinueAsNewOptions? options);
+
+        /// <summary>
         /// Backing call for <see cref="Workflow.DelayAsync(TimeSpan, CancellationToken?)" /> and
         /// overloads.
         /// </summary>
@@ -64,6 +75,42 @@ namespace Temporalio.Workflows
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns>Task for completion.</returns>
         Task DelayAsync(TimeSpan delay, CancellationToken? cancellationToken);
+
+        /// <summary>
+        /// Backing call for
+        /// <see cref="Workflow.ExecuteActivityAsync{TResult}(string, IReadOnlyCollection{object?}, ActivityOptions)" />.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity name.</param>
+        /// <param name="args">Activity args.</param>
+        /// <param name="options">Options.</param>
+        /// <returns>Activity result.</returns>
+        Task<TResult> ExecuteActivityAsync<TResult>(
+            string activity, IReadOnlyCollection<object?> args, ActivityOptions options);
+
+        /// <summary>
+        /// Backing call for
+        /// <see cref="Workflow.ExecuteLocalActivityAsync{TResult}(string, IReadOnlyCollection{object?}, LocalActivityOptions)" />.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity name.</param>
+        /// <param name="args">Activity args.</param>
+        /// <param name="options">Options.</param>
+        /// <returns>Activity result.</returns>
+        Task<TResult> ExecuteLocalActivityAsync<TResult>(
+            string activity, IReadOnlyCollection<object?> args, LocalActivityOptions options);
+
+        /// <summary>
+        /// Backing call for
+        /// <see cref="Workflow.StartChildWorkflowAsync{TResult}(string, IReadOnlyCollection{object?}, ChildWorkflowOptions?)" />.
+        /// </summary>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="workflow">Workflow name.</param>
+        /// <param name="args">Workflow args.</param>
+        /// <param name="options">Options.</param>
+        /// <returns>Child workflow handle.</returns>
+        Task<ChildWorkflowHandle<TResult>> StartChildWorkflowAsync<TResult>(
+            string workflow, IReadOnlyCollection<object?> args, ChildWorkflowOptions options);
 
         /// <summary>
         /// Backing call for <see cref="Workflow.UpsertMemo" />.

--- a/src/Temporalio/Workflows/LocalActivityOptions.cs
+++ b/src/Temporalio/Workflows/LocalActivityOptions.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+
+namespace Temporalio.Workflows
+{
+    /// <summary>
+    /// Options for local activity execution from a workflow. Either
+    /// <see cref="ScheduleToCloseTimeout" /> or <see cref="StartToCloseTimeout" /> must be set.
+    /// </summary>
+    public class LocalActivityOptions : ICloneable
+    {
+        /// <summary>
+        /// Gets or sets the schedule to close timeout.
+        /// </summary>
+        /// <remarks>
+        /// This is the timeout from schedule to completion of the activity (all attempts,
+        /// including retries). Either this or <see cref="StartToCloseTimeout" /> must be set. If
+        /// unset, default is the workflow execution timeout.
+        /// </remarks>
+        public TimeSpan? ScheduleToCloseTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule to start timeout.
+        /// </summary>
+        /// <remarks>
+        /// This is the timeout from schedule to when the activity is picked up by a worker. If
+        /// unset, defaults to <see cref="ScheduleToCloseTimeout" />.
+        /// </remarks>
+        public TimeSpan? ScheduleToStartTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start to close timeout.
+        /// </summary>
+        /// <remarks>
+        /// This is the timeout for each separate retry attempt from start to completion of the
+        /// attempt. Either this or <see cref="ScheduleToCloseTimeout" /> must be set.
+        /// </remarks>
+        public TimeSpan? StartToCloseTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the retry policy. If unset, defaults to retrying forever.
+        /// </summary>
+        public RetryPolicy? RetryPolicy { get; set; }
+
+        /// <summary>
+        /// Gets or sets how the workflow will send/wait for cancellation of the activity. Default
+        /// is <see cref="ActivityCancellationType.TryCancel" />.
+        /// </summary>
+        public ActivityCancellationType CancellationType { get; set; } = ActivityCancellationType.TryCancel;
+
+        /// <summary>
+        /// Gets or sets the cancellation token for this activity. If unset, this defaults to the
+        /// workflow cancellation token.
+        /// </summary>
+        public CancellationToken? CancellationToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier for the activity. This should never be set unless
+        /// users have a strong understanding of the system. Contact Temporal support to discuss the
+        /// use case before setting this value.
+        /// </summary>
+        public string? ActivityID { get; set; }
+
+        /// <summary>
+        /// Gets or sets the local retry threshold. If unset, default is 1m.
+        /// </summary>
+        /// <remarks>
+        /// If the activity is retrying and backoff would exceed this value, an internal timer will
+        /// be scheduled to retry the activity after. Otherwise, backoff will happen internally
+        /// without a timer.
+        /// </remarks>
+        public TimeSpan? LocalRetryThreshold { get; set; }
+
+        /// <summary>
+        /// Create a shallow copy of these options.
+        /// </summary>
+        /// <returns>A shallow copy of these options.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio/Workflows/ParentClosePolicy.cs
+++ b/src/Temporalio/Workflows/ParentClosePolicy.cs
@@ -1,0 +1,28 @@
+namespace Temporalio.Workflows
+{
+    /// <summary>
+    /// How a workflow child will be handled when its parent workflow closes.
+    /// </summary>
+    public enum ParentClosePolicy
+    {
+        /// <summary>
+        /// No value set and will internally default. This should not be used.
+        /// </summary>
+        None = Bridge.Api.ChildWorkflow.ParentClosePolicy.Unspecified,
+
+        /// <summary>
+        /// Child workflow will be terminated.
+        /// </summary>
+        Terminate = Bridge.Api.ChildWorkflow.ParentClosePolicy.Terminate,
+
+        /// <summary>
+        /// Child workflow will do nothing.
+        /// </summary>
+        Abandon = Bridge.Api.ChildWorkflow.ParentClosePolicy.Abandon,
+
+        /// <summary>
+        /// Cancellation will be requested on the child workflow.
+        /// </summary>
+        RequestCancel = Bridge.Api.ChildWorkflow.ParentClosePolicy.RequestCancel,
+    }
+}

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -100,6 +100,82 @@ namespace Temporalio.Workflows
             TaskScheduler.Current as IWorkflowContext ?? throw new InvalidOperationException("Not in workflow");
 
         /// <summary>
+        /// Create an exception that, when thrown out of the workflow, will continue-as-new with
+        /// the given workflow.
+        /// </summary>
+        /// <param name="workflow">Workflow.</param>
+        /// <param name="options">Continue as new options.</param>
+        /// <returns>Exception for continuing as new.</returns>
+        public static ContinueAsNewException CreateContinueAsNewException(
+            Func<Task> workflow, ContinueAsNewOptions? options = null) =>
+            CreateContinueAsNewException(
+                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Create an exception that, when thrown out of the workflow, will continue-as-new with
+        /// the given workflow.
+        /// </summary>
+        /// <typeparam name="T">Workflow argument type.</typeparam>
+        /// <param name="workflow">Workflow.</param>
+        /// <param name="arg">Workflow argument.</param>
+        /// <param name="options">Continue as new options.</param>
+        /// <returns>Exception for continuing as new.</returns>
+        public static ContinueAsNewException CreateContinueAsNewException<T>(
+            Func<T, Task> workflow, T arg, ContinueAsNewOptions? options = null) =>
+            CreateContinueAsNewException(
+                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Create an exception that, when thrown out of the workflow, will continue-as-new with
+        /// the given workflow.
+        /// </summary>
+        /// <typeparam name="TResult">Workflow return type.</typeparam>
+        /// <param name="workflow">Workflow.</param>
+        /// <param name="options">Continue as new options.</param>
+        /// <returns>Exception for continuing as new.</returns>
+        public static ContinueAsNewException CreateContinueAsNewException<TResult>(
+            Func<Task<TResult>> workflow, ContinueAsNewOptions? options = null) =>
+            CreateContinueAsNewException(
+                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Create an exception that, when thrown out of the workflow, will continue-as-new with
+        /// the given workflow.
+        /// </summary>
+        /// <typeparam name="T">Workflow argument type.</typeparam>
+        /// <typeparam name="TResult">Workflow return type.</typeparam>
+        /// <param name="workflow">Workflow.</param>
+        /// <param name="arg">Workflow argument.</param>
+        /// <param name="options">Continue as new options.</param>
+        /// <returns>Exception for continuing as new.</returns>
+        public static ContinueAsNewException CreateContinueAsNewException<T, TResult>(
+            Func<T, Task<TResult>> workflow, T arg, ContinueAsNewOptions? options = null) =>
+            CreateContinueAsNewException(
+                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Create an exception that, when thrown out of the workflow, will continue-as-new with
+        /// the given workflow.
+        /// </summary>
+        /// <param name="workflow">Workflow name.</param>
+        /// <param name="args">Workflow arguments.</param>
+        /// <param name="options">Continue as new options.</param>
+        /// <returns>Exception for continuing as new.</returns>
+        public static ContinueAsNewException CreateContinueAsNewException(
+            string workflow,
+            IReadOnlyCollection<object?> args,
+            ContinueAsNewOptions? options = null) =>
+            Context.CreateContinueAsNewException(workflow, args, options);
+
+        /// <summary>
         /// Sleep in a workflow for the given time. See documentation of
         /// <see cref="DelayAsync(TimeSpan, CancellationToken?)" /> for details.
         /// </summary>
@@ -135,6 +211,636 @@ namespace Temporalio.Workflows
         /// </remarks>
         public static Task DelayAsync(TimeSpan delay, CancellationToken? cancellationToken = null) =>
             Context.DelayAsync(delay, cancellationToken);
+
+        /// <summary>
+        /// Execute an activity with a result and no arguments.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteActivityAsync<TResult>(
+            Func<TResult> activity, ActivityOptions options) =>
+            ExecuteActivityAsync<TResult>(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Execute an activity with a result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Activity argument type.</typeparam>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="arg">Activity argument.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteActivityAsync<T, TResult>(
+            Func<T, TResult> activity, T arg, ActivityOptions options) =>
+            ExecuteActivityAsync<TResult>(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Execute an activity with no result and no arguments.
+        /// </summary>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteActivityAsync(
+            Action activity, ActivityOptions options) =>
+            ExecuteActivityAsync(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Execute an activity with no result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Activity argument type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="arg">Activity argument.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteActivityAsync<T>(
+            Action<T> activity, T arg, ActivityOptions options) =>
+            ExecuteActivityAsync(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Execute an activity with a result and no arguments.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteActivityAsync<TResult>(
+            Func<Task<TResult>> activity, ActivityOptions options) =>
+            ExecuteActivityAsync<TResult>(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Execute an activity with a result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Activity argument type.</typeparam>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="arg">Activity argument.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteActivityAsync<T, TResult>(
+            Func<T, Task<TResult>> activity, T arg, ActivityOptions options) =>
+            ExecuteActivityAsync<TResult>(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Execute an activity with no result and no arguments.
+        /// </summary>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteActivityAsync(
+            Func<Task> activity, ActivityOptions options) =>
+            ExecuteActivityAsync(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Execute an activity with no result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Activity argument type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="arg">Activity argument.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteActivityAsync<T>(
+            Func<T, Task> activity, T arg, ActivityOptions options) =>
+            ExecuteActivityAsync(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Execute an activity by name with no result and any number of arguments.
+        /// </summary>
+        /// <param name="activity">Activity name to execute.</param>
+        /// <param name="args">Activity arguments.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteActivityAsync(
+            string activity, IReadOnlyCollection<object?> args, ActivityOptions options) =>
+            ExecuteActivityAsync<ValueTuple>(activity, args, options);
+
+        /// <summary>
+        /// Execute an activity by name with a result and any number of arguments.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity name to execute.</param>
+        /// <param name="args">Activity arguments.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteActivityAsync<TResult>(
+            string activity, IReadOnlyCollection<object?> args, ActivityOptions options) =>
+            Context.ExecuteActivityAsync<TResult>(activity, args, options);
+
+        /// <summary>
+        /// Shortcut for
+        /// <see cref="StartChildWorkflowAsync{TResult}(Func{Task{TResult}}, ChildWorkflowOptions?)" />
+        /// +
+        /// <see cref="ChildWorkflowHandle{TResult}.GetResultAsync" />.
+        /// </summary>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="workflow">Workflow to execute.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>Task for workflow completion.</returns>
+        public static async Task<TResult> ExecuteChildWorkflowAsync<TResult>(
+            Func<Task<TResult>> workflow, ChildWorkflowOptions? options = null)
+        {
+            var handle = await StartChildWorkflowAsync(workflow, options).ConfigureAwait(true);
+            return await handle.GetResultAsync().ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Shortcut for
+        /// <see cref="StartChildWorkflowAsync{T, TResult}(Func{T, Task{TResult}}, T, ChildWorkflowOptions?)" />
+        /// +
+        /// <see cref="ChildWorkflowHandle{TResult}.GetResultAsync" />.
+        /// </summary>
+        /// <typeparam name="T">Workflow argument type.</typeparam>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="workflow">Workflow to execute.</param>
+        /// <param name="arg">Workflow argument.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>Task for workflow completion.</returns>
+        public static async Task<TResult> ExecuteChildWorkflowAsync<T, TResult>(
+            Func<T, Task<TResult>> workflow, T arg, ChildWorkflowOptions? options = null)
+        {
+            var handle = await StartChildWorkflowAsync(
+                workflow, arg, options).ConfigureAwait(true);
+            return await handle.GetResultAsync().ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Shortcut for
+        /// <see cref="StartChildWorkflowAsync(Func{Task}, ChildWorkflowOptions?)" />
+        /// +
+        /// <see cref="ChildWorkflowHandle.GetResultAsync" />.
+        /// </summary>
+        /// <param name="workflow">Workflow to execute.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>Task for workflow completion.</returns>
+        public static async Task ExecuteChildWorkflowAsync(
+            Func<Task> workflow, ChildWorkflowOptions? options = null)
+        {
+            var handle = await StartChildWorkflowAsync(workflow, options).ConfigureAwait(true);
+            await handle.GetResultAsync().ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Shortcut for
+        /// <see cref="StartChildWorkflowAsync{T}(Func{T, Task}, T, ChildWorkflowOptions?)" />
+        /// +
+        /// <see cref="ChildWorkflowHandle.GetResultAsync" />.
+        /// </summary>
+        /// <typeparam name="T">Workflow argument type.</typeparam>
+        /// <param name="workflow">Workflow to execute.</param>
+        /// <param name="arg">Workflow argument.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>Task for workflow completion.</returns>
+        public static async Task ExecuteChildWorkflowAsync<T>(
+            Func<T, Task> workflow, T arg, ChildWorkflowOptions? options = null)
+        {
+            var handle = await StartChildWorkflowAsync(
+                workflow, arg, options).ConfigureAwait(true);
+            await handle.GetResultAsync().ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Shortcut for
+        /// <see cref="StartChildWorkflowAsync(string, IReadOnlyCollection{object?}, ChildWorkflowOptions?)" />
+        /// +
+        /// <see cref="ChildWorkflowHandle.GetResultAsync" />.
+        /// </summary>
+        /// <param name="workflow">Workflow name to execute.</param>
+        /// <param name="args">Workflow arguments.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>Task for workflow completion.</returns>
+        public static async Task ExecuteChildWorkflowAsync(
+            string workflow, IReadOnlyCollection<object?> args, ChildWorkflowOptions? options = null)
+        {
+            var handle = await StartChildWorkflowAsync(
+                workflow, args, options).ConfigureAwait(true);
+            await handle.GetResultAsync().ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Shortcut for
+        /// <see cref="StartChildWorkflowAsync{TResult}(string, IReadOnlyCollection{object?}, ChildWorkflowOptions?)" />
+        /// +
+        /// <see cref="ChildWorkflowHandle{TResult}.GetResultAsync" />.
+        /// </summary>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="workflow">Workflow name to execute.</param>
+        /// <param name="args">Workflow arguments.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>Task for workflow completion.</returns>
+        public static async Task<TResult> ExecuteChildWorkflowAsync<TResult>(
+            string workflow, IReadOnlyCollection<object?> args, ChildWorkflowOptions? options = null)
+        {
+            var handle = await StartChildWorkflowAsync<TResult>(
+                workflow, args, options).ConfigureAwait(true);
+            return await handle.GetResultAsync().ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Execute a local activity with a result and no arguments.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteLocalActivityAsync<TResult>(
+            Func<TResult> activity, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync<TResult>(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Execute a local activity with a result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Activity argument type.</typeparam>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="arg">Activity argument.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteLocalActivityAsync<T, TResult>(
+            Func<T, TResult> activity, T arg, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync<TResult>(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Execute a local activity with no result and no arguments.
+        /// </summary>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteLocalActivityAsync(
+            Action activity, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Execute a local activity with no result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Activity argument type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="arg">Activity argument.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteLocalActivityAsync<T>(
+            Action<T> activity, T arg, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Execute a local activity with a result and no arguments.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteLocalActivityAsync<TResult>(
+            Func<Task<TResult>> activity, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync<TResult>(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Execute a local activity with a result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Activity argument type.</typeparam>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="arg">Activity argument.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteLocalActivityAsync<T, TResult>(
+            Func<T, Task<TResult>> activity, T arg, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync<TResult>(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Execute a local activity with no result and no arguments.
+        /// </summary>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteLocalActivityAsync(
+            Func<Task> activity, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Execute a local activity with no result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Activity argument type.</typeparam>
+        /// <param name="activity">Activity to execute.</param>
+        /// <param name="arg">Activity argument.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteLocalActivityAsync<T>(
+            Func<T, Task> activity, T arg, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync(
+                Activities.ActivityDefinition.FromDelegate(activity).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Execute a local activity by name with no result and any number of arguments.
+        /// </summary>
+        /// <param name="activity">Activity name to execute.</param>
+        /// <param name="args">Activity arguments.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task ExecuteLocalActivityAsync(
+            string activity, IReadOnlyCollection<object?> args, LocalActivityOptions options) =>
+            ExecuteLocalActivityAsync<ValueTuple>(activity, args, options);
+
+        /// <summary>
+        /// Execute a local activity by name with a result and any number of arguments.
+        /// </summary>
+        /// <typeparam name="TResult">Activity result type.</typeparam>
+        /// <param name="activity">Activity name to execute.</param>
+        /// <param name="args">Activity arguments.</param>
+        /// <param name="options">Activity options. This is required and either
+        /// <see cref="ActivityOptions.ScheduleToCloseTimeout" /> or
+        /// <see cref="ActivityOptions.StartToCloseTimeout" /> must be set.</param>
+        /// <returns>Task for completion with result.</returns>
+        /// <remarks>
+        /// The task will throw an <see cref="Exceptions.ActivityFailureException" /> on activity
+        /// failure.
+        /// </remarks>
+        public static Task<TResult> ExecuteLocalActivityAsync<TResult>(
+            string activity, IReadOnlyCollection<object?> args, LocalActivityOptions options) =>
+            Context.ExecuteLocalActivityAsync<TResult>(activity, args, options);
+
+        /// <summary>
+        /// Deterministically create a new <see cref="Guid" /> similar to
+        /// <see cref="Guid.NewGuid" /> (which cannot be used in workflows). The resulting GUID
+        /// intentionally represents a version 4 UUID.
+        /// </summary>
+        /// <returns>A new GUID.</returns>
+        public static Guid NewGuid()
+        {
+            var bytes = new byte[16];
+#pragma warning disable CA5394 // We intentionally are not wanting strong random
+            Random.NextBytes(bytes);
+#pragma warning restore CA5394
+            // Make it look like UUIDv4
+            bytes[7] = (byte)((bytes[7] & 0x0F) | 0x40);
+            bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
+            return new(bytes);
+        }
+
+        /// <summary>
+        /// Start a child workflow with a result and no arguments.
+        /// </summary>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="workflow">Workflow to execute.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>The child workflow handle once started.</returns>
+        /// <remarks>
+        /// The task can throw a <see cref="Exceptions.WorkflowAlreadyStartedException" /> if an ID
+        /// is given in the options but it is already running.
+        /// </remarks>
+        public static Task<ChildWorkflowHandle<TResult>> StartChildWorkflowAsync<TResult>(
+            Func<Task<TResult>> workflow, ChildWorkflowOptions? options = null) =>
+            StartChildWorkflowAsync<TResult>(
+                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Start a child workflow with a result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Workflow argument type.</typeparam>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="workflow">Workflow to execute.</param>
+        /// <param name="arg">Workflow argument.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>The child workflow handle once started.</returns>
+        /// <remarks>
+        /// The task can throw a <see cref="Exceptions.WorkflowAlreadyStartedException" /> if an ID
+        /// is given in the options but it is already running.
+        /// </remarks>
+        public static Task<ChildWorkflowHandle<TResult>> StartChildWorkflowAsync<T, TResult>(
+            Func<T, Task<TResult>> workflow, T arg, ChildWorkflowOptions? options = null) =>
+            StartChildWorkflowAsync<TResult>(
+                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Start a child workflow with no result and no arguments.
+        /// </summary>
+        /// <param name="workflow">Workflow to execute.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>The child workflow handle once started.</returns>
+        /// <remarks>
+        /// The task can throw a <see cref="Exceptions.WorkflowAlreadyStartedException" /> if an ID
+        /// is given in the options but it is already running.
+        /// </remarks>
+        public static Task<ChildWorkflowHandle> StartChildWorkflowAsync(
+            Func<Task> workflow, ChildWorkflowOptions? options = null) =>
+            StartChildWorkflowAsync(
+                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
+                Array.Empty<object?>(),
+                options);
+
+        /// <summary>
+        /// Start a child workflow with no result and one argument.
+        /// </summary>
+        /// <typeparam name="T">Workflow argument type.</typeparam>
+        /// <param name="workflow">Workflow to execute.</param>
+        /// <param name="arg">Workflow argument.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>The child workflow handle once started.</returns>
+        /// <remarks>
+        /// The task can throw a <see cref="Exceptions.WorkflowAlreadyStartedException" /> if an ID
+        /// is given in the options but it is already running.
+        /// </remarks>
+        public static Task<ChildWorkflowHandle> StartChildWorkflowAsync<T>(
+            Func<T, Task> workflow, T arg, ChildWorkflowOptions? options = null) =>
+            StartChildWorkflowAsync(
+                WorkflowDefinition.FromRunMethod(workflow.Method).Name,
+                new object?[] { arg },
+                options);
+
+        /// <summary>
+        /// Start a child workflow by name with no result and any number of argument.
+        /// </summary>
+        /// <param name="workflow">Workflow name to execute.</param>
+        /// <param name="args">Workflow arguments.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>The child workflow handle once started.</returns>
+        /// <remarks>
+        /// The task can throw a <see cref="Exceptions.WorkflowAlreadyStartedException" /> if an ID
+        /// is given in the options but it is already running.
+        /// </remarks>
+        public static async Task<ChildWorkflowHandle> StartChildWorkflowAsync(
+            string workflow, IReadOnlyCollection<object?> args, ChildWorkflowOptions? options = null) =>
+            await StartChildWorkflowAsync<ValueTuple>(workflow, args, options).ConfigureAwait(true);
+
+        /// <summary>
+        /// Start a child workflow by name with a result and any number of arguments.
+        /// </summary>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="workflow">Workflow name to execute.</param>
+        /// <param name="args">Workflow arguments.</param>
+        /// <param name="options">Workflow options.</param>
+        /// <returns>The child workflow handle once started.</returns>
+        /// <remarks>
+        /// The task can throw a <see cref="Exceptions.WorkflowAlreadyStartedException" /> if an ID
+        /// is given in the options but it is already running.
+        /// </remarks>
+        public static Task<ChildWorkflowHandle<TResult>> StartChildWorkflowAsync<TResult>(
+            string workflow, IReadOnlyCollection<object?> args, ChildWorkflowOptions? options = null) =>
+            Context.StartChildWorkflowAsync<TResult>(workflow, args, options ?? new());
 
         /// <summary>
         /// Issue updates to the workflow memo.

--- a/tests/Temporalio.Tests/TestBase.cs
+++ b/tests/Temporalio.Tests/TestBase.cs
@@ -13,8 +13,9 @@ public abstract class TestBase : IDisposable
         if (Program.InProc)
         {
             LoggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
-                builder.AddSimpleConsole().SetMinimumLevel(
-                    Program.Verbose ? LogLevel.Trace : LogLevel.Information));
+                builder.
+                    AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+                    SetMinimumLevel(Program.Verbose ? LogLevel.Trace : LogLevel.Information));
         }
         else
         {


### PR DESCRIPTION
## What was changed

* Activities and local activities
* Child workflows (with the exception of sending signals to them atm)
* Continue as new support w/ type safety
* Doc fixes to include defaults
* Code fixes to use expression bodied members where possible
* Other minor changes:
  * `Workflow.NewGuid()`
  * workflow-not-registered tests
  * Renamed `Temporalio.Client.WorkflowStartOptions` to `Temporalio.Client.WorkflowOptions`

Please do a full review regardless of CI state (known Windows bug in dotnet format that MS is fixing)