### PR TITLE
Support setting metadata (i.e. headers) on connection

### DIFF
--- a/src/Temporalio/Bridge/Client.cs
+++ b/src/Temporalio/Bridge/Client.cs
@@ -70,6 +70,21 @@ namespace Temporalio.Bridge
         }
 
         /// <summary>
+        /// Update client metadata (i.e. headers).
+        /// </summary>
+        /// <param name="metadata">Metadata to set.</param>
+        public void UpdateMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
+        {
+            using (var scope = new Scope())
+            {
+                unsafe
+                {
+                    Interop.Methods.client_update_metadata(Ptr, scope.Metadata(metadata));
+                }
+            }
+        }
+
+        /// <summary>
         /// Make RPC call to Temporal.
         /// </summary>
         /// <typeparam name="T">Return proto type.</typeparam>

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -371,6 +371,9 @@ namespace Temporalio.Bridge.Interop
         public static extern void client_free([NativeTypeName("struct Client *")] Client* client);
 
         [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void client_update_metadata([NativeTypeName("struct Client *")] Client* client, [NativeTypeName("struct ByteArrayRef")] ByteArrayRef metadata);
+
+        [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void client_rpc_call([NativeTypeName("struct Client *")] Client* client, [NativeTypeName("const struct RpcCallOptions *")] RpcCallOptions* options, void* user_data, [NativeTypeName("ClientRpcCallCallback")] IntPtr callback);
 
         [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
+++ b/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
@@ -262,6 +262,8 @@ void client_connect(struct Runtime *runtime,
 
 void client_free(struct Client *client);
 
+void client_update_metadata(struct Client *client, struct ByteArrayRef metadata);
+
 /**
  * Client, options, and user data must live through callback.
  */

--- a/src/Temporalio/Bridge/src/client.rs
+++ b/src/Temporalio/Bridge/src/client.rs
@@ -138,6 +138,12 @@ pub extern "C" fn client_free(client: *mut Client) {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn client_update_metadata(client: *mut Client, metadata: ByteArrayRef) {
+    let client = unsafe { &*client };
+    client.core.get_client().set_headers(metadata.to_string_map_on_newlines());
+}
+
 #[repr(C)]
 pub struct RpcCallOptions {
     service: RpcService,

--- a/src/Temporalio/Client/ITemporalConnection.cs
+++ b/src/Temporalio/Client/ITemporalConnection.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Temporalio.Client
@@ -8,6 +9,13 @@ namespace Temporalio.Client
     /// <seealso cref="TemporalConnection" />
     public interface ITemporalConnection : IBridgeClientProvider
     {
+        /// <summary>
+        /// Gets or sets the current RPC metadata (i.e. the headers). This can be updated which will
+        /// apply to all future calls the client makes including inside a worker. Setting this value
+        /// is thread safe.
+        /// </summary>
+        IReadOnlyCollection<KeyValuePair<string, string>> RpcMetadata { get; set; }
+
         /// <summary>
         /// Gets the raw workflow service.
         /// </summary>
@@ -22,7 +30,7 @@ namespace Temporalio.Client
         /// Gets the raw gRPC test service.
         /// </summary>
         /// <remarks>
-        /// Only the <see cref="Temporalio.Testing.WorkflowEnvironment.StartTimeSkippingAsync" />
+        /// Only the <see cref="Testing.WorkflowEnvironment.StartTimeSkippingAsync" />
         /// environment has this service implemented.
         /// </remarks>
         public TestService TestService { get; }

--- a/src/Temporalio/Client/RpcOptions.cs
+++ b/src/Temporalio/Client/RpcOptions.cs
@@ -24,7 +24,7 @@ namespace Temporalio.Client
         /// Newlines are not allowed in keys or values. Keys here will override any connection-level
         /// metadata values for the same keys.
         /// </remarks>
-        public IEnumerable<KeyValuePair<string, string>>? Metadata { get; set; }
+        public IReadOnlyCollection<KeyValuePair<string, string>>? Metadata { get; set; }
 
         /// <summary>
         /// Gets or sets the timeout for the call. Default is no timeout.

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -54,8 +54,12 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).
         /// </summary>
+        /// <remarks>
+        /// Note, this is only the initial value, updates will not be applied. Use
+        /// <see cref="ITemporalConnection.RpcMetadata" /> property setter to update.
+        /// </remarks>
         /// <seealso cref="RpcOptions.Metadata" />
-        public IEnumerable<KeyValuePair<string, string>>? RpcMetadata { get; set; }
+        public IReadOnlyCollection<KeyValuePair<string, string>>? RpcMetadata { get; set; }
 
         /// <summary>
         /// Gets or sets the identity for this connection.

--- a/tests/Temporalio.Tests/Client/TemporalClientTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientTests.cs
@@ -18,5 +18,13 @@ public class TemporalClientTests : WorkflowEnvironmentTestBase
         // Just confirm the response has a version and capabilities
         Assert.NotEmpty(resp.ServerVersion);
         Assert.NotNull(resp.Capabilities);
+
+        // Update some headers and call again
+        // TODO(cretz): Find way to confirm this works without running our own gRPC server
+        Client.Connection.RpcMetadata = new Dictionary<string, string> { ["header"] = "value" };
+        resp = await Client.Connection.WorkflowService.GetSystemInfoAsync(
+            new Api.WorkflowService.V1.GetSystemInfoRequest());
+        Assert.NotEmpty(resp.ServerVersion);
+        Assert.NotNull(resp.Capabilities);
     }
 }


### PR DESCRIPTION
## What was changed

Added property on connection for metadata so it can be set after creation

## Checklist

1. Closes #70