### PR TITLE
Return collection instead of enumerable and fix/re-enable task scheduler check (💥 BREAKING CHANGES)

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,10 +689,15 @@ with .NET tasks inside of workflows:
 * Do not use `Task.Delay`, `Task.Wait`, timeout-based `CancellationTokenSource`, or anything that uses .NET built-in
   timers.
   * `Workflow.DelayAsync`, `Workflow.WaitConditionAsync`, or non-timeout-based cancellation token source is suggested.
+* Do not use `Task.WhenAny`.
+  * Use `Workflow.WhenAnyAsync` instead.
+  * Technically this only applies to an enumerable set of tasks with results or more than 2 tasks with results. Other
+    uses are safe. See [this issue](https://github.com/dotnet/runtime/issues/87481).
 * Be wary of additional libraries' implicit use of the default scheduler.
   * For example, while there are articles for `Dataflow` about
-    [using a specific scheduler](https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-specify-a-task-scheduler-in-a-dataflow-block), there are hidden implicit uses of `TaskScheduler.Default`. For
-    example, see [this bug](https://github.com/dotnet/runtime/issues/83159).
+    [using a specific scheduler](https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-specify-a-task-scheduler-in-a-dataflow-block),
+    there are hidden implicit uses of `TaskScheduler.Default`. For example, see
+    [this bug](https://github.com/dotnet/runtime/issues/83159).
 
 In order to help catch wrong scheduler use, by default the Temporal .NET SDK adds an event source listener for
 info-level task events. While this technically receives events from all uses of tasks in the process, we make sure to

--- a/src/Temporalio/Client/Schedules/ScheduleRange.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleRange.cs
@@ -43,8 +43,8 @@ namespace Temporalio.Client.Schedules
         /// </summary>
         /// <param name="ranges">Ranges to convert.</param>
         /// <returns>Protos.</returns>
-        internal static IEnumerable<Api.Schedule.V1.Range> ToProtos(
-            IEnumerable<ScheduleRange> ranges) => ranges.Select(r => r.ToProto());
+        internal static IReadOnlyCollection<Api.Schedule.V1.Range> ToProtos(
+            IEnumerable<ScheduleRange> ranges) => ranges.Select(r => r.ToProto()).ToList();
 
         /// <summary>
         /// Convert to proto.

--- a/src/Temporalio/Common/SearchAttributeCollection.cs
+++ b/src/Temporalio/Common/SearchAttributeCollection.cs
@@ -20,7 +20,7 @@ namespace Temporalio.Common
     /// be mutated during workflow run so it is not strictly immutable. From a client perspective,
     /// this collection is immutable.
     /// </remarks>
-    public class SearchAttributeCollection : IEnumerable<SearchAttributeKey>
+    public class SearchAttributeCollection : IReadOnlyCollection<SearchAttributeKey>
     {
         /// <summary>
         /// An empty search attribute collection.

--- a/src/Temporalio/Converters/ConverterExtensions.cs
+++ b/src/Temporalio/Converters/ConverterExtensions.cs
@@ -18,7 +18,7 @@ namespace Temporalio.Converters
         /// <param name="converter">Converter to use.</param>
         /// <param name="values">Values to convert and encode.</param>
         /// <returns>Converted and encoded payloads.</returns>
-        public static async Task<IEnumerable<Payload>> ToPayloadsAsync(
+        public static async Task<IReadOnlyCollection<Payload>> ToPayloadsAsync(
             this DataConverter converter, IReadOnlyCollection<object?> values)
         {
             // Convert then encode
@@ -29,7 +29,7 @@ namespace Temporalio.Converters
                 payloads = await converter.PayloadCodec.EncodeAsync(
                     payloads.ToList()).ConfigureAwait(false);
             }
-            return payloads;
+            return payloads.ToList();
         }
 
         /// <summary>
@@ -160,9 +160,9 @@ namespace Temporalio.Converters
         /// <param name="converter">Converter to use.</param>
         /// <param name="values">Values to convert.</param>
         /// <returns>Converted values.</returns>
-        public static IEnumerable<Payload> ToPayloads(
+        public static IReadOnlyCollection<Payload> ToPayloads(
             this IPayloadConverter converter, IReadOnlyCollection<object?> values) =>
-            values.Select(converter.ToPayload);
+            values.Select(converter.ToPayload).ToList();
 
         /// <summary>
         /// Convert the given payload to a value of the given type.

--- a/src/Temporalio/Converters/IPayloadCodec.cs
+++ b/src/Temporalio/Converters/IPayloadCodec.cs
@@ -19,7 +19,7 @@ namespace Temporalio.Converters
         /// <returns>
         /// Encoded payloads. This must have at least one value and cannot have more than was given.
         /// </returns>
-        Task<IEnumerable<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads);
+        Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads);
 
         /// <summary>
         /// Decode the given collection of payloads.
@@ -29,6 +29,6 @@ namespace Temporalio.Converters
         /// Decoded payloads. This must return the exact same number that was given to
         /// <see cref="EncodeAsync" />.
         /// </returns>
-        Task<IEnumerable<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads);
+        Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads);
     }
 }

--- a/src/Temporalio/Converters/PayloadCodecExtensions.cs
+++ b/src/Temporalio/Converters/PayloadCodecExtensions.cs
@@ -56,7 +56,7 @@ namespace Temporalio.Converters
 
         private static async Task ApplyToFailurePayloadAsync(
             Failure failure,
-            Func<IReadOnlyCollection<Payload>, Task<IEnumerable<Payload>>> func)
+            Func<IReadOnlyCollection<Payload>, Task<IReadOnlyCollection<Payload>>> func)
         {
             if (failure.EncodedAttributes != null)
             {
@@ -91,7 +91,7 @@ namespace Temporalio.Converters
 
         private static async Task ApplyPayloadsAsync(
             Payloads payloads,
-            Func<IReadOnlyCollection<Payload>, Task<IEnumerable<Payload>>> func)
+            Func<IReadOnlyCollection<Payload>, Task<IReadOnlyCollection<Payload>>> func)
         {
             if (payloads != null && payloads.Payloads_.Count > 0)
             {

--- a/src/Temporalio/Runtime/OpenTelemetryOptions.cs
+++ b/src/Temporalio/Runtime/OpenTelemetryOptions.cs
@@ -39,7 +39,7 @@ namespace Temporalio.Runtime
         /// <summary>
         /// Gets or sets the headers to include in OpenTelemetry calls.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>>? Headers { get; set; }
+        public IReadOnlyCollection<KeyValuePair<string, string>>? Headers { get; set; }
 
         /// <summary>
         /// Gets or sets how frequently in metrics should be exported.

--- a/src/Temporalio/Testing/TemporaliteOptions.cs
+++ b/src/Temporalio/Testing/TemporaliteOptions.cs
@@ -49,7 +49,7 @@ namespace Temporalio.Testing
         /// <remarks>
         /// Newlines are not allowed in values.
         /// </remarks>
-        public IEnumerable<string>? ExtraArgs { get; set; }
+        public IReadOnlyCollection<string>? ExtraArgs { get; set; }
 
         /// <summary>
         /// Create a shallow copy of these options.

--- a/src/Temporalio/Testing/TestServerOptions.cs
+++ b/src/Temporalio/Testing/TestServerOptions.cs
@@ -32,7 +32,7 @@ namespace Temporalio.Testing
         /// <remarks>
         /// Newlines are not allowed in values.
         /// </remarks>
-        public IEnumerable<string>? ExtraArgs { get; set; }
+        public IReadOnlyCollection<string>? ExtraArgs { get; set; }
 
         /// <summary>
         /// Create a shallow copy of these options.

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -45,16 +45,17 @@ namespace Temporalio.Worker
 
             // Interceptors are the client interceptors that implement IWorkerInterceptor followed
             // by the explicitly provided ones in options.
-            Interceptors = Client.Options.Interceptors?.OfType<IWorkerInterceptor>() ??
+            var interceptors = Client.Options.Interceptors?.OfType<IWorkerInterceptor>() ??
                 Enumerable.Empty<IWorkerInterceptor>();
             if (Options.Interceptors != null)
             {
-                Interceptors = Interceptors.Concat(Options.Interceptors);
+                interceptors = interceptors.Concat(Options.Interceptors);
             }
+            Interceptors = interceptors.ToList();
 
             // Enable workflow task tracing if needed
             workflowTracingEventListenerEnabled =
-                !options.DisableWorkflowTracingEventListener && workflowWorker != null;
+                !options.DisableWorkflowTracingEventListener && options.Workflows.Count > 0;
             if (workflowTracingEventListenerEnabled)
             {
                 WorkflowTracingEventListener.Instance.Register();
@@ -108,7 +109,7 @@ namespace Temporalio.Worker
         /// <summary>
         /// Gets the set of interceptors in the order they should be applied.
         /// </summary>
-        internal IEnumerable<IWorkerInterceptor> Interceptors { get; private init; }
+        internal IReadOnlyCollection<IWorkerInterceptor> Interceptors { get; private init; }
 
         /// <summary>
         /// Gets the logger factory.

--- a/src/Temporalio/Worker/WorkflowInstanceDetails.cs
+++ b/src/Temporalio/Worker/WorkflowInstanceDetails.cs
@@ -29,7 +29,7 @@ namespace Temporalio.Worker
         WorkflowDefinition Definition,
         WorkflowActivation InitialActivation,
         StartWorkflow Start,
-        IEnumerable<Interceptors.IWorkerInterceptor> Interceptors,
+        IReadOnlyCollection<Interceptors.IWorkerInterceptor> Interceptors,
         IPayloadConverter PayloadConverter,
         IFailureConverter FailureConverter,
         ILoggerFactory LoggerFactory,

--- a/src/Temporalio/Worker/WorkflowWorkerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowWorkerOptions.cs
@@ -11,7 +11,7 @@ namespace Temporalio.Worker
         string TaskQueue,
         IList<WorkflowDefinition> Workflows,
         Converters.DataConverter DataConverter,
-        IEnumerable<Interceptors.IWorkerInterceptor> Interceptors,
+        IReadOnlyCollection<Interceptors.IWorkerInterceptor> Interceptors,
         ILoggerFactory LoggerFactory,
         Func<WorkflowInstanceDetails, IWorkflowInstance> WorkflowInstanceFactory,
         bool DebugMode,

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -918,6 +918,52 @@ namespace Temporalio.Workflows
                 Context.WaitConditionAsync(conditionCheck, timeout, cancellationToken);
 
         /// <summary>
+        /// Workflow-safe form of <see cref="Task.WhenAny(Task[])" />.
+        /// </summary>
+        /// <param name="tasks">Tasks to wait for first completed of.</param>
+        /// <returns>First completed task.</returns>
+        public static Task<Task> WhenAnyAsync(params Task[] tasks) =>
+            // This uses our scheduler properly
+            Task.WhenAny(tasks);
+
+        /// <summary>
+        /// Workflow-safe form of <see cref="Task.WhenAny(IEnumerable{Task})" />.
+        /// </summary>
+        /// <param name="tasks">Tasks to wait for first completed of.</param>
+        /// <returns>First completed task.</returns>
+        public static Task<Task> WhenAnyAsync(IEnumerable<Task> tasks) =>
+            // This uses our scheduler properly
+            Task.WhenAny(tasks);
+
+        /// <summary>
+        /// Workflow-safe form of <see cref="Task.WhenAny{TResult}(Task{TResult}[])" />.
+        /// </summary>
+        /// <typeparam name="TResult">Result type.</typeparam>
+        /// <param name="tasks">Tasks to wait for first completed of.</param>
+        /// <returns>First completed task.</returns>
+        public static async Task<Task<TResult>> WhenAnyAsync<TResult>(params Task<TResult>[] tasks)
+        {
+            // The .NET one does not use the scheduler properly, so we do the non-generic one and
+            // convert back
+            var task = await Task.WhenAny((Task[])tasks).ConfigureAwait(true);
+            return (Task<TResult>)task;
+        }
+
+        /// <summary>
+        /// Workflow-safe form of <see cref="Task.WhenAny{TResult}(IEnumerable{Task{TResult}})" />.
+        /// </summary>
+        /// <typeparam name="TResult">Result type.</typeparam>
+        /// <param name="tasks">Tasks to wait for first completed of.</param>
+        /// <returns>First completed task.</returns>
+        public static async Task<Task<TResult>> WhenAnyAsync<TResult>(IEnumerable<Task<TResult>> tasks)
+        {
+            // The .NET one does not use the scheduler properly, so we do the non-generic one and
+            // convert back
+            var task = await Task.WhenAny((IEnumerable<Task>)tasks).ConfigureAwait(true);
+            return (Task<TResult>)task;
+        }
+
+        /// <summary>
         /// Unsafe calls that can be made in a workflow.
         /// </summary>
         public static class Unsafe

--- a/tests/Temporalio.Tests/AssertMore.cs
+++ b/tests/Temporalio.Tests/AssertMore.cs
@@ -9,7 +9,13 @@ namespace Temporalio.Tests
         public static Task EventuallyAsync(
             Func<Task> func, TimeSpan? interval = null, int iterations = 15) =>
             EventuallyAsync(
-                () => func().ContinueWith(_ => ValueTuple.Create()), interval, iterations);
+                async () =>
+                {
+                    await func();
+                    return ValueTuple.Create();
+                },
+                interval,
+                iterations);
 
         public static async Task<T> EventuallyAsync<T>(
             Func<Task<T>> func, TimeSpan? interval = null, int iterations = 15)

--- a/tests/Temporalio.Tests/Converters/Base64PayloadCodec.cs
+++ b/tests/Temporalio.Tests/Converters/Base64PayloadCodec.cs
@@ -13,8 +13,8 @@ public class Base64PayloadCodec : IPayloadCodec
 {
     public const string EncodingName = "my-encoding";
 
-    public Task<IEnumerable<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
-        Task.FromResult<IEnumerable<Payload>>(payloads.Select(p =>
+    public Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
+        Task.FromResult<IReadOnlyCollection<Payload>>(payloads.Select(p =>
             new Payload()
             {
                 Data = ByteString.CopyFrom(
@@ -29,9 +29,9 @@ public class Base64PayloadCodec : IPayloadCodec
                 },
             }).ToList());
 
-    public Task<IEnumerable<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads)
+    public Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads)
     {
-        return Task.FromResult<IEnumerable<Payload>>(payloads.Select(p =>
+        return Task.FromResult<IReadOnlyCollection<Payload>>(payloads.Select(p =>
         {
             Assert.Equal(EncodingName, p.Metadata["encoding"].ToStringUtf8());
             return Payload.Parser.ParseFrom(

--- a/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
@@ -207,12 +207,12 @@ public class KitchenSinkWorkflow
             }).ToList();
             tasks.AddRange(activityTasks);
             // Wait for any including cancel
-            await Task.WhenAny(tasks);
+            await Workflow.WhenAnyAsync(tasks);
             // Wait for every activity, return last result
             object? lastResult = null;
             while (activityTasks.Count > 0)
             {
-                var task = await Task.WhenAny(activityTasks);
+                var task = await Workflow.WhenAnyAsync(activityTasks);
                 activityTasks.Remove(task);
                 lastResult = await task;
             }

--- a/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
@@ -153,20 +153,20 @@ public class WorkflowCodecHelperTests : TestBase
 
     private class MarkerPayloadCodec : IPayloadCodec
     {
-        public Task<IEnumerable<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
-            Task.FromResult(payloads.Select(p =>
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult<IReadOnlyCollection<Payload>>(payloads.Select(p =>
             {
                 var newP = p.Clone();
                 newP.Metadata["encoded"] = ByteString.Empty;
                 return newP;
-            }));
+            }).ToList());
 
-        public Task<IEnumerable<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads) =>
-            Task.FromResult(payloads.Select(p =>
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult<IReadOnlyCollection<Payload>>(payloads.Select(p =>
             {
                 var newP = p.Clone();
                 newP.Metadata["decoded"] = ByteString.Empty;
                 return newP;
-            }));
+            }).ToList());
     }
 }


### PR DESCRIPTION
## What was changed

* Change converter/codec/etc non-streaming `IEnumerable` return values to `IReadOnlyCollection`
  * Lazy enumerables for this case were confusing users and are against best practices
  * 💥 BREAKING CHANGE on some return types
* Fix issue that inadvertently disabled the task-on-workflow-scheduler checker (i.e. re-enable it)
  * 💥 BREAKING CHANGE on behavior because for the last couple of alphas this checker was inadvertently disabled
* Provided workaround for [`Task.WhenAny` sometimes using thread pool](https://github.com/dotnet/runtime/issues/87481)
  * Updated README and made `Workflow.WhenAnyAsync` that is workflow safe