### PR TITLE
Dependency injection hosting extension

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -132,6 +132,8 @@ jobs:
           path: |
             src/Temporalio/bin/Release/*.nupkg
             src/Temporalio/bin/Release/*.snupkg
+            src/Temporalio.Extensions.Hosting/bin/Release/*.nupkg
+            src/Temporalio.Extensions.Hosting/bin/Release/*.snupkg
             src/Temporalio.Extensions.OpenTelemetry/bin/Release/*.nupkg
             src/Temporalio.Extensions.OpenTelemetry/bin/Release/*.snupkg
 

--- a/Temporalio.sln
+++ b/Temporalio.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Temporalio.Tests", "tests\T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Temporalio.Extensions.OpenTelemetry", "src\Temporalio.Extensions.OpenTelemetry\Temporalio.Extensions.OpenTelemetry.csproj", "{D4AC2E2B-1C24-491D-9175-874D448D30FE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Temporalio.Extensions.Hosting", "src\Temporalio.Extensions.Hosting\Temporalio.Extensions.Hosting.csproj", "{E8D1975A-5AF7-4375-BAD0-3C256DCB7F87}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,10 +36,15 @@ Global
 		{D4AC2E2B-1C24-491D-9175-874D448D30FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4AC2E2B-1C24-491D-9175-874D448D30FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D4AC2E2B-1C24-491D-9175-874D448D30FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8D1975A-5AF7-4375-BAD0-3C256DCB7F87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8D1975A-5AF7-4375-BAD0-3C256DCB7F87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8D1975A-5AF7-4375-BAD0-3C256DCB7F87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8D1975A-5AF7-4375-BAD0-3C256DCB7F87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7AE1422A-0937-40D7-9A62-431DD0E2F6D5} = {758B61E2-9AB6-46BF-B53C-16BD140BF56B}
 		{D5F245E2-73A2-49C6-8C52-FBE892E87169} = {F2683DAA-F157-448E-96C8-DF7BB019886D}
 		{D4AC2E2B-1C24-491D-9175-874D448D30FE} = {758B61E2-9AB6-46BF-B53C-16BD140BF56B}
+		{E8D1975A-5AF7-4375-BAD0-3C256DCB7F87} = {758B61E2-9AB6-46BF-B53C-16BD140BF56B}
 	EndGlobalSection
 EndGlobal

--- a/src/Temporalio.Extensions.Hosting/ITemporalWorkerServiceOptionsBuilder.cs
+++ b/src/Temporalio.Extensions.Hosting/ITemporalWorkerServiceOptionsBuilder.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Interface for configuring <see cref="TemporalWorkerServiceOptions" /> for
+    /// <see cref="TemporalWorkerService" />. Methods for using this are as extensions in this
+    /// namespace.
+    /// </summary>
+    public interface ITemporalWorkerServiceOptionsBuilder
+    {
+        /// <summary>
+        /// Gets the task queue for this worker service.
+        /// </summary>
+        string TaskQueue { get; }
+
+        /// <summary>
+        /// Gets the service collection being configured.
+        /// </summary>
+        IServiceCollection Services { get; }
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/README.md
+++ b/src/Temporalio.Extensions.Hosting/README.md
@@ -12,8 +12,8 @@ until the SDK is marked stable.
 
 ## Quick Start
 
-Add the `Temporalio.Extensions.Hosting` package from [NuGet](https://www.nuget.org/packages/Temporalio). For example,
-using the `dotnet` CLI:
+Add the `Temporalio.Extensions.Hosting` package from
+[NuGet](https://www.nuget.org/packages/Temporalio.Extensions.Hosting). For example, using the `dotnet` CLI:
 
     dotnet add package Temporalio.Extensions.Hosting --prerelease
 
@@ -28,7 +28,7 @@ builder.Services.
     AddHostedTemporalWorker(
         "my-temporal-host:7233",
         "my-namespace",
-        "my-task-queue).
+        "my-task-queue").
     AddScopedActivities<MyActivityClass>().
     AddWorkflow<MyWorkflow>();
 
@@ -39,8 +39,8 @@ host.Run();
 
 This creates a hosted Temporal worker which returns a builder. Then `MyActivityClass` is added to the service collection
 as scoped (via
-`TryAddScoped`(https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.extensions.servicecollectiondescriptorextensions.tryaddscoped)) and registered on the worker. Also `MyWorkflow` is registered as a
-workflow on the worker.
+[`TryAddScoped`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.extensions.servicecollectiondescriptorextensions.tryaddscoped))
+and registered on the worker. Also `MyWorkflow` is registered as a workflow on the worker.
 
 This means that for every activity invocation, a new scope is created and the the activity is obtained via the service
 provider. So if it is registered as scoped the activity is created each time but if it registered as singleton it is

--- a/src/Temporalio.Extensions.Hosting/README.md
+++ b/src/Temporalio.Extensions.Hosting/README.md
@@ -1,0 +1,93 @@
+# Hosting and Dependency Injection Support
+
+This extension adds support for worker
+[Generic Host](https://learn.microsoft.com/en-us/dotnet/core/extensions/generic-host)s and activity
+[Dependency Injection](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) to the
+[Temporal .NET SDK](https://github.com/temporalio/sdk-dotnet).
+
+⚠️ UNDER ACTIVE DEVELOPMENT
+
+This SDK is under active development and has not released a stable version yet. APIs may change in incompatible ways
+until the SDK is marked stable.
+
+## Quick Start
+
+Add the `Temporalio.Extensions.Hosting` package from [NuGet](https://www.nuget.org/packages/Temporalio). For example,
+using the `dotnet` CLI:
+
+    dotnet add package Temporalio.Extensions.Hosting --prerelease
+
+To create a worker service, you can do the following:
+
+```csharp
+using Temporalio.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+// Add a hosted Temporal worker which returns a builder to add activities and workflows
+builder.Services.
+    AddHostedTemporalWorker(
+        "my-temporal-host:7233",
+        "my-namespace",
+        "my-task-queue).
+    AddScopedActivities<MyActivityClass>().
+    AddWorkflow<MyWorkflow>();
+
+// Run
+var host = builder.Build();
+host.Run();
+```
+
+This creates a hosted Temporal worker which returns a builder. Then `MyActivityClass` is added to the service collection
+as scoped (via
+`TryAddScoped`(https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.extensions.servicecollectiondescriptorextensions.tryaddscoped)) and registered on the worker. Also `MyWorkflow` is registered as a
+workflow on the worker.
+
+This means that for every activity invocation, a new scope is created and the the activity is obtained via the service
+provider. So if it is registered as scoped the activity is created each time but if it registered as singleton it is
+created only once and reused. The activity's constructor can be used to accept injected dependencies.
+
+Workflows are inherently self-contained, deterministic units of work and therefore should never call anything external.
+Therefore, there is no such thing as dependency injection for workflows, their construction and lifetime is managed by
+Temporal.
+
+## Worker Services
+
+When this extension is depended upon, two overloads for `AddHostedTemporalWorker` are added as extension methods on
+`IServiceCollection` in the `Microsoft.Extensions.DependencyInjection`.
+
+One overload of `AddHostedTemporalWorker`, used in the quick start sample above, accepts the client target host, the
+client namespace, and the worker task queue. This form will connect to a client for the worker. The other overload of
+`AddHostedTemporalWorker` only accepts the worker task queue. In the latter, an `ITemporalClient` can either be set on
+the services container and therefore reused across workers, or the resulting builder can have client options set.
+
+When called, these register a `TemporalWorkerServiceOptions` options class with the container and return a
+`ITemporalWorkerServiceOptionsBuilder` for configuring the worker service options.
+
+For adding activity classes to the service collection and registering activities with the worker, the following
+extension methods exist on the builder each accepting activity type:
+
+* `AddSingletonActivities` - `TryAddSingleton` + register activities on worker
+* `AddScopedActivities` - `TryAddScoped` + register activities on worker
+* `AddTransientActivities` - `TryAddTransient` + register activities on worker
+* `AddStaticActivities` - register activities on worker that all must be static
+* `AddActivitiesInstance` - register activities on worker via an existing instance
+
+These all expect the activity methods to have the `[Activity]` attribute on them. If an activity type is already added
+to the service collection, `ApplyTemporalActivities` can be used to just register the activities on the worker.
+
+For registering workflows on the worker, `AddWorkflow` extension method is available. This does nothing to the service
+collection because the construction and lifecycle of workflows is managed by Temporal. Dependency injection for
+workflows is intentionally not supported.
+
+Other worker and client options can be configured on the builder via the `ConfigureOptions` extension method. With no
+parameters, this returns an `OptionsBuilder<TemporalWorkerServiceOptions>` to use. When provided an action, the options
+are available as parameters that can be configured. `TemporalWorkerServiceOptions` simply extends
+`TemporalWorkerOptions` with an added property for optional client options that can be set to connect a client on worker
+start instead of expecting a `ITemporalClient` to be present on the service collection.
+
+## Activity Dependency Injection without Worker Services
+
+Some users may prefer to manually create the `TemporalWorker` without using host support, but still make their
+activities created via the service provider. `CreateTemporalActivityDefinitions` extension methods are present on
+`IServiceProvider` that will return a collection of `ActivityDefinition` instances for each activity on the type. These
+can be added to the `TemporalWorkerOptions` directly.

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Temporalio.Activities;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Temporal extension methods for <see cref="IServiceProvider" />.
+    /// </summary>
+    public static class ServiceProviderExtensions
+    {
+        /// <summary>
+        /// Create activity definitions for every activity-attributed method on the given type. For
+        /// non-static methods, this will use the service provider to get the instance to call the
+        /// method on.
+        /// </summary>
+        /// <typeparam name="T">Type to create activity definitions from.</typeparam>
+        /// <param name="provider">Service provider for creating the instance for non-static
+        /// activities.</param>
+        /// <returns>Collection of activity definitions.</returns>
+        public static IReadOnlyCollection<ActivityDefinition> CreateTemporalActivityDefinitions<T>(
+            this IServiceProvider provider) =>
+            provider.CreateTemporalActivityDefinitions(typeof(T));
+
+        /// <summary>
+        /// Create activity definitions for every activity-attributed method on the given type. For
+        /// non-static methods, this will use the service provider to get the instance to call the
+        /// method on.
+        /// </summary>
+        /// <param name="provider">Service provider for creating the instance for non-static
+        /// activities.</param>
+        /// <param name="type">Type to create activity definitions from.</param>
+        /// <returns>Collection of activity definitions.</returns>
+        public static IReadOnlyCollection<ActivityDefinition> CreateTemporalActivityDefinitions(
+            this IServiceProvider provider, Type type) =>
+            type.
+                GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance).
+                Where(method => method.IsDefined(typeof(ActivityAttribute))).
+                Select(method => provider.CreateTemporalActivityDefinition(type, method)).
+                ToList();
+
+        /// <summary>
+        /// Create activity definition for the given activity-attributed method on the given
+        /// instance type. If the method is non-static, this will use the service provider to get
+        /// the instance to call the method on.
+        /// </summary>
+        /// <param name="provider">Service provider for creating the instance if the method is
+        /// non-static.</param>
+        /// <param name="instanceType">Type of the instance.</param>
+        /// <param name="method">Method to create activity definition from.</param>
+        /// <returns>Created definition.</returns>
+        public static ActivityDefinition CreateTemporalActivityDefinition(
+            this IServiceProvider provider, Type instanceType, MethodInfo method)
+        {
+            // Invoker can be async (i.e. returns Task<object?>)
+            Func<object?[], Task<object>> invoker = async args =>
+            {
+                // If static, just invoke and unwrap exception
+                if (method.IsStatic)
+                {
+                    try
+                    {
+                        return method.Invoke(null, args);
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        ExceptionDispatchInfo.Capture(e.InnerException!).Throw();
+                        // Unreachable
+                        throw new InvalidOperationException("Unreachable");
+                    }
+                }
+                // Wrap in a scope
+                using (var scope = provider.CreateScope())
+                {
+                    object? result;
+                    try
+                    {
+                        result = method.Invoke(scope.ServiceProvider.GetRequiredService(instanceType), args);
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        ExceptionDispatchInfo.Capture(e.InnerException!).Throw();
+                        // Unreachable
+                        throw new InvalidOperationException("Unreachable");
+                    }
+                    // In order to make sure the scope lasts the life of the activity, we need to
+                    // wait on the task if it's a task
+                    if (result is Task resultTask)
+                    {
+                        await resultTask.ConfigureAwait(false);
+                        // We have to use reflection to extract value if it's a Task<>
+                        var resultTaskType = resultTask.GetType();
+                        if (resultTaskType.IsGenericType)
+                        {
+                            result = resultTaskType.GetProperty("Result")!.GetValue(resultTask);
+                        }
+                        else
+                        {
+                            result = ValueTuple.Create();
+                        }
+                    }
+                    return result;
+                }
+            };
+            return ActivityDefinition.Create(method, invoker);
+        }
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/TemporalHostingServiceCollectionExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalHostingServiceCollectionExtensions.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Hosting;
+using Temporalio.Extensions.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Temporal extensions for <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class TemporalHostingServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Add a hosted Temporal worker service as a <see cref="IHostedService" /> that contains
+        /// its own client that connects with the given target and namespace. To use an injected
+        /// <see cref="Temporalio.Client.ITemporalClient" />, use
+        /// <see cref="AddHostedTemporalWorker(IServiceCollection, string)" />. The worker service
+        /// will be registered as a singleton. The result is an options builder that can be used to
+        /// configure the service.
+        /// </summary>
+        /// <param name="services">Service collection to create hosted worker on.</param>
+        /// <param name="clientTargetHost">Client target host to connect to when starting the
+        /// worker.</param>
+        /// <param name="clientNamespace">Client namespace to connect to when starting the worker.
+        /// </param>
+        /// <param name="taskQueue">Task queue for the worker.</param>
+        /// <returns>Options builder to configure the service.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddHostedTemporalWorker(
+            this IServiceCollection services,
+            string clientTargetHost,
+            string clientNamespace,
+            string taskQueue) =>
+            services.AddHostedTemporalWorker(taskQueue).ConfigureOptions(options =>
+                options.ClientOptions = new(clientTargetHost) { Namespace = clientNamespace });
+
+        /// <summary>
+        /// Add a hosted Temporal worker service as a <see cref="IHostedService" /> that expects
+        /// an injected <see cref="Temporalio.Client.ITemporalClient" /> (or the returned builder
+        /// can have client options populated). Use
+        /// <see cref="AddHostedTemporalWorker(IServiceCollection, string, string, string)" /> to
+        /// not expect an injected instance and instead connect to a client on worker start. The
+        /// worker service will be registered as a singleton. The result is an options builder that
+        /// can be used to configure the service.
+        /// </summary>
+        /// <param name="services">Service collection to create hosted worker on.</param>
+        /// <param name="taskQueue">Task queue for the worker.</param>
+        /// <returns>Options builder to configure the service.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddHostedTemporalWorker(
+            this IServiceCollection services, string taskQueue)
+        {
+            // We have to use AddSingleton instead of AddHostedService because the latter does
+            // not allow us to register multiple of the same type, see
+            // https://github.com/dotnet/runtime/issues/38751
+            services.AddSingleton<IHostedService>(provider =>
+                ActivatorUtilities.CreateInstance<TemporalWorkerService>(provider, taskQueue));
+            return new TemporalWorkerServiceOptionsBuilder(taskQueue, services).ConfigureOptions(
+                options => options.TaskQueue = taskQueue);
+        }
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerService.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerService.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Temporalio.Client;
+using Temporalio.Worker;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Temporal worker implementation as a <see cref="BackgroundService" />.
+    /// </summary>
+    public class TemporalWorkerService : BackgroundService
+    {
+        // These two are mutually exclusive
+        private readonly TemporalClientConnectOptions? newClientOptions;
+        private readonly ITemporalClient? existingClient;
+        private readonly TemporalWorkerOptions workerOptions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalWorkerService"/> class using
+        /// service options. This will create a client on worker start and therefore
+        /// <see cref="TemporalWorkerServiceOptions.ClientOptions" /> must be non-null. To provide
+        /// a client, use
+        /// <see cref="TemporalWorkerService(ITemporalClient, TemporalWorkerOptions)" />.
+        /// </summary>
+        /// <param name="options">Options to use to create the worker service.</param>
+        public TemporalWorkerService(TemporalWorkerServiceOptions options)
+        {
+            newClientOptions = options.ClientOptions ?? throw new ArgumentException(
+                "Client options is required", nameof(options));
+            workerOptions = options;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalWorkerService"/> class using
+        /// client options and worker options. This will create a client on worker start. To provide
+        /// a client, use
+        /// <see cref="TemporalWorkerService(ITemporalClient, TemporalWorkerOptions)" />.
+        /// </summary>
+        /// <param name="clientOptions">Options to connect a client.</param>
+        /// <param name="workerOptions">Options for the worker.</param>
+        public TemporalWorkerService(
+            TemporalClientConnectOptions clientOptions,
+            TemporalWorkerOptions workerOptions)
+        {
+            newClientOptions = clientOptions;
+            this.workerOptions = workerOptions;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalWorkerService"/> class using
+        /// an existing client and worker options.
+        /// </summary>
+        /// <param name="client">Client to use.</param>
+        /// <param name="workerOptions">Options for the worker.</param>
+        public TemporalWorkerService(
+            ITemporalClient client,
+            TemporalWorkerOptions workerOptions)
+        {
+            existingClient = client;
+            this.workerOptions = workerOptions;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalWorkerService"/> class using
+        /// options and possibly an existing client. This constructor is mostly used by DI
+        /// containers. The task queue is used as the name on the options monitor to lookup the
+        /// options for the worker service.
+        /// </summary>
+        /// <param name="taskQueue">Task queue which is the options name.</param>
+        /// <param name="optionsMonitor">Used to lookup the options to build the worker with.
+        /// </param>
+        /// <param name="existingClient">Existing client to use if the options don't specify
+        /// client connection options.</param>
+        /// <param name="loggerFactory">Logger factory to use if there is no logger factory on the
+        /// existing client, or the client connect options, or the worker options.</param>
+        [ActivatorUtilitiesConstructor]
+        public TemporalWorkerService(
+            string taskQueue,
+            IOptionsMonitor<TemporalWorkerServiceOptions> optionsMonitor,
+            ITemporalClient? existingClient = null,
+            ILoggerFactory? loggerFactory = null)
+        {
+            var options = (TemporalWorkerServiceOptions)optionsMonitor.Get(taskQueue).Clone();
+            newClientOptions = options.ClientOptions;
+            if (newClientOptions == null)
+            {
+                this.existingClient = existingClient;
+                if (existingClient == null)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot start worker service with no client and no client connect options");
+                }
+            }
+
+            workerOptions = options;
+            // If a logging factory is provided and it is not on the client options already or
+            // worker options already, set it on the worker options
+            if (loggerFactory != null &&
+                workerOptions.LoggerFactory == null &&
+                newClientOptions?.LoggerFactory == null &&
+                existingClient?.Options?.LoggerFactory == null)
+            {
+                options.LoggerFactory = loggerFactory;
+            }
+        }
+
+        /// <inheritdoc />
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var client = existingClient ?? await TemporalClient.ConnectAsync(newClientOptions!).ConfigureAwait(false);
+            using var worker = new TemporalWorker(client, workerOptions);
+            await worker.ExecuteAsync(stoppingToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptions.cs
@@ -1,0 +1,45 @@
+using Temporalio.Client;
+using Temporalio.Worker;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Extension of <see cref="TemporalWorkerOptions" /> for Temporal worker service that also
+    /// includes optional client connection options.
+    /// </summary>
+    public class TemporalWorkerServiceOptions : TemporalWorkerOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalWorkerServiceOptions"/> class.
+        /// </summary>
+        public TemporalWorkerServiceOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalWorkerServiceOptions"/> class.
+        /// </summary>
+        /// <param name="taskQueue">Task queue for the worker.</param>
+        public TemporalWorkerServiceOptions(string taskQueue)
+            : base(taskQueue)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the client options. If set, the client will be connected on worker start.
+        /// If not set, the worker service will expect an existing client to be present.
+        /// </summary>
+        public TemporalClientConnectOptions? ClientOptions { get; set; }
+
+        /// <inheritdoc />
+        public override object Clone()
+        {
+            var options = (TemporalWorkerServiceOptions)base.Clone();
+            if (ClientOptions != null)
+            {
+                options.ClientOptions = (TemporalClientConnectOptions)ClientOptions.Clone();
+            }
+            return options;
+        }
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilder.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilder.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Implementation of <see cref="ITemporalWorkerServiceOptionsBuilder" />.
+    /// </summary>
+    public class TemporalWorkerServiceOptionsBuilder : ITemporalWorkerServiceOptionsBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalWorkerServiceOptionsBuilder" />
+        /// class.
+        /// </summary>
+        /// <param name="taskQueue">Task queue for the worker.</param>
+        /// <param name="services">Service collection being configured.</param>
+        public TemporalWorkerServiceOptionsBuilder(string taskQueue, IServiceCollection services)
+        {
+            TaskQueue = taskQueue;
+            Services = services;
+        }
+
+        /// <inheritdoc />
+        public string TaskQueue { get; private init; }
+
+        /// <inheritdoc />
+        public IServiceCollection Services { get; private init; }
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
@@ -1,0 +1,222 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Extension methods for <see cref="ITemporalWorkerServiceOptionsBuilder" /> to configure
+    /// worker services.
+    /// </summary>
+    public static class TemporalWorkerServiceOptionsBuilderExtensions
+    {
+        /// <summary>
+        /// Register the given type as a singleton if not already done and all activities of the
+        /// given type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton{TService}(IServiceCollection)" />
+        /// +
+        /// <see cref="ApplyTemporalActivities{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// </summary>
+        /// <typeparam name="T">Type to register activities for.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddSingletonActivities<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) => builder.AddSingletonActivities(typeof(T));
+
+        /// <summary>
+        /// Register the given type as a singleton if not already done and all activities of the
+        /// given type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton(IServiceCollection, Type)" />
+        /// +
+        /// <see cref="ApplyTemporalActivities(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="type">Type to register activities for.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddSingletonActivities(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type type)
+        {
+            builder.Services.TryAddSingleton(type);
+            return builder.ApplyTemporalActivities(type);
+        }
+
+        /// <summary>
+        /// Register the given type as scoped if not already done and all activities of the given
+        /// type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddScoped{TService}(IServiceCollection)" />
+        /// +
+        /// <see cref="ApplyTemporalActivities{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// </summary>
+        /// <typeparam name="T">Type to register activities for.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddScopedActivities<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) => builder.AddScopedActivities(typeof(T));
+
+        /// <summary>
+        /// Register the given type as a scoped if not already done and all activities of the given
+        /// type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddScoped(IServiceCollection, Type)" />
+        /// +
+        /// <see cref="ApplyTemporalActivities(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="type">Type to register activities for.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddScopedActivities(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type type)
+        {
+            builder.Services.TryAddScoped(type);
+            return builder.ApplyTemporalActivities(type);
+        }
+
+        /// <summary>
+        /// Register the given type as transient if not already done and all activities of the given
+        /// type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddTransient{TService}(IServiceCollection)" />
+        /// +
+        /// <see cref="ApplyTemporalActivities{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// </summary>
+        /// <typeparam name="T">Type to register activities for.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddTransientActivities<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) => builder.AddTransientActivities(typeof(T));
+
+        /// <summary>
+        /// Register the given type as transient if not already done and all activities of the given
+        /// type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddTransient(IServiceCollection, Type)" />
+        /// +
+        /// <see cref="ApplyTemporalActivities(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="type">Type to register activities for.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddTransientActivities(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type type)
+        {
+            builder.Services.TryAddTransient(type);
+            return builder.ApplyTemporalActivities(type);
+        }
+
+        /// <summary>
+        /// Register the given type's activities. The activity methods must all be static.
+        /// </summary>
+        /// <typeparam name="T">Type to register activities for.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddStaticActivities<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) => builder.AddStaticActivities(typeof(T));
+
+        /// <summary>
+        /// Register the given type's activities. The activity methods must all be static.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="type">Type to register activities for.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddStaticActivities(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type type) =>
+            builder.ConfigureOptions(options => options.AddAllActivities(type, null));
+
+        /// <summary>
+        /// Register the given type's activities with an existing instance. The given instance will
+        /// be used to invoke non-static activity methods.
+        /// </summary>
+        /// <typeparam name="T">Type to register activities for.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="instance">Instance to use.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddActivitiesInstance<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder, T instance) =>
+            builder.AddActivitiesInstance(typeof(T), instance!);
+
+        /// <summary>
+        /// Register the given type's activities with an existing instance. The given instance will
+        /// be used to invoke non-static activity methods.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="type">Type to register activities for.</param>
+        /// <param name="instance">Instance to use.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddActivitiesInstance(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type type, object instance) =>
+            builder.ConfigureOptions(options => options.AddAllActivities(type, instance));
+
+        /// <summary>
+        /// Add the given workflow type as a workflow on this worker service.
+        /// </summary>
+        /// <typeparam name="T">Workflow type.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddWorkflow<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) => builder.AddWorkflow(typeof(T));
+
+        /// <summary>
+        /// Add the given workflow type as a workflow on this worker service.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="type">Workflow type.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddWorkflow(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type type) =>
+            builder.ConfigureOptions(options => options.AddWorkflow(type));
+
+        /// <summary>
+        /// Get an options builder to configure worker service options.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Options builder.</returns>
+        public static OptionsBuilder<TemporalWorkerServiceOptions> ConfigureOptions(
+            this ITemporalWorkerServiceOptionsBuilder builder) =>
+            builder.Services.AddOptions<TemporalWorkerServiceOptions>(builder.TaskQueue);
+
+        /// <summary>
+        /// Configure worker service options using an action.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="configure">Configuration action.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder ConfigureOptions(
+            this ITemporalWorkerServiceOptionsBuilder builder,
+            Action<TemporalWorkerServiceOptions> configure)
+        {
+            builder.ConfigureOptions().Configure(configure);
+            return builder;
+        }
+
+        /// <summary>
+        /// Register the given type's activities. This uses the service provider to create the
+        /// instance for non-static methods, but does not register the type/instance with the
+        /// service collection.
+        /// </summary>
+        /// <typeparam name="T">Type to register activities for.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder ApplyTemporalActivities<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) =>
+            builder.ApplyTemporalActivities(typeof(T));
+
+        /// <summary>
+        /// Register the given type's activities. This uses the service provider to create the
+        /// instance for non-static methods, but does not register the type/instance with the
+        /// service collection.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="type">Type to register activities for.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder ApplyTemporalActivities(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type type)
+        {
+            builder.ConfigureOptions().PostConfigure<IServiceProvider>((options, provider) =>
+            {
+                foreach (var defn in provider.CreateTemporalActivityDefinitions(type))
+                {
+                    options.AddActivity(defn);
+                }
+            });
+            return builder;
+        }
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj
+++ b/src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Temporal SDK .NET Hosting and Dependency Injection Extension</Description>
+    <EnablePackageValidation Condition="'$(TargetFramework)' == 'netcoreapp3.1'">true</EnablePackageValidation>
+    <IncludeSymbols>true</IncludeSymbols>
+    <LangVersion>9.0</LangVersion>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Temporalio\Temporalio.csproj" />
+  </ItemGroup>
+
+  <!-- Pack the README -->
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/src/Temporalio.Extensions.Hosting/_LanguageHelpers.cs
+++ b/src/Temporalio.Extensions.Hosting/_LanguageHelpers.cs
@@ -1,0 +1,11 @@
+#pragma warning disable SA1649
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Needed for init-only properties to work on older .NET versions.
+    /// </summary>
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/src/Temporalio.Extensions.OpenTelemetry/README.md
+++ b/src/Temporalio.Extensions.OpenTelemetry/README.md
@@ -17,8 +17,8 @@ until the SDK is marked stable.
 
 ## Quick Start
 
-Add the `Temporalio.Extensions.OpenTelemetry` package from [NuGet](https://www.nuget.org/packages/Temporalio). For
-example, using the `dotnet` CLI:
+Add the `Temporalio.Extensions.OpenTelemetry` package from
+[NuGet](https://www.nuget.org/packages/Temporalio.Extensions.OpenTelemetry). For example, using the `dotnet` CLI:
 
     dotnet add package Temporalio.Extensions.OpenTelemetry --prerelease
 

--- a/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
@@ -1,0 +1,186 @@
+#pragma warning disable SA1201, SA1204 // We want to have classes near their tests
+namespace Temporalio.Tests.Extensions.Hosting;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Temporalio.Activities;
+using Temporalio.Client;
+using Temporalio.Extensions.Hosting;
+using Temporalio.Workflows;
+using Xunit;
+using Xunit.Abstractions;
+
+public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
+{
+    public TemporalWorkerServiceTests(ITestOutputHelper output, WorkflowEnvironment env)
+        : base(output, env)
+    {
+    }
+
+    public class DatabaseClient
+    {
+        private int counter = 5;
+
+        public async Task<string> SelectSomethingAsync() => $"something-{++counter}";
+    }
+
+    public class DatabaseActivities
+    {
+        private readonly DatabaseClient databaseClient;
+
+        public DatabaseActivities(DatabaseClient databaseClient) =>
+            this.databaseClient = databaseClient;
+
+        [Activity]
+        public async Task<List<string>> DoThingsAsync() => new()
+        {
+            await databaseClient.SelectSomethingAsync(),
+            await databaseClient.SelectSomethingAsync(),
+        };
+    }
+
+    [Workflow]
+    public class DatabaseWorkflow
+    {
+        [WorkflowRun]
+        public async Task<List<string>> RunAsync()
+        {
+            var list = await Workflow.ExecuteActivityAsync(
+                (DatabaseActivities act) => act.DoThingsAsync(),
+                new() { StartToCloseTimeout = TimeSpan.FromMinutes(5) });
+            list.AddRange(await Workflow.ExecuteActivityAsync(
+                (DatabaseActivities act) => act.DoThingsAsync(),
+                new() { StartToCloseTimeout = TimeSpan.FromMinutes(5) }));
+            return list;
+        }
+    }
+
+    [Fact]
+    public async Task TemporalWorkerService_ExecuteAsync_SimpleWorker()
+    {
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var host = Host.CreateDefaultBuilder().
+            ConfigureServices(services => services.
+                AddSingleton(Client).
+                AddScoped<DatabaseClient>().
+                AddHostedTemporalWorker(taskQueue).
+                AddScopedActivities<DatabaseActivities>().
+                AddWorkflow<DatabaseWorkflow>()).
+            Build();
+
+        // Start the host
+        using var tokenSource = new CancellationTokenSource();
+        var hostTask = Task.Run(() => host.RunAsync(tokenSource.Token));
+
+        // Execute the workflow
+        var result = await Client.ExecuteWorkflowAsync(
+            (DatabaseWorkflow wf) => wf.RunAsync(),
+            new($"wf-{Guid.NewGuid()}", taskQueue));
+        // Single activity calls use the same client but different calls use different clients
+        Assert.Equal(
+            new List<string> { "something-6", "something-7", "something-6", "something-7" },
+            result);
+    }
+
+    public class SingletonCounter
+    {
+        public int Counter { get; set; } = 5;
+
+        [Activity("singleton-increment-and-get")]
+        public string IncrementAndGet() =>
+            $"tq: {ActivityExecutionContext.Current.Info.TaskQueue}, counter: {++Counter}";
+    }
+
+    public class ScopedCounter
+    {
+        public int Counter { get; set; } = 5;
+
+        [Activity("scoped-increment-and-get")]
+        public string IncrementAndGet() =>
+            $"tq: {ActivityExecutionContext.Current.Info.TaskQueue}, counter: {++Counter}";
+    }
+
+    [Workflow]
+    public class MultiTaskQueueWorkflow
+    {
+        [WorkflowRun]
+        public async Task<Dictionary<string, string>> RunAsync(string otherTaskQueue)
+        {
+            var opts = new ActivityOptions() { ScheduleToCloseTimeout = TimeSpan.FromMinutes(5) };
+            var otherOpts = new ActivityOptions()
+            {
+                TaskQueue = otherTaskQueue,
+                ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+            };
+            return new Dictionary<string, string>()
+            {
+                ["singleton1"] = await Workflow.ExecuteActivityAsync(
+                    (SingletonCounter act) => act.IncrementAndGet(), opts),
+                ["singleton2"] = await Workflow.ExecuteActivityAsync(
+                    (SingletonCounter act) => act.IncrementAndGet(), opts),
+                ["scoped1"] = await Workflow.ExecuteActivityAsync(
+                    (ScopedCounter act) => act.IncrementAndGet(), opts),
+                ["scoped2"] = await Workflow.ExecuteActivityAsync(
+                    (ScopedCounter act) => act.IncrementAndGet(), opts),
+                ["singleton-other1"] = await Workflow.ExecuteActivityAsync(
+                    (SingletonCounter act) => act.IncrementAndGet(), otherOpts),
+                ["singleton-other2"] = await Workflow.ExecuteActivityAsync(
+                    (SingletonCounter act) => act.IncrementAndGet(), otherOpts),
+                ["scoped-other1"] = await Workflow.ExecuteActivityAsync(
+                    (ScopedCounter act) => act.IncrementAndGet(), otherOpts),
+                ["scoped-other2"] = await Workflow.ExecuteActivityAsync(
+                    (ScopedCounter act) => act.IncrementAndGet(), otherOpts),
+            };
+        }
+    }
+
+    [Fact]
+    public async Task TemporalWorkerService_ExecuteAsync_MultipleWorkers()
+    {
+        var taskQueue1 = $"tq-{Guid.NewGuid()}";
+        var taskQueue2 = $"tq-{Guid.NewGuid()}";
+
+        var bld = Host.CreateApplicationBuilder();
+        // Add the first worker with the workflow and client already DI'd
+        bld.Services.
+            AddSingleton(Client).
+            AddHostedTemporalWorker(taskQueue1).
+            AddSingletonActivities<SingletonCounter>().
+            AddScopedActivities<ScopedCounter>().
+            AddWorkflow<MultiTaskQueueWorkflow>();
+
+        // Add another worker with the client target info and only activities
+        bld.Services.
+            AddHostedTemporalWorker(
+                clientTargetHost: Client.Connection.Options.TargetHost!,
+                clientNamespace: Client.Options.Namespace,
+                taskQueue: taskQueue2).
+            AddSingletonActivities<SingletonCounter>().
+            AddScopedActivities<ScopedCounter>();
+
+        // Start the host
+        using var tokenSource = new CancellationTokenSource();
+        using var host = bld.Build();
+        var hostTask = Task.Run(() => host.RunAsync(tokenSource.Token));
+
+        // Execute the workflow
+        var result = await Client.ExecuteWorkflowAsync(
+            (MultiTaskQueueWorkflow wf) => wf.RunAsync(taskQueue2),
+            new($"wf-{Guid.NewGuid()}", taskQueue1));
+        Assert.Equal(
+            new Dictionary<string, string>()
+            {
+                // Singletons share
+                ["singleton1"] = $"tq: {taskQueue1}, counter: 6",
+                ["singleton2"] = $"tq: {taskQueue1}, counter: 7",
+                ["singleton-other1"] = $"tq: {taskQueue2}, counter: 8",
+                ["singleton-other2"] = $"tq: {taskQueue2}, counter: 9",
+                // Scoped do not share
+                ["scoped1"] = $"tq: {taskQueue1}, counter: 6",
+                ["scoped2"] = $"tq: {taskQueue1}, counter: 6",
+                ["scoped-other1"] = $"tq: {taskQueue2}, counter: 6",
+                ["scoped-other2"] = $"tq: {taskQueue2}, counter: 6",
+            },
+            result);
+    }
+}

--- a/tests/Temporalio.Tests/Temporalio.Tests.csproj
+++ b/tests/Temporalio.Tests/Temporalio.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Temporalio\Temporalio.csproj" />
+    <ProjectReference Include="..\..\src\Temporalio.Extensions.Hosting\Temporalio.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Temporalio.Extensions.OpenTelemetry\Temporalio.Extensions.OpenTelemetry.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## What was changed

Added a new `Temporalio.Extensions.Hosting` project which supports hosted worker services (via [.NET generic hosts](https://learn.microsoft.com/en-us/dotnet/core/extensions/generic-host)) and activity dependency injection (via [.NET dependency injection](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection)). See the README of the project in this PR for more details.

## Checklist

1. Closes #46