### PR TITLE
Support query properties and disallow static signals/queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Attributes that can be applied:
   * The attribute can have a string argument for the signal name. Otherwise the name is defaulted to the unqualified
     method name with `Async` trimmed off the end if it is present.
   * This attribute is not inherited and therefore must be explicitly set on any override.
-* `[WorkflowQuery]` attribute may be present on any public method that handles queries.
+* `[WorkflowQuery]` attribute may be present on any public method or property with public getter that handles queries.
   * Query methods must be non-`void` but cannot return a `Task` (i.e. they cannot be async).
   * The attribute can have a string argument for the query name. Otherwise the name is defaulted to the unqualified
     method name.

--- a/src/Temporalio/Workflows/WorkflowDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowDefinition.cs
@@ -267,6 +267,27 @@ namespace Temporalio.Workflows
                 errs.Add($"{type} does not have a valid WorkflowRun method");
             }
 
+            // Get query attributes on properties
+            foreach (var property in type.GetProperties(bindingFlagsAny))
+            {
+                if (property.IsDefined(typeof(WorkflowQueryAttribute), false))
+                {
+                    try
+                    {
+                        var defn = WorkflowQueryDefinition.FromProperty(property);
+                        if (queries.ContainsKey(defn.Name))
+                        {
+                            errs.Add($"{type} has more than one query named {defn.Name}");
+                        }
+                        queries[defn.Name] = defn;
+                    }
+                    catch (ArgumentException e)
+                    {
+                        errs.Add(e.Message);
+                    }
+                }
+            }
+
             // If there are any errors, throw
             if (errs.Count > 0)
             {

--- a/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
@@ -10,7 +10,7 @@ namespace Temporalio.Workflows
     /// method must be a public, non-async, non-static method (i.e. cannot return a Task) and must
     /// return a non-void value.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
     public sealed class WorkflowQueryAttribute : Attribute
     {
         /// <summary>

--- a/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
@@ -7,8 +7,8 @@ namespace Temporalio.Workflows
     /// </summary>
     /// <remarks>
     /// This is not inherited, so if a method is overridden, it must also have this attribute. The
-    /// method must be a non-async method (i.e. cannot return a Task) and must return a non-void
-    /// value.
+    /// method must be a public, non-async, non-static method (i.e. cannot return a Task) and must
+    /// return a non-void value.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     public sealed class WorkflowQueryAttribute : Attribute

--- a/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
@@ -45,6 +45,10 @@ namespace Temporalio.Workflows
             {
                 throw new ArgumentException($"WorkflowQuery method {method} must be public");
             }
+            if (method.IsStatic)
+            {
+                throw new ArgumentException($"WorkflowQuery method {method} cannot be static");
+            }
             return Definitions.GetOrAdd(method, CreateFromMethod);
         }
 

--- a/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
@@ -10,7 +10,8 @@ namespace Temporalio.Workflows
     /// </summary>
     public class WorkflowQueryDefinition
     {
-        private static readonly ConcurrentDictionary<MethodInfo, WorkflowQueryDefinition> Definitions = new();
+        private static readonly ConcurrentDictionary<MethodInfo, WorkflowQueryDefinition> MethodDefinitions = new();
+        private static readonly ConcurrentDictionary<PropertyInfo, WorkflowQueryDefinition> PropertyDefinitions = new();
 
         private WorkflowQueryDefinition(string name, MethodInfo? method, Delegate? del)
         {
@@ -49,8 +50,30 @@ namespace Temporalio.Workflows
             {
                 throw new ArgumentException($"WorkflowQuery method {method} cannot be static");
             }
-            return Definitions.GetOrAdd(method, CreateFromMethod);
+            return MethodDefinitions.GetOrAdd(method, CreateFromMethod);
         }
+
+        /// <summary>
+        /// Get a query definition from a property getter or fail. The result is cached.
+        /// </summary>
+        /// <param name="property">Query property.</param>
+        /// <returns>Query definition.</returns>
+        public static WorkflowQueryDefinition FromProperty(PropertyInfo property) =>
+            PropertyDefinitions.GetOrAdd(property, _ =>
+            {
+                var attr = property.GetCustomAttribute<WorkflowQueryAttribute>(false) ??
+                    throw new ArgumentException($"{property} missing WorkflowQuery attribute");
+                var method = property.GetGetMethod();
+                if (method == null)
+                {
+                    throw new ArgumentException($"WorkflowQuery property {property} must have public getter");
+                }
+                else if (method.IsStatic)
+                {
+                    throw new ArgumentException($"WorkflowQuery property {property} cannot be static");
+                }
+                return new(attr.Name ?? property.Name, method, null);
+            });
 
         /// <summary>
         /// Creates a query definition from an explicit name and method. Most users should use

--- a/src/Temporalio/Workflows/WorkflowRunAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowRunAttribute.cs
@@ -8,8 +8,8 @@ namespace Temporalio.Workflows
     /// <remarks>
     /// All workflows must have a single method with this attribute. The method must be declared on
     /// the workflow class with this attribute even if it just delegates to a base class. The method
-    /// must return a task. It is encouraged to use a single parameter record and a return type
-    /// record so that fields can be added to either in a future-proof way.
+    /// must be public and return a task. It is encouraged to use a single parameter record and a
+    /// return type record so that fields can be added to either in a future-proof way.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     public sealed class WorkflowRunAttribute : Attribute

--- a/src/Temporalio/Workflows/WorkflowSignalAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowSignalAttribute.cs
@@ -7,7 +7,7 @@ namespace Temporalio.Workflows
     /// </summary>
     /// <remarks>
     /// This is not inherited, so if a method is overridden, it must also have this attribute. The
-    /// method must return a task (not a task with a type embedded).
+    /// method must be a public non-static and return a task (not a task with a type embedded).
     /// </remarks>
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     public sealed class WorkflowSignalAttribute : Attribute

--- a/src/Temporalio/Workflows/WorkflowSignalDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowSignalDefinition.cs
@@ -45,6 +45,10 @@ namespace Temporalio.Workflows
             {
                 throw new ArgumentException($"WorkflowSignal method {method} must be public");
             }
+            if (method.IsStatic)
+            {
+                throw new ArgumentException($"WorkflowSignal method {method} cannot be static");
+            }
             return Definitions.GetOrAdd(method, CreateFromMethod);
         }
 

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -881,6 +881,12 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         [WorkflowQuery("custom-name")]
         public string QueryCustom(string arg) => $"QueryCustom: {arg}";
 
+        [WorkflowQuery]
+        public string QueryProperty => "QueryProperty";
+
+        [WorkflowQuery]
+        public string QueryNoArg() => "QueryNoArg";
+
         [WorkflowSignal]
         public async Task AddQueryHandlerAsync(string name) =>
             Workflow.Queries[name] = WorkflowQueryDefinition.CreateWithoutAttribute(
@@ -913,11 +919,14 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             Assert.Equal(
                 "QueryCustom: bar",
                 await handle.QueryAsync(wf => wf.QueryCustom("bar")));
+            Assert.Equal(
+                "QueryProperty",
+                await handle.QueryAsync(wf => wf.QueryProperty));
             // Non-existent query
             var exc = await Assert.ThrowsAsync<WorkflowQueryFailedException>(
                 () => handle.QueryAsync<string>("some-query", new[] { "some-arg" }));
             Assert.Contains(
-                "known queries: [custom-name QueryFail QueryMakingCommands QuerySimple]",
+                "known queries: [custom-name QueryFail QueryMakingCommands QueryNoArg QueryProperty QuerySimple]",
                 exc.Message);
             // Add that non-existent query then try again
             await handle.SignalAsync(wf => wf.AddQueryHandlerAsync("some-query"));
@@ -932,6 +941,34 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             var exc3 = await Assert.ThrowsAsync<WorkflowQueryFailedException>(
                 () => handle.QueryAsync(wf => wf.QueryMakingCommands()));
             Assert.Contains("created workflow commands", exc3.Message);
+            // Access method as property
+            var exc4 = await Assert.ThrowsAsync<ArgumentException>(
+                () => handle.QueryAsync<Func<string>>(wf => wf.QueryNoArg));
+            Assert.Contains("must be a single method call or property access", exc4.Message);
+        });
+    }
+
+    [Workflow]
+    public class PropertyWorkflow
+    {
+        [WorkflowRun]
+        public async Task RunAsync(string value) => Value = value;
+
+        [WorkflowQuery]
+        public string Value { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_Properties_ProperlySupported()
+    {
+        await ExecuteWorkerAsync<PropertyWorkflow>(async worker =>
+        {
+            // Run the workflow
+            var handle = await Env.Client.StartWorkflowAsync(
+                (PropertyWorkflow wf) => wf.RunAsync("some string"),
+                new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+            await handle.GetResultAsync();
+            Assert.Equal("some string", await handle.QueryAsync(wf => wf.Value));
         });
     }
 

--- a/tests/Temporalio.Tests/Workflows/WorkflowAttributeTests.cs
+++ b/tests/Temporalio.Tests/Workflows/WorkflowAttributeTests.cs
@@ -172,6 +172,18 @@ public class WorkflowAttributeTests
     }
 
     [Fact]
+    public void Create_QueryAttributeOnStaticProperty_Throws()
+    {
+        AssertBad<Bad.Wf1>("StaticQueryProp cannot be static");
+    }
+
+    [Fact]
+    public void Create_QueryAttributeOnProtectedProperty_Throws()
+    {
+        AssertBad<Bad.Wf1>("ProtectedQueryProp must have public getter");
+    }
+
+    [Fact]
     public void Create_Generics_Throws()
     {
         // We disallow generics because it is too complicated to handle at this time
@@ -281,6 +293,12 @@ public class WorkflowAttributeTests
             {
             }
 
+            [WorkflowQuery]
+            public static string? StaticQueryProp { get; }
+
+            [WorkflowQuery]
+            protected string? ProtectedQueryProp { get; }
+
             [WorkflowSignal]
             public static Task SomeStaticSignalAsync() => Task.CompletedTask;
 
@@ -351,6 +369,9 @@ public class WorkflowAttributeTests
         [Workflow]
         public interface IWf1
         {
+            [WorkflowQuery]
+            string SomeQueryProp { get; }
+
             [WorkflowRun]
             Task RunAsync();
 
@@ -389,6 +410,9 @@ public class WorkflowAttributeTests
             public Wf2(string param1, int param2 = 5)
             {
             }
+
+            [WorkflowQuery]
+            public string? SomeQueryProp { get; }
 
             [WorkflowRun]
             public override Task RunAsync(string param1, int param2 = 5) => Task.CompletedTask;

--- a/tests/Temporalio.Tests/Workflows/WorkflowAttributeTests.cs
+++ b/tests/Temporalio.Tests/Workflows/WorkflowAttributeTests.cs
@@ -99,6 +99,12 @@ public class WorkflowAttributeTests
     }
 
     [Fact]
+    public void Create_SignalAttributeOnStatic_Throws()
+    {
+        AssertBad<Bad.Wf1>("SomeStaticSignalAsync() cannot be static");
+    }
+
+    [Fact]
     public void Create_SignalAttributeOnMultiple_Throws()
     {
         AssertBad<Bad.IWf4>("has more than one signal named SomeSignal1");
@@ -139,6 +145,12 @@ public class WorkflowAttributeTests
     public void Create_QueryAttributeOnNonPublic_Throws()
     {
         AssertBad<Bad.Wf1>("SomeQuery() must be public");
+    }
+
+    [Fact]
+    public void Create_QueryAttributeOnStatic_Throws()
+    {
+        AssertBad<Bad.Wf1>("SomeStaticQuery() cannot be static");
     }
 
     [Fact]
@@ -268,6 +280,12 @@ public class WorkflowAttributeTests
             public Wf1(string name)
             {
             }
+
+            [WorkflowSignal]
+            public static Task SomeStaticSignalAsync() => Task.CompletedTask;
+
+            [WorkflowQuery]
+            public static string SomeStaticQuery() => string.Empty;
 
             public override Task SomeVirtualSignalAsync() => Task.CompletedTask;
 


### PR DESCRIPTION
## What was changed

* Allow properties to be queries, flows very natural with .NET
* Disallow signals/queries as static (workflow run methods already can't be static)

## Checklist

1. Closes #85
2. Closes #86
