### PR TITLE
Remove build information from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ jobs:
             runsOn: buildjet-4vcpu-ubuntu-2204-arm
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
-      - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,9 +39,6 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     container: ${{ matrix.container }}
     steps:
-      - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
@@ -106,9 +103,6 @@ jobs:
       - build-bridge-libraries
     runs-on: windows-latest
     steps:
-      - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
@@ -147,9 +141,6 @@ jobs:
             runsOn: buildjet-4vcpu-ubuntu-2204-arm
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
-      - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## What was changed
Remove unused log line that contains an injection vulnerability.

## Why?
To remove the injection vulnerability (despite it not being an auto-run risk, humans are fallible)

## Checklist

How was this tested:
Running dotnet test locally and watching the github workflows (one linter for ubuntu-arm failed because it timed out due to no workers, but nothing should have changed to cause that to fail).