### PR TITLE
Dynamic workflows, activities, signals, and queries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,10 @@
     <Authors>Temporal</Authors>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <!--
+    TODO(cretz): Reenable when https://github.com/dotnet/format/issues/1800 fixed
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,10 +5,7 @@
     <Authors>Temporal</Authors>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <!--
-    TODO(cretz): Reenable when https://github.com/dotnet/format/issues/1800 fixed
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Temporalio/Activities/ActivityAttribute.cs
+++ b/src/Temporalio/Activities/ActivityAttribute.cs
@@ -32,5 +32,12 @@ namespace Temporalio.Activities
         /// name (with "Async" trimmed off the end if present and the return type is a task).
         /// </summary>
         public string? Name { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the activity is dynamic. If an activity is
+        /// dynamic, it cannot by given a name in this attribute and the method must accept a vararg
+        /// parameter array of <see cref="Converters.IRawValue" />.
+        /// </summary>
+        public bool Dynamic { get; set; }
     }
 }

--- a/src/Temporalio/Activities/ActivityAttribute.cs
+++ b/src/Temporalio/Activities/ActivityAttribute.cs
@@ -35,8 +35,8 @@ namespace Temporalio.Activities
 
         /// <summary>
         /// Gets or sets a value indicating whether the activity is dynamic. If an activity is
-        /// dynamic, it cannot by given a name in this attribute and the method must accept a vararg
-        /// parameter array of <see cref="Converters.IRawValue" />.
+        /// dynamic, it cannot by given a name in this attribute and the method must accept an array
+        /// of <see cref="Converters.IRawValue" />.
         /// </summary>
         public bool Dynamic { get; set; }
     }

--- a/src/Temporalio/Activities/ActivityDefinition.cs
+++ b/src/Temporalio/Activities/ActivityDefinition.cs
@@ -101,7 +101,7 @@ namespace Temporalio.Activities
                 parameterTypes.SingleOrDefault() != typeof(Converters.IRawValue[])))
             {
                 throw new ArgumentException(
-                    $"Dynamic activity must accept required vararg parameter array of IRawValue");
+                    $"Dynamic activity must accept a required array of IRawValue");
             }
 
             if (requiredParameterCount > parameterTypes.Count)
@@ -233,13 +233,6 @@ namespace Temporalio.Activities
             var attr = method.GetCustomAttribute<ActivityAttribute>(false) ??
                 throw new ArgumentException($"{method} missing Activity attribute");
             var parms = method.GetParameters();
-            // Check that param is vararg for dynamic (Create will check the arity)
-            if (attr.Dynamic &&
-                parms.SingleOrDefault()?.IsDefined(typeof(ParamArrayAttribute)) == false)
-            {
-                throw new ArgumentException(
-                    $"Dynamic activity must accept required vararg parameter array of IRawValue");
-            }
             return Create(
                 NameFromAttributed(method, attr),
                 method.ReturnType,

--- a/src/Temporalio/Activities/ActivityDefinition.cs
+++ b/src/Temporalio/Activities/ActivityDefinition.cs
@@ -18,7 +18,7 @@ namespace Temporalio.Activities
         private readonly Func<object?[], object?> invoker;
 
         private ActivityDefinition(
-            string name,
+            string? name,
             Type returnType,
             IReadOnlyCollection<Type> parameterTypes,
             int requiredParameterCount,
@@ -32,9 +32,9 @@ namespace Temporalio.Activities
         }
 
         /// <summary>
-        /// Gets the activity name.
+        /// Gets the activity name or null if workflow is dynamic.
         /// </summary>
-        public string Name { get; private init; }
+        public string? Name { get; private init; }
 
         /// <summary>
         /// Gets the return type for the definition. This may be a Task for async activities. This
@@ -53,6 +53,11 @@ namespace Temporalio.Activities
         /// Activity invocation will fail if fewer are given.
         /// </summary>
         public int RequiredParameterCount { get; private init; }
+
+        /// <summary>
+        /// Gets a value indicating whether the activity is dynamic.
+        /// </summary>
+        public bool Dynamic => Name == null;
 
         /// <summary>
         /// Create an activity definition from a delegate. <see cref="Delegate.DynamicInvoke" /> is
@@ -75,7 +80,7 @@ namespace Temporalio.Activities
         /// <summary>
         /// Create an activity definition manually from the given values.
         /// </summary>
-        /// <param name="name">Name to use for the activity.</param>
+        /// <param name="name">Name to use for the activity or null for dynamic.</param>
         /// <param name="returnType">Return type of the activity. This is currently unused.</param>
         /// <param name="parameterTypes">Parameter types for the invoker.</param>
         /// <param name="requiredParameterCount">Minimum number of parameters that must be provided
@@ -83,12 +88,22 @@ namespace Temporalio.Activities
         /// <param name="invoker">Function to call on activity invocation.</param>
         /// <returns>Definition built from the given pieces.</returns>
         public static ActivityDefinition Create(
-            string name,
+            string? name,
             Type returnType,
             IReadOnlyCollection<Type> parameterTypes,
             int requiredParameterCount,
             Func<object?[], object?> invoker)
         {
+            // If there is a null name, which means dynamic, there must only be one parameter type
+            // and it must be varargs IRawValue
+            if (name == null && (
+                requiredParameterCount != 1 ||
+                parameterTypes.SingleOrDefault() != typeof(Converters.IRawValue[])))
+            {
+                throw new ArgumentException(
+                    $"Dynamic activity must accept required vararg parameter array of IRawValue");
+            }
+
             if (requiredParameterCount > parameterTypes.Count)
             {
                 throw new ArgumentException(
@@ -154,21 +169,6 @@ namespace Temporalio.Activities
         }
 
         /// <summary>
-        /// Gets the activity name from the given ActivityAttribute method.
-        /// </summary>
-        /// <param name="method">Method to get name from.</param>
-        /// <returns>Name.</returns>
-        /// <exception cref="ArgumentException">
-        /// If method does not have ActivityAttribute.
-        /// </exception>
-        public static string NameFromMethod(MethodInfo method)
-        {
-            var attr = method.GetCustomAttribute<ActivityAttribute>(false) ??
-                throw new ArgumentException($"{method} missing Activity attribute");
-            return NameFromAttributed(method, attr);
-        }
-
-        /// <summary>
         /// Invoke this activity with the given parameters. Before calling this, callers should
         /// have already validated that the parameters match <see cref="ParameterTypes" /> and there
         /// are at least <see cref="RequiredParameterCount" /> parameters. If the activity returns
@@ -209,6 +209,20 @@ namespace Temporalio.Activities
             return result;
         }
 
+        /// <summary>
+        /// Gets the activity name for calling or fail if no attribute or if dynamic.
+        /// </summary>
+        /// <param name="method">Method to get name from.</param>
+        /// <returns>Name.</returns>
+        internal static string NameFromMethodForCall(MethodInfo method)
+        {
+            var attr = method.GetCustomAttribute<ActivityAttribute>(false) ??
+                throw new ArgumentException($"{method} missing Activity attribute");
+            return NameFromAttributed(method, attr) ??
+                throw new ArgumentException(
+                    $"{method} cannot be used directly since it is a dynamic activity");
+        }
+
         private static ActivityDefinition Create(
             MethodInfo method, bool cache, Func<object?[], object?> invoker)
         {
@@ -219,6 +233,13 @@ namespace Temporalio.Activities
             var attr = method.GetCustomAttribute<ActivityAttribute>(false) ??
                 throw new ArgumentException($"{method} missing Activity attribute");
             var parms = method.GetParameters();
+            // Check that param is vararg for dynamic (Create will check the arity)
+            if (attr.Dynamic &&
+                parms.SingleOrDefault()?.IsDefined(typeof(ParamArrayAttribute)) == false)
+            {
+                throw new ArgumentException(
+                    $"Dynamic activity must accept required vararg parameter array of IRawValue");
+            }
             return Create(
                 NameFromAttributed(method, attr),
                 method.ReturnType,
@@ -243,8 +264,18 @@ namespace Temporalio.Activities
             return ret.ToArray();
         }
 
-        private static string NameFromAttributed(MethodInfo method, ActivityAttribute attr)
+        private static string? NameFromAttributed(MethodInfo method, ActivityAttribute attr)
         {
+            // Dynamic doesn't have name
+            if (attr.Dynamic)
+            {
+                if (attr.Name != null)
+                {
+                    throw new ArgumentException(
+                        "Activity ${method} cannot be dynamic and have custom name");
+                }
+                return null;
+            }
             var name = attr.Name;
             if (name != null)
             {

--- a/src/Temporalio/Activities/ActivityExecutionContext.cs
+++ b/src/Temporalio/Activities/ActivityExecutionContext.cs
@@ -82,6 +82,11 @@ namespace Temporalio.Activities
         public CancellationToken WorkerShutdownToken { get; private init; }
 
         /// <summary>
+        /// Gets the payload converter in use by this activity worker.
+        /// </summary>
+        public IPayloadConverter PayloadConverter { get; private init; }
+
+        /// <summary>
         /// Gets the async local current value.
         /// </summary>
         internal static AsyncLocal<ActivityExecutionContext?> AsyncLocalCurrent { get; } = new();
@@ -102,11 +107,6 @@ namespace Temporalio.Activities
         /// Gets the raw proto task token for this activity.
         /// </summary>
         internal ByteString TaskToken { get; private init; }
-
-        /// <summary>
-        /// Gets the payload converter in use by this activity worker.
-        /// </summary>
-        public IPayloadConverter PayloadConverter { get; private init; }
 
         /// <summary>
         /// Record a heartbeat on the activity.

--- a/src/Temporalio/Activities/ActivityExecutionContext.cs
+++ b/src/Temporalio/Activities/ActivityExecutionContext.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
+using Temporalio.Converters;
 
 namespace Temporalio.Activities
 {
@@ -20,19 +21,22 @@ namespace Temporalio.Activities
         /// <param name="workerShutdownToken">Workflow shutdown token.</param>
         /// <param name="taskToken">Raw activity task token.</param>
         /// <param name="logger">Logger.</param>
+        /// <param name="payloadConverter">Payload converter.</param>
 #pragma warning disable CA1068 // We don't require cancellation token as last param
         internal ActivityExecutionContext(
             ActivityInfo info,
             CancellationToken cancellationToken,
             CancellationToken workerShutdownToken,
             ByteString taskToken,
-            ILogger logger)
+            ILogger logger,
+            IPayloadConverter payloadConverter)
         {
             Info = info;
             CancellationToken = cancellationToken;
             WorkerShutdownToken = workerShutdownToken;
             TaskToken = taskToken;
             Logger = logger;
+            PayloadConverter = payloadConverter;
         }
 #pragma warning restore CA1068
 
@@ -98,6 +102,11 @@ namespace Temporalio.Activities
         /// Gets the raw proto task token for this activity.
         /// </summary>
         internal ByteString TaskToken { get; private init; }
+
+        /// <summary>
+        /// Gets the payload converter in use by this activity worker.
+        /// </summary>
+        public IPayloadConverter PayloadConverter { get; private init; }
 
         /// <summary>
         /// Record a heartbeat on the activity.

--- a/src/Temporalio/Client/Schedules/ScheduleActionStartWorkflow.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleActionStartWorkflow.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Google.Protobuf.WellKnownTypes;
-using Temporalio.Api.Common.V1;
 using Temporalio.Common;
 using Temporalio.Converters;
 
@@ -25,7 +24,7 @@ namespace Temporalio.Client.Schedules
         string Workflow,
         IReadOnlyCollection<object?> Args,
         WorkflowOptions Options,
-        IReadOnlyDictionary<string, Payload>? Headers = null) : ScheduleAction
+        IReadOnlyDictionary<string, IEncodedRawValue>? Headers = null) : ScheduleAction
     {
         /// <summary>
         /// Create a scheduled action that starts a workflow via lambda invoking the run method.
@@ -91,6 +90,9 @@ namespace Temporalio.Client.Schedules
             IReadOnlyCollection<object?> args = proto.Input == null ?
                 Array.Empty<object?>() :
                 proto.Input.Payloads_.Select(p => new EncodedRawValue(dataConverter, p)).ToList();
+            var headers = proto.Header?.Fields?.ToDictionary(
+                kvp => kvp.Key,
+                kvp => (IEncodedRawValue)new EncodedRawValue(dataConverter, kvp.Value));
             return new(
                 Workflow: proto.WorkflowType.Name,
                 Args: args,
@@ -107,7 +109,8 @@ namespace Temporalio.Client.Schedules
                     TypedSearchAttributes = proto.SearchAttributes == null ?
                         SearchAttributeCollection.Empty :
                         SearchAttributeCollection.FromProto(proto.SearchAttributes),
-                });
+                },
+                Headers: headers);
         }
 
         /// <inheritdoc />
@@ -132,6 +135,17 @@ namespace Temporalio.Client.Schedules
                 throw new ArgumentException("RPC options cannot be set on scheduled workflow");
             }
 
+            // Build input. We have to go one payload at a time here because half could be encoded
+            // and half not (e.g. they just changed the second parameter).
+            var input = await Task.WhenAll(Args.Select(arg =>
+            {
+                if (arg is IEncodedRawValue raw)
+                {
+                    return Task.FromResult(raw.Payload);
+                }
+                return dataConverter.ToPayloadAsync(arg);
+            }).ToList()).ConfigureAwait(false);
+
             var workflow = new Api.Workflow.V1.NewWorkflowExecutionInfo()
             {
                 WorkflowId = Options.ID ??
@@ -142,10 +156,7 @@ namespace Temporalio.Client.Schedules
                     Name = Options.TaskQueue ??
                         throw new ArgumentException("Task queue required on workflow action"),
                 },
-                Input = Args.Count == 0 ? null : new()
-                {
-                    Payloads_ = { await dataConverter.ToPayloadsAsync(Args).ConfigureAwait(false) },
-                },
+                Input = Args.Count == 0 ? null : new() { Payloads_ = { input } },
                 WorkflowExecutionTimeout = Options.ExecutionTimeout is TimeSpan execTimeout ?
                     Duration.FromTimeSpan(execTimeout) : null,
                 WorkflowRunTimeout = Options.RunTimeout is TimeSpan runTimeout ?
@@ -163,9 +174,9 @@ namespace Temporalio.Client.Schedules
                     {
                         throw new ArgumentException($"Memo value for {field.Key} is null");
                     }
-                    workflow.Memo.Fields.Add(
-                        field.Key,
-                        await dataConverter.ToPayloadAsync(field.Value).ConfigureAwait(false));
+                    var value = field.Value is IEncodedRawValue raw ? raw.Payload :
+                        await dataConverter.ToPayloadAsync(field.Value).ConfigureAwait(false);
+                    workflow.Memo.Fields.Add(field.Key, value);
                 }
             }
             if (Options.TypedSearchAttributes != null && Options.TypedSearchAttributes.Count > 0)
@@ -177,7 +188,7 @@ namespace Temporalio.Client.Schedules
                 workflow.Header = new();
                 foreach (var pair in Headers)
                 {
-                    workflow.Header.Fields.Add(pair.Key, pair.Value);
+                    workflow.Header.Fields.Add(pair.Key, pair.Value.Payload);
                 }
             }
 

--- a/src/Temporalio/Client/Schedules/ScheduleActionStartWorkflow.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleActionStartWorkflow.cs
@@ -40,9 +40,9 @@ namespace Temporalio.Client.Schedules
         public static ScheduleActionStartWorkflow Create<TWorkflow, TResult>(
             Expression<Func<TWorkflow, Task<TResult>>> workflowRunCall, WorkflowOptions options)
         {
-            var (runMethod, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
+            var (runMethod, args) = ExpressionUtil.ExtractCall(workflowRunCall);
             return Create(
-                Workflows.WorkflowDefinition.FromRunMethod(runMethod).Name,
+                Workflows.WorkflowDefinition.NameFromRunMethodForCall(runMethod),
                 args,
                 options);
         }
@@ -59,9 +59,9 @@ namespace Temporalio.Client.Schedules
         public static ScheduleActionStartWorkflow Create<TWorkflow>(
             Expression<Func<TWorkflow, Task>> workflowRunCall, WorkflowOptions options)
         {
-            var (runMethod, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
+            var (runMethod, args) = ExpressionUtil.ExtractCall(workflowRunCall);
             return Create(
-                Workflows.WorkflowDefinition.FromRunMethod(runMethod).Name,
+                Workflows.WorkflowDefinition.NameFromRunMethodForCall(runMethod),
                 args,
                 options);
         }

--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -28,7 +28,7 @@ namespace Temporalio.Client
         {
             var (runMethod, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
             return await OutboundInterceptor.StartWorkflowAsync<TWorkflow, TResult>(new(
-                Workflow: Workflows.WorkflowDefinition.FromRunMethod(runMethod).Name,
+                Workflow: Workflows.WorkflowDefinition.NameFromRunMethodForCall(runMethod),
                 Args: args,
                 Options: options,
                 Headers: null)).ConfigureAwait(false);
@@ -40,7 +40,7 @@ namespace Temporalio.Client
         {
             var (runMethod, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
             return await OutboundInterceptor.StartWorkflowAsync<TWorkflow, ValueTuple>(new(
-                Workflow: Workflows.WorkflowDefinition.FromRunMethod(runMethod).Name,
+                Workflow: Workflows.WorkflowDefinition.NameFromRunMethodForCall(runMethod),
                 Args: args,
                 Options: options,
                 Headers: null)).ConfigureAwait(false);

--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -5,13 +5,13 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Temporalio.Api.Enums.V1;
 using Temporalio.Api.History.V1;
+using Temporalio.Common;
 using Temporalio.Converters;
 using Temporalio.Exceptions;
 
 #if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Temporalio.Common;
 #endif
 
 namespace Temporalio.Client
@@ -210,9 +210,9 @@ namespace Temporalio.Client
         public Task SignalAsync<TWorkflow>(
             Expression<Func<TWorkflow, Task>> signalCall, WorkflowSignalOptions? options = null)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(signalCall);
+            var (method, args) = ExpressionUtil.ExtractCall(signalCall);
             return SignalAsync(
-                Workflows.WorkflowSignalDefinition.FromMethod(method).Name,
+                Workflows.WorkflowSignalDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -258,7 +258,7 @@ namespace Temporalio.Client
             WorkflowQueryOptions? options = null)
         {
             // Try property first
-            var member = Common.ExpressionUtil.ExtractMemberAccess(queryCall);
+            var member = ExpressionUtil.ExtractMemberAccess(queryCall);
             if (member != null)
             {
                 if (member is not PropertyInfo property)
@@ -266,15 +266,15 @@ namespace Temporalio.Client
                     throw new ArgumentException("Expression must be a single method call or property access");
                 }
                 return QueryAsync<TQueryResult>(
-                    Workflows.WorkflowQueryDefinition.FromProperty(property).Name,
+                    Workflows.WorkflowQueryDefinition.NameFromPropertyForCall(property),
                     Array.Empty<object?>(),
                     options);
             }
             // Try method
-            var (method, args) = Common.ExpressionUtil.ExtractCall(
+            var (method, args) = ExpressionUtil.ExtractCall(
                 queryCall, errorSaysPropertyAccepted: true);
             return QueryAsync<TQueryResult>(
-                Workflows.WorkflowQueryDefinition.FromMethod(method).Name,
+                Workflows.WorkflowQueryDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }

--- a/src/Temporalio/Converters/ConverterExtensions.cs
+++ b/src/Temporalio/Converters/ConverterExtensions.cs
@@ -176,5 +176,24 @@ namespace Temporalio.Converters
             // We count on the payload converter to check whether the type is nullable
             return (T)converter.ToValue(payload, typeof(T))!;
         }
+
+        /// <summary>
+        /// Convert the given raw value to a value of the given type.
+        /// </summary>
+        /// <typeparam name="T">Value type.</typeparam>
+        /// <param name="converter">The converter to use.</param>
+        /// <param name="rawValue">The raw value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static T ToValue<T>(this IPayloadConverter converter, IRawValue rawValue) =>
+            converter.ToValue<T>(rawValue.Payload);
+
+        /// <summary>
+        /// Convert the given value to a raw value.
+        /// </summary>
+        /// <param name="converter">The converter to use.</param>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static RawValue ToRawValue(this IPayloadConverter converter, object? value) =>
+            new(converter.ToPayload(value));
     }
 }

--- a/src/Temporalio/Converters/DefaultPayloadConverter.cs
+++ b/src/Temporalio/Converters/DefaultPayloadConverter.cs
@@ -127,7 +127,7 @@ namespace Temporalio.Converters
         /// <inheritdoc />
         public object? ToValue(Payload payload, Type type)
         {
-            if (type.IsAssignableFrom(typeof(RawValue)))
+            if (type == typeof(IRawValue) || type == typeof(RawValue))
             {
                 return new RawValue(payload);
             }

--- a/src/Temporalio/Converters/DefaultPayloadConverter.cs
+++ b/src/Temporalio/Converters/DefaultPayloadConverter.cs
@@ -105,13 +105,13 @@ namespace Temporalio.Converters
         /// <inheritdoc />
         public Payload ToPayload(object? value)
         {
+            if (value is IEncodedRawValue)
+            {
+                throw new InvalidOperationException("Cannot convert IEncodedRawValue");
+            }
             if (value is IRawValue rawValue)
             {
                 return rawValue.Payload;
-            }
-            if (value is IEncodedRawValue encodedRawValue)
-            {
-                return encodedRawValue.Payload;
             }
             foreach (var enc in EncodingConverters)
             {
@@ -127,9 +127,9 @@ namespace Temporalio.Converters
         /// <inheritdoc />
         public object? ToValue(Payload payload, Type type)
         {
-            if (typeof(IRawValue).IsAssignableFrom(type))
+            if (type.IsAssignableFrom(typeof(RawValue)))
             {
-                return new RawValue(this, payload);
+                return new RawValue(payload);
             }
             var encoding = payload.Metadata["encoding"];
             if (IndexedEncodingConverters.TryGetValue(encoding, out var converter))

--- a/src/Temporalio/Converters/IPayloadConverter.cs
+++ b/src/Temporalio/Converters/IPayloadConverter.cs
@@ -21,7 +21,7 @@ namespace Temporalio.Converters
         /// <returns>The converted payload.</returns>
         /// <remarks>
         /// Implementers are expected to be able just return the payload for
-        /// <see cref="IRawValue" /> and <see cref="IEncodedRawValue" />.
+        /// <see cref="IRawValue" />.
         /// </remarks>
         Payload ToPayload(object? value);
 

--- a/src/Temporalio/Converters/IRawValue.cs
+++ b/src/Temporalio/Converters/IRawValue.cs
@@ -1,4 +1,3 @@
-using System;
 using Temporalio.Api.Common.V1;
 
 namespace Temporalio.Converters
@@ -12,19 +11,5 @@ namespace Temporalio.Converters
         /// Gets the raw payload value.
         /// </summary>
         Payload Payload { get; }
-
-        /// <summary>
-        /// Convert the raw value to the given type.
-        /// </summary>
-        /// <typeparam name="T">Type to convert to.</typeparam>
-        /// <returns>Converted value.</returns>
-        T ToValue<T>();
-
-        /// <summary>
-        /// Convert the raw value to the given type.
-        /// </summary>
-        /// <param name="type">Type to convert to.</param>
-        /// <returns>Converted value.</returns>
-        object? ToValue(Type type);
     }
 }

--- a/src/Temporalio/Converters/RawValue.cs
+++ b/src/Temporalio/Converters/RawValue.cs
@@ -1,4 +1,3 @@
-using System;
 using Temporalio.Api.Common.V1;
 
 namespace Temporalio.Converters
@@ -6,14 +5,6 @@ namespace Temporalio.Converters
     /// <summary>
     /// Implementation of a <see cref="IRawValue" />.
     /// </summary>
-    /// <param name="PayloadConverter">Payload converter to perform conversions.</param>
     /// <param name="Payload">Raw payload.</param>
-    public record RawValue(IPayloadConverter PayloadConverter, Payload Payload) : IRawValue
-    {
-        /// <inheritdoc />
-        public T ToValue<T>() => PayloadConverter.ToValue<T>(Payload);
-
-        /// <inheritdoc />
-        public object? ToValue(Type type) => PayloadConverter.ToValue(Payload, type);
-    }
+    public record RawValue(Payload Payload) : IRawValue;
 }

--- a/src/Temporalio/Testing/ActivityEnvironment.cs
+++ b/src/Temporalio/Testing/ActivityEnvironment.cs
@@ -50,6 +50,11 @@ namespace Temporalio.Testing
         public ILogger Logger { get; init; } = NullLogger.Instance;
 
         /// <summary>
+        /// Gets or inits the payload converter. Default is default converter.
+        /// </summary>
+        public IPayloadConverter PayloadConverter { get; init; } = DataConverter.Default.PayloadConverter;
+
+        /// <summary>
         /// Gets or sets the cancel reason. Callers may prefer <see cref="Cancel" /> instead.
         /// </summary>
         public ActivityCancelReason CancelReason
@@ -121,7 +126,8 @@ namespace Temporalio.Testing
                     workerShutdownToken: WorkerShutdownTokenSource.Token,
                     // This task token is not used for anything in this env
                     taskToken: ByteString.Empty,
-                    logger: Logger)
+                    logger: Logger,
+                    payloadConverter: PayloadConverter)
                 {
                     Heartbeater = Heartbeater,
                     CancelReasonRef = CancelReasonRef,

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -25,6 +25,7 @@ namespace Temporalio.Worker
         private readonly ILogger logger;
         // Keyed by name
         private readonly Dictionary<string, ActivityDefinition> activities;
+        private readonly ActivityDefinition? dynamicActivity;
         // Keyed by task token
         private readonly ConcurrentDictionary<ByteString, RunningActivity> runningActivities = new();
 
@@ -41,11 +42,22 @@ namespace Temporalio.Worker
             activities = new(worker.Options.Activities.Count);
             foreach (var defn in worker.Options.Activities)
             {
-                if (activities.ContainsKey(defn.Name))
+                if (defn.Name == null)
+                {
+                    if (dynamicActivity != null)
+                    {
+                        throw new ArgumentException("Multiple dynamic activities provided");
+                    }
+                    dynamicActivity = defn;
+                }
+                else if (activities.ContainsKey(defn.Name))
                 {
                     throw new ArgumentException($"Duplicate activity named {defn.Name}");
                 }
-                activities[defn.Name] = defn;
+                else
+                {
+                    activities[defn.Name] = defn;
+                }
             }
         }
 
@@ -280,32 +292,49 @@ namespace Temporalio.Worker
                 // Find activity or fail
                 if (!activities.TryGetValue(act.Context.Info.ActivityType, out var defn))
                 {
-                    var avail = activities.Keys.ToList();
-                    avail.Sort();
-                    var availStr = string.Join(", ", avail);
-                    throw new ApplicationFailureException(
-                        $"Activity {act.Context.Info.ActivityType} is not registered on this worker," +
-                        $" available activities: {availStr}",
-                        errorType: "NotFoundError");
+                    defn = dynamicActivity;
+                    if (defn == null)
+                    {
+                        var avail = activities.Keys.ToList();
+                        avail.Sort();
+                        var availStr = string.Join(", ", avail);
+                        throw new ApplicationFailureException(
+                            $"Activity {act.Context.Info.ActivityType} is not registered on this worker," +
+                            $" available activities: {availStr}",
+                            errorType: "NotFoundError");
+                    }
                 }
 
-                // Deserialize arguments. If the input is less than the required parameter count, we
-                // error.
-                if (tsk.Start.Input.Count < defn.RequiredParameterCount)
-                {
-                    throw new ApplicationFailureException(
-                        $"Activity {act.Context.Info.ActivityType} given {tsk.Start.Input.Count} parameter(s)," +
-                        " but more than that are required by the signature");
-                }
-                // Zip the params and input and then decode each. It is intentional that we discard
-                // extra input arguments that the signature doesn't accept.
                 object?[] paramVals;
                 try
                 {
-                    paramVals = await Task.WhenAll(
-                        tsk.Start.Input.Zip(defn.ParameterTypes, (input, paramType) =>
-                            worker.Client.Options.DataConverter.ToValueAsync(
-                                input, paramType))).ConfigureAwait(false);
+                    // Dynamic activities are just one param of a raw array, otherwise, deserialize
+                    if (defn.Dynamic)
+                    {
+                        paramVals = new[]
+                        {
+                            await Task.WhenAll(tsk.Start.Input.Select(p =>
+                                worker.Client.Options.DataConverter.ToValueAsync<IRawValue>(p))).
+                                ConfigureAwait(false),
+                        };
+                    }
+                    else
+                    {
+                        // Deserialize arguments. If the input is less than the required parameter
+                        // count, we error.
+                        if (tsk.Start.Input.Count < defn.RequiredParameterCount)
+                        {
+                            throw new ApplicationFailureException(
+                                $"Activity {act.Context.Info.ActivityType} given {tsk.Start.Input.Count} parameter(s)," +
+                                " but more than that are required by the signature");
+                        }
+                        // Zip the params and input and then decode each. It is intentional that we
+                        // discard extra input arguments that the signature doesn't accept.
+                        paramVals = await Task.WhenAll(
+                            tsk.Start.Input.Zip(defn.ParameterTypes, (input, paramType) =>
+                                worker.Client.Options.DataConverter.ToValueAsync(
+                                    input, paramType))).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -176,8 +176,9 @@ namespace Temporalio.Worker
                 info: info,
                 cancellationToken: cancelTokenSource.Token,
                 workerShutdownToken: workerShutdownTokenSource.Token,
-                tsk.TaskToken,
-                worker.LoggerFactory.CreateLogger($"Temporalio.Activity:{info.ActivityType}"));
+                taskToken: tsk.TaskToken,
+                logger: worker.LoggerFactory.CreateLogger($"Temporalio.Activity:{info.ActivityType}"),
+                payloadConverter: worker.Client.Options.DataConverter.PayloadConverter);
 
             // Start task
             using (context.Logger.BeginScope(info.LoggerScope))

--- a/src/Temporalio/Workflows/ChildWorkflowHandle.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowHandle.cs
@@ -53,7 +53,7 @@ namespace Temporalio.Workflows
         {
             var (method, args) = Common.ExpressionUtil.ExtractCall(signalCall);
             return SignalAsync(
-                WorkflowSignalDefinition.FromMethod(method).Name,
+                WorkflowSignalDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }

--- a/src/Temporalio/Workflows/ExternalWorkflowHandle.cs
+++ b/src/Temporalio/Workflows/ExternalWorkflowHandle.cs
@@ -35,7 +35,7 @@ namespace Temporalio.Workflows
         {
             var (method, args) = Common.ExpressionUtil.ExtractCall(signalCall);
             return SignalAsync(
-                WorkflowSignalDefinition.FromMethod(method).Name,
+                WorkflowSignalDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -19,6 +19,16 @@ namespace Temporalio.Workflows
         CancellationToken CancellationToken { get; }
 
         /// <summary>
+        /// Gets or sets value for <see cref="Workflow.DynamicQuery" />.
+        /// </summary>
+        WorkflowQueryDefinition? DynamicQuery { get; set; }
+
+        /// <summary>
+        /// Gets or sets value for <see cref="Workflow.DynamicSignal" />.
+        /// </summary>
+        WorkflowSignalDefinition? DynamicSignal { get; set; }
+
+        /// <summary>
         /// Gets value for <see cref="Workflow.Info" />.
         /// </summary>
         WorkflowInfo Info { get; }

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -39,6 +39,11 @@ namespace Temporalio.Workflows
         IReadOnlyDictionary<string, IRawValue> Memo { get; }
 
         /// <summary>
+        /// Gets value for <see cref="Workflow.PayloadConverter" />.
+        /// </summary>
+        IPayloadConverter PayloadConverter { get; }
+
+        /// <summary>
         /// Gets value for <see cref="Workflow.Queries" />.
         /// </summary>
         IDictionary<string, WorkflowQueryDefinition> Queries { get; }

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -28,6 +28,27 @@ namespace Temporalio.Workflows
         public static CancellationToken CancellationToken => Context.CancellationToken;
 
         /// <summary>
+        /// Gets or sets the current dynamic query handler. This can be null for no dynamic query
+        /// handling.
+        /// </summary>
+        public static WorkflowQueryDefinition? DynamicQuery
+        {
+            get => Context.DynamicQuery;
+            set => Context.DynamicQuery = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the current dynamic signal handler. This can be null for no dynamic signal
+        /// handling. If this is set to a value where none was there before, all buffered signals
+        /// will be immediately delivered to it.
+        /// </summary>
+        public static WorkflowSignalDefinition? DynamicSignal
+        {
+            get => Context.DynamicSignal;
+            set => Context.DynamicSignal = value;
+        }
+
+        /// <summary>
         /// Gets information about the workflow.
         /// </summary>
         public static WorkflowInfo Info => Context.Info;
@@ -97,7 +118,9 @@ namespace Temporalio.Workflows
         /// </summary>
         /// <remarks>
         /// This dictionary can be mutated during workflow run. However, users are strongly
-        /// encouraged to use fixed methods with the <c>[WorkflowSignal]</c> attribute.
+        /// encouraged to use fixed methods with the <c>[WorkflowSignal]</c> attribute. If a new
+        /// signal handler is added for a signal name where one wasn't present before, all buffered
+        /// signals are sent to the handler immediately.
         /// </remarks>
         public static IDictionary<string, WorkflowSignalDefinition> Signals => Context.Signals;
 
@@ -126,9 +149,9 @@ namespace Temporalio.Workflows
             Expression<Func<TWorkflow, Task<TResult>>> workflowRunCall,
             ContinueAsNewOptions? options = null)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
+            var (method, args) = ExpressionUtil.ExtractCall(workflowRunCall);
             return CreateContinueAsNewException(
-                WorkflowDefinition.FromRunMethod(method).Name,
+                WorkflowDefinition.NameFromRunMethodForCall(method),
                 args,
                 options);
         }
@@ -145,9 +168,9 @@ namespace Temporalio.Workflows
             Expression<Func<TWorkflow, Task>> workflowRunCall,
             ContinueAsNewOptions? options = null)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
+            var (method, args) = ExpressionUtil.ExtractCall(workflowRunCall);
             return CreateContinueAsNewException(
-                WorkflowDefinition.FromRunMethod(method).Name,
+                WorkflowDefinition.NameFromRunMethodForCall(method),
                 args,
                 options);
         }
@@ -231,9 +254,9 @@ namespace Temporalio.Workflows
         public static Task<TResult> ExecuteActivityAsync<TResult>(
             Expression<Func<TResult>> activityCall, ActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteActivityAsync<TResult>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -253,9 +276,9 @@ namespace Temporalio.Workflows
         public static Task ExecuteActivityAsync(
             Expression<Action> activityCall, ActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteActivityAsync<ValueTuple>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -277,9 +300,9 @@ namespace Temporalio.Workflows
         public static Task<TResult> ExecuteActivityAsync<TActivityInstance, TResult>(
             Expression<Func<TActivityInstance, TResult>> activityCall, ActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteActivityAsync<TResult>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -300,9 +323,9 @@ namespace Temporalio.Workflows
         public static Task ExecuteActivityAsync<TActivityInstance>(
             Expression<Action<TActivityInstance>> activityCall, ActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteActivityAsync<ValueTuple>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -323,9 +346,9 @@ namespace Temporalio.Workflows
         public static Task<TResult> ExecuteActivityAsync<TResult>(
             Expression<Func<Task<TResult>>> activityCall, ActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteActivityAsync<TResult>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -345,9 +368,9 @@ namespace Temporalio.Workflows
         public static Task ExecuteActivityAsync(
             Expression<Func<Task>> activityCall, ActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteActivityAsync<ValueTuple>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -369,9 +392,9 @@ namespace Temporalio.Workflows
         public static Task<TResult> ExecuteActivityAsync<TActivityInstance, TResult>(
             Expression<Func<TActivityInstance, Task<TResult>>> activityCall, ActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteActivityAsync<TResult>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -392,9 +415,9 @@ namespace Temporalio.Workflows
         public static Task ExecuteActivityAsync<TActivityInstance>(
             Expression<Func<TActivityInstance, Task>> activityCall, ActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteActivityAsync<ValueTuple>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -524,9 +547,9 @@ namespace Temporalio.Workflows
         public static Task<TResult> ExecuteLocalActivityAsync<TResult>(
             Expression<Func<TResult>> activityCall, LocalActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteLocalActivityAsync<TResult>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -546,9 +569,9 @@ namespace Temporalio.Workflows
         public static Task ExecuteLocalActivityAsync(
             Expression<Action> activityCall, LocalActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteLocalActivityAsync<ValueTuple>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -570,9 +593,9 @@ namespace Temporalio.Workflows
         public static Task<TResult> ExecuteLocalActivityAsync<TActivityInstance, TResult>(
             Expression<Func<TActivityInstance, TResult>> activityCall, LocalActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteLocalActivityAsync<TResult>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -593,9 +616,9 @@ namespace Temporalio.Workflows
         public static Task ExecuteLocalActivityAsync<TActivityInstance>(
             Expression<Action<TActivityInstance>> activityCall, LocalActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteLocalActivityAsync<ValueTuple>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -616,9 +639,9 @@ namespace Temporalio.Workflows
         public static Task<TResult> ExecuteLocalActivityAsync<TResult>(
             Expression<Func<Task<TResult>>> activityCall, LocalActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteLocalActivityAsync<TResult>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -638,9 +661,9 @@ namespace Temporalio.Workflows
         public static Task ExecuteLocalActivityAsync(
             Expression<Func<Task>> activityCall, LocalActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteLocalActivityAsync<ValueTuple>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -662,9 +685,9 @@ namespace Temporalio.Workflows
         public static Task<TResult> ExecuteLocalActivityAsync<TActivityInstance, TResult>(
             Expression<Func<TActivityInstance, Task<TResult>>> activityCall, LocalActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteLocalActivityAsync<TResult>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -685,9 +708,9 @@ namespace Temporalio.Workflows
         public static Task ExecuteLocalActivityAsync<TActivityInstance>(
             Expression<Func<TActivityInstance, Task>> activityCall, LocalActivityOptions options)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(activityCall);
+            var (method, args) = ExpressionUtil.ExtractCall(activityCall);
             return ExecuteLocalActivityAsync<ValueTuple>(
-                Activities.ActivityDefinition.NameFromMethod(method),
+                Activities.ActivityDefinition.NameFromMethodForCall(method),
                 args,
                 options);
         }
@@ -800,9 +823,9 @@ namespace Temporalio.Workflows
             Expression<Func<TWorkflow, Task<TResult>>> workflowRunCall,
             ChildWorkflowOptions? options = null)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
+            var (method, args) = ExpressionUtil.ExtractCall(workflowRunCall);
             return Context.StartChildWorkflowAsync<TWorkflow, TResult>(
-                WorkflowDefinition.FromRunMethod(method).Name, args, options ?? new());
+                WorkflowDefinition.NameFromRunMethodForCall(method), args, options ?? new());
         }
 
         /// <summary>
@@ -819,9 +842,9 @@ namespace Temporalio.Workflows
         public static async Task<ChildWorkflowHandle<TWorkflow>> StartChildWorkflowAsync<TWorkflow>(
             Expression<Func<TWorkflow, Task>> workflowRunCall, ChildWorkflowOptions? options = null)
         {
-            var (method, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
+            var (method, args) = ExpressionUtil.ExtractCall(workflowRunCall);
             return await Context.StartChildWorkflowAsync<TWorkflow, ValueTuple>(
-                WorkflowDefinition.FromRunMethod(method).Name, args, options ?? new()).
+                WorkflowDefinition.NameFromRunMethodForCall(method), args, options ?? new()).
                 ConfigureAwait(true);
         }
 

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -54,6 +54,11 @@ namespace Temporalio.Workflows
         public static IReadOnlyDictionary<string, IRawValue> Memo => Context.Memo;
 
         /// <summary>
+        /// Gets the payload converter for the workflow.
+        /// </summary>
+        public static IPayloadConverter PayloadConverter => Context.PayloadConverter;
+
+        /// <summary>
         /// Gets queries for this workflow.
         /// </summary>
         /// <remarks>

--- a/src/Temporalio/Workflows/WorkflowAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowAttribute.cs
@@ -38,5 +38,12 @@ namespace Temporalio.Workflows
         /// capital letter, the "I" is trimmed when creating the default name.
         /// </summary>
         public string? Name { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the workflow is dynamic. If a workflow is
+        /// dynamic, it cannot by given a name in this attribute and the run method must accept a
+        /// vararg parameter array of <see cref="Converters.IRawValue" />.
+        /// </summary>
+        public bool Dynamic { get; set; }
     }
 }

--- a/src/Temporalio/Workflows/WorkflowAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowAttribute.cs
@@ -41,8 +41,8 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Gets or sets a value indicating whether the workflow is dynamic. If a workflow is
-        /// dynamic, it cannot by given a name in this attribute and the run method must accept a
-        /// vararg parameter array of <see cref="Converters.IRawValue" />.
+        /// dynamic, it cannot by given a name in this attribute and the run method must an array of
+        /// <see cref="Converters.IRawValue" />.
         /// </summary>
         public bool Dynamic { get; set; }
     }

--- a/src/Temporalio/Workflows/WorkflowDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowDefinition.cs
@@ -231,7 +231,7 @@ namespace Temporalio.Workflows
                     }
                     else if (attr.Dynamic && !HasValidDynamicParameters(method, requireNameFirst: false))
                     {
-                        errs.Add($"WorkflowRun on {method} for dynamic workflow must accept vararg parameter array of IRawValue");
+                        errs.Add($"WorkflowRun on {method} for dynamic workflow must accept an array of IRawValue");
                     }
                     else
                     {
@@ -411,9 +411,7 @@ namespace Temporalio.Workflows
             {
                 return false;
             }
-            var last = parms.Last();
-            return last.ParameterType == typeof(Converters.IRawValue[]) &&
-                last.IsDefined(typeof(ParamArrayAttribute));
+            return parms.Last().ParameterType == typeof(Converters.IRawValue[]);
         }
 
         private static bool IsDefinedOnBase<T>(MethodInfo method)

--- a/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
@@ -39,8 +39,8 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Gets or sets a value indicating whether the query is dynamic. If a query is dynamic, it
-        /// cannot be given a name in this attribute and the method must accept a vararg parameter
-        /// array of <see cref="Converters.IRawValue" />.
+        /// cannot be given a name in this attribute and the method must accept a string name and
+        /// an array of <see cref="Converters.IRawValue" />.
         /// </summary>
         public bool Dynamic { get; set; }
     }

--- a/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryAttribute.cs
@@ -36,5 +36,12 @@ namespace Temporalio.Workflows
         /// name.
         /// </summary>
         public string? Name { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the query is dynamic. If a query is dynamic, it
+        /// cannot be given a name in this attribute and the method must accept a vararg parameter
+        /// array of <see cref="Converters.IRawValue" />.
+        /// </summary>
+        public bool Dynamic { get; set; }
     }
 }

--- a/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
@@ -131,7 +131,7 @@ namespace Temporalio.Workflows
             var name = attr.Name;
             if (attr.Dynamic && name != null)
             {
-                throw new ArgumentException($"WorkflowQuery method {method} cannot by dynamic with custom name");
+                throw new ArgumentException($"WorkflowQuery method {method} cannot be dynamic with custom name");
             }
             else if (!attr.Dynamic && name == null)
             {
@@ -151,11 +151,11 @@ namespace Temporalio.Workflows
             {
                 throw new ArgumentException($"WorkflowQuery method {method} cannot return a Task");
             }
-            // If it's dynamic, must have IRawValue parameter array
+            // If it's dynamic, must have specific signature
             if (dynamic && !WorkflowDefinition.HasValidDynamicParameters(method, requireNameFirst: true))
             {
                 throw new ArgumentException(
-                    $"WorkflowQuery method {method} must accept string then vararg parameter array of IRawValue");
+                    $"WorkflowQuery method {method} must accept string and an array of IRawValue");
             }
         }
     }

--- a/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
@@ -13,7 +13,7 @@ namespace Temporalio.Workflows
         private static readonly ConcurrentDictionary<MethodInfo, WorkflowQueryDefinition> MethodDefinitions = new();
         private static readonly ConcurrentDictionary<PropertyInfo, WorkflowQueryDefinition> PropertyDefinitions = new();
 
-        private WorkflowQueryDefinition(string name, MethodInfo? method, Delegate? del)
+        private WorkflowQueryDefinition(string? name, MethodInfo? method, Delegate? del)
         {
             Name = name;
             Method = method;
@@ -21,9 +21,14 @@ namespace Temporalio.Workflows
         }
 
         /// <summary>
-        /// Gets the query name.
+        /// Gets the query name. This is null if the query is dynamic.
         /// </summary>
-        public string Name { get; private init; }
+        public string? Name { get; private init; }
+
+        /// <summary>
+        /// Gets a value indicating whether the query is dynamic.
+        /// </summary>
+        public bool Dynamic => Name == null;
 
         /// <summary>
         /// Gets the query method.
@@ -72,6 +77,10 @@ namespace Temporalio.Workflows
                 {
                     throw new ArgumentException($"WorkflowQuery property {property} cannot be static");
                 }
+                else if (attr.Dynamic)
+                {
+                    throw new ArgumentException($"WorkflowQuery property {property} cannot be dynamic");
+                }
                 return new(attr.Name ?? property.Name, method, null);
             });
 
@@ -79,33 +88,74 @@ namespace Temporalio.Workflows
         /// Creates a query definition from an explicit name and method. Most users should use
         /// <see cref="FromMethod" /> with attributes instead.
         /// </summary>
-        /// <param name="name">Query name.</param>
+        /// <param name="name">Query name. Null for dynamic query.</param>
         /// <param name="del">Query delegate.</param>
         /// <returns>Query definition.</returns>
-        public static WorkflowQueryDefinition CreateWithoutAttribute(string name, Delegate del)
+        public static WorkflowQueryDefinition CreateWithoutAttribute(string? name, Delegate del)
         {
-            AssertValid(del.Method);
+            AssertValid(del.Method, dynamic: name == null);
             return new(name, null, del);
+        }
+
+        /// <summary>
+        /// Gets the query name for calling or fail if no attribute or if dynamic.
+        /// </summary>
+        /// <param name="method">Method to get name from.</param>
+        /// <returns>Name.</returns>
+        internal static string NameFromMethodForCall(MethodInfo method)
+        {
+            var defn = FromMethod(method);
+            return defn.Name ??
+                throw new ArgumentException(
+                    $"{method} cannot be used directly since it is a dynamic query");
+        }
+
+        /// <summary>
+        /// Gets the query name for calling or fail if no attribute or if dynamic.
+        /// </summary>
+        /// <param name="property">Property to get name from.</param>
+        /// <returns>Name.</returns>
+        internal static string NameFromPropertyForCall(PropertyInfo property)
+        {
+            var defn = FromProperty(property);
+            return defn.Name ??
+                throw new ArgumentException(
+                    $"{property} cannot be used directly since it is a dynamic query");
         }
 
         private static WorkflowQueryDefinition CreateFromMethod(MethodInfo method)
         {
             var attr = method.GetCustomAttribute<WorkflowQueryAttribute>(false) ??
                 throw new ArgumentException($"{method} missing WorkflowQuery attribute");
-            AssertValid(method);
-            return new(attr.Name ?? method.Name, method, null);
+            AssertValid(method, attr.Dynamic);
+            var name = attr.Name;
+            if (attr.Dynamic && name != null)
+            {
+                throw new ArgumentException($"WorkflowQuery method {method} cannot by dynamic with custom name");
+            }
+            else if (!attr.Dynamic && name == null)
+            {
+                name = method.Name;
+            }
+            return new(name, method, null);
         }
 
-        private static void AssertValid(MethodInfo method)
+        private static void AssertValid(MethodInfo method, bool dynamic)
         {
             // Method must not return void or a Task
             if (method.ReturnType == typeof(void))
             {
                 throw new ArgumentException($"WorkflowQuery method {method} must return a value");
             }
-            else if (typeof(Task).IsAssignableFrom(method.ReturnType))
+            if (typeof(Task).IsAssignableFrom(method.ReturnType))
             {
                 throw new ArgumentException($"WorkflowQuery method {method} cannot return a Task");
+            }
+            // If it's dynamic, must have IRawValue parameter array
+            if (dynamic && !WorkflowDefinition.HasValidDynamicParameters(method, requireNameFirst: true))
+            {
+                throw new ArgumentException(
+                    $"WorkflowQuery method {method} must accept string then vararg parameter array of IRawValue");
             }
         }
     }

--- a/src/Temporalio/Workflows/WorkflowSignalAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowSignalAttribute.cs
@@ -36,5 +36,12 @@ namespace Temporalio.Workflows
         /// default.
         /// </summary>
         public string? Name { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the signal is dynamic. If a signal is dynamic,
+        /// it cannot be given a name in this attribute and the method must accept a string name and
+        /// a vararg parameter array of <see cref="Converters.IRawValue" />.
+        /// </summary>
+        public bool Dynamic { get; set; }
     }
 }

--- a/src/Temporalio/Workflows/WorkflowSignalAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowSignalAttribute.cs
@@ -40,7 +40,7 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Gets or sets a value indicating whether the signal is dynamic. If a signal is dynamic,
         /// it cannot be given a name in this attribute and the method must accept a string name and
-        /// a vararg parameter array of <see cref="Converters.IRawValue" />.
+        /// an array of <see cref="Converters.IRawValue" />.
         /// </summary>
         public bool Dynamic { get; set; }
     }

--- a/src/Temporalio/Workflows/WorkflowSignalDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowSignalDefinition.cs
@@ -92,7 +92,7 @@ namespace Temporalio.Workflows
             var name = attr.Name;
             if (attr.Dynamic && name != null)
             {
-                throw new ArgumentException($"WorkflowSignal method {method} cannot by dynamic with custom name");
+                throw new ArgumentException($"WorkflowSignal method {method} cannot be dynamic with custom name");
             }
             else if (!attr.Dynamic && name == null)
             {
@@ -113,11 +113,11 @@ namespace Temporalio.Workflows
             {
                 throw new ArgumentException($"WorkflowSignal method {method} must return Task");
             }
-            // If it's dynamic, must have IRawValue parameter array
+            // If it's dynamic, must have specific signature
             if (dynamic && !WorkflowDefinition.HasValidDynamicParameters(method, requireNameFirst: true))
             {
                 throw new ArgumentException(
-                    $"WorkflowSignal method {method} must accept string then vararg parameter array of IRawValue");
+                    $"WorkflowSignal method {method} must accept string and an array of IRawValue");
             }
         }
     }

--- a/src/Temporalio/Workflows/WorkflowSignalDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowSignalDefinition.cs
@@ -12,7 +12,7 @@ namespace Temporalio.Workflows
     {
         private static readonly ConcurrentDictionary<MethodInfo, WorkflowSignalDefinition> Definitions = new();
 
-        private WorkflowSignalDefinition(string name, MethodInfo? method, Delegate? del)
+        private WorkflowSignalDefinition(string? name, MethodInfo? method, Delegate? del)
         {
             Name = name;
             Method = method;
@@ -20,9 +20,14 @@ namespace Temporalio.Workflows
         }
 
         /// <summary>
-        /// Gets the signal name.
+        /// Gets the signal name. This is null if the signal is dynamic.
         /// </summary>
-        public string Name { get; private init; }
+        public string? Name { get; private init; }
+
+        /// <summary>
+        /// Gets a value indicating whether the signal is dynamic.
+        /// </summary>
+        public bool Dynamic => Name == null;
 
         /// <summary>
         /// Gets the signal method if done with attribute.
@@ -56,22 +61,40 @@ namespace Temporalio.Workflows
         /// Creates a signal definition from an explicit name and method. Most users should use
         /// <see cref="FromMethod" /> with attributes instead.
         /// </summary>
-        /// <param name="name">Signal name.</param>
+        /// <param name="name">Signal name. Null for dynamic signal.</param>
         /// <param name="del">Signal delegate.</param>
         /// <returns>Signal definition.</returns>
-        public static WorkflowSignalDefinition CreateWithoutAttribute(string name, Delegate del)
+        public static WorkflowSignalDefinition CreateWithoutAttribute(
+            string? name, Delegate del)
         {
-            AssertValid(del.Method);
+            AssertValid(del.Method, dynamic: name == null);
             return new(name, null, del);
+        }
+
+        /// <summary>
+        /// Gets the signal name for calling or fail if no attribute or if dynamic.
+        /// </summary>
+        /// <param name="method">Method to get name from.</param>
+        /// <returns>Name.</returns>
+        internal static string NameFromMethodForCall(MethodInfo method)
+        {
+            var defn = FromMethod(method);
+            return defn.Name ??
+                throw new ArgumentException(
+                    $"{method} cannot be used directly since it is a dynamic signal");
         }
 
         private static WorkflowSignalDefinition CreateFromMethod(MethodInfo method)
         {
-            AssertValid(method);
             var attr = method.GetCustomAttribute<WorkflowSignalAttribute>(false) ??
                 throw new ArgumentException($"{method} missing WorkflowSignal attribute");
+            AssertValid(method, attr.Dynamic);
             var name = attr.Name;
-            if (name == null)
+            if (attr.Dynamic && name != null)
+            {
+                throw new ArgumentException($"WorkflowSignal method {method} cannot by dynamic with custom name");
+            }
+            else if (!attr.Dynamic && name == null)
             {
                 name = method.Name;
                 // Trim trailing "Async" if that's not just the full name
@@ -83,12 +106,18 @@ namespace Temporalio.Workflows
             return new(name, method, null);
         }
 
-        private static void AssertValid(MethodInfo method)
+        private static void AssertValid(MethodInfo method, bool dynamic)
         {
             // Method must only return a Task (not a subclass thereof)
             if (method.ReturnType != typeof(Task))
             {
                 throw new ArgumentException($"WorkflowSignal method {method} must return Task");
+            }
+            // If it's dynamic, must have IRawValue parameter array
+            if (dynamic && !WorkflowDefinition.HasValidDynamicParameters(method, requireNameFirst: true))
+            {
+                throw new ArgumentException(
+                    $"WorkflowSignal method {method} must accept string then vararg parameter array of IRawValue");
             }
         }
     }

--- a/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
@@ -792,7 +792,7 @@ public class ActivityWorkerTests : WorkflowEnvironmentTestBase
             async () =>
             {
                 var arg = new KSWorkflowParams(new KSAction(ExecuteActivity: new(
-                    Name: ActivityDefinition.Create(activity).Name,
+                    Name: ActivityDefinition.Create(activity).Name!,
                     TaskQueue: taskQueue,
                     Args: args,
                     WaitForCancellation: waitForCancellation,

--- a/tests/Temporalio.Tests/Workflows/WorkflowDefinitionTests.cs
+++ b/tests/Temporalio.Tests/Workflows/WorkflowDefinitionTests.cs
@@ -2,10 +2,11 @@
 
 namespace Temporalio.Tests.Workflows;
 
+using Temporalio.Converters;
 using Temporalio.Workflows;
 using Xunit;
 
-public class WorkflowAttributeTests
+public class WorkflowDefinitionTests
 {
     [Fact]
     public void Create_RunAttributeMissing_Throws()
@@ -193,6 +194,23 @@ public class WorkflowAttributeTests
         AssertBad<Bad.Wf5<string>>("with WorkflowQuery contains generic parameters");
     }
 
+    [Fact]
+    public void Create_BadDynamic_Throws()
+    {
+        AssertBad<Bad.Wf6>("custom name for dynamic workflow");
+        AssertBad<Bad.Wf6>("dynamic workflow must accept an array of IRawValue");
+        AssertBad<Bad.Wf6>("more than one dynamic signal");
+        AssertBad<Bad.Wf6>("DynamicSignal3Async(System.String, Temporalio.Converters.IRawValue[])" +
+            " cannot be dynamic with custom name");
+        AssertBad<Bad.Wf6>("DynamicSignal4Async(Temporalio.Converters.IRawValue[])" +
+            " must accept string and an array of IRawValue");
+        AssertBad<Bad.Wf6>("more than one dynamic query");
+        AssertBad<Bad.Wf6>("DynamicQuery3(System.String, Temporalio.Converters.IRawValue[])" +
+            " cannot be dynamic with custom name");
+        AssertBad<Bad.Wf6>("DynamicQuery4(Temporalio.Converters.IRawValue[])" +
+            " must accept string and an array of IRawValue");
+    }
+
     private static void AssertBad<T>(string errContains)
     {
         var err = Assert.ThrowsAny<Exception>(() => WorkflowDefinition.Create(typeof(T)));
@@ -361,6 +379,37 @@ public class WorkflowAttributeTests
 
             [WorkflowQuery]
             public string SomeQuery<TLocal>(TLocal _) => string.Empty;
+        }
+
+        [Workflow("CustomName", Dynamic = true)]
+        public class Wf6
+        {
+            [WorkflowRun]
+            public Task RunAsync(int param) => Task.CompletedTask;
+
+            [WorkflowSignal(Dynamic = true)]
+            public Task DynamicSignal1Async(string signalName, IRawValue[] args) => Task.CompletedTask;
+
+            [WorkflowSignal(Dynamic = true)]
+            public Task DynamicSignal2Async(string signalName, IRawValue[] args) => Task.CompletedTask;
+
+            [WorkflowSignal("CustomName", Dynamic = true)]
+            public Task DynamicSignal3Async(string signalName, IRawValue[] args) => Task.CompletedTask;
+
+            [WorkflowSignal(Dynamic = true)]
+            public Task DynamicSignal4Async(IRawValue[] args) => Task.CompletedTask;
+
+            [WorkflowQuery(Dynamic = true)]
+            public string DynamicQuery1(string signalName, IRawValue[] args) => string.Empty;
+
+            [WorkflowQuery(Dynamic = true)]
+            public string DynamicQuery2(string signalName, IRawValue[] args) => string.Empty;
+
+            [WorkflowQuery("CustomName", Dynamic = true)]
+            public string DynamicQuery3(string signalName, IRawValue[] args) => string.Empty;
+
+            [WorkflowQuery(Dynamic = true)]
+            public string DynamicQuery4(IRawValue[] args) => string.Empty;
         }
     }
 


### PR DESCRIPTION
## What was changed

* Added support for `[Activity(Dynamic = true)]` which gets called on unmatched activity in worker with single `IRawValue[]` parameter
* Added support for `[Workflow(Dynamic = true)]` which gets called on unmatched workflow in worker with single `IRawValue[]` parameter
* Added support for `[WorkflowSignal(Dynamic = true)]` which gets called on unmatched signal in workflow with string signal name and `IRawValue[]` parameter
* Added support for `[WorkflowQuery(Dynamic = true)]` which gets called on unmatched query in workflow with string query name and `IRawValue[]` parameter
* Added `ActivityExecutionContext.PayloadConverter` for use by activities
* Added `Workflow.PayloadConverter` for use by workflows
* Fixed double-encoding issue for schedule workflow updates
* Added `IPayloadConverter.ToRawValue` and `IPayloadConverter.ToValue<T>` extensions to assist in conversion to/from raw values respectively
* Removed embedded payload converter from `RawValue`/`IRawValue` - we make the converters otherwise available and this was needed because people may need to construct these values and the converter was only there for convenience
* Added `Workflow.DynamicSignal` and `Workflow.DynamicQuery` as properties that can be set from within a workflow

## Checklist

1. Closes #27