### PR TITLE
Random with 64-bit seed

### DIFF
--- a/src/Temporalio/Bridge/Cargo.lock
+++ b/src/Temporalio/Bridge/Cargo.lock
@@ -1785,6 +1785,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,6 +2293,8 @@ dependencies = [
  "parking_lot",
  "prost",
  "prost-types",
+ "rand",
+ "rand_pcg",
  "temporal-client",
  "temporal-sdk-core",
  "temporal-sdk-core-api",

--- a/src/Temporalio/Bridge/Cargo.toml
+++ b/src/Temporalio/Bridge/Cargo.toml
@@ -15,6 +15,11 @@ log = "0.4"
 parking_lot = "0.12"
 prost = "0.11"
 prost-types = "0.11"
+# We rely on Cargo semver rules not updating a 0.x to 0.y. Per the rand
+# documentation, before 1.0, minor 0.x updates _can_ break portability which can
+# cause non-determinism.
+rand = "0.8.5"
+rand_pcg = "0.3.1"
 temporal-client = { version = "0.1.0", path = "./sdk-core/client" }
 temporal-sdk-core = { version = "0.1.0", path = "./sdk-core/core" }
 temporal-sdk-core-api = { version = "0.1.0", path = "./sdk-core/core-api" }

--- a/src/Temporalio/Bridge/DeterministicRandom.cs
+++ b/src/Temporalio/Bridge/DeterministicRandom.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Temporalio.Bridge
+{
+    /// <summary>
+    /// Core-owned random number generator. Not thread safe.
+    /// </summary>
+    internal class DeterministicRandom : SafeHandle
+    {
+        private readonly unsafe Interop.Random* ptr;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeterministicRandom" /> class.
+        /// </summary>
+        /// <param name="seed">Seed to initialize with.</param>
+        public DeterministicRandom(ulong seed)
+            : base(IntPtr.Zero, true)
+        {
+            unsafe
+            {
+                ptr = Interop.Methods.random_new(seed);
+                SetHandle((IntPtr)ptr);
+            }
+        }
+
+        /// <inheritdoc />
+        public override unsafe bool IsInvalid => false;
+
+        /// <summary>
+        /// Generate a random integer within the given range.
+        /// </summary>
+        /// <param name="min">Inclusive minimum.</param>
+        /// <param name="max">Maximum.</param>
+        /// <param name="maxInclusive">Whether max is inclusive or not.</param>
+        /// <returns>Random integer.</returns>
+        public int RandomInt32(int min, int max, bool maxInclusive)
+        {
+            unsafe
+            {
+                return Interop.Methods.random_int32_range(
+                    ptr, min, max, (byte)(maxInclusive ? 1 : 0));
+            }
+        }
+
+        /// <summary>
+        /// Generate a random double within the given range.
+        /// </summary>
+        /// <param name="min">Inclusive minimum.</param>
+        /// <param name="max">Maximum.</param>
+        /// <param name="maxInclusive">Whether max is inclusive or not.</param>
+        /// <returns>Random double.</returns>
+        public double RandomDouble(double min, double max, bool maxInclusive)
+        {
+            unsafe
+            {
+                return Interop.Methods.random_double_range(
+                    ptr, min, max, (byte)(maxInclusive ? 1 : 0));
+            }
+        }
+
+        /// <summary>
+        /// Fill the given array with random bytes.
+        /// </summary>
+        /// <param name="bytes">Byte array to fill.</param>
+        public void RandomFillBytes(byte[] bytes)
+        {
+            using (var scope = new Scope())
+            {
+                unsafe
+                {
+                    Interop.Methods.random_fill_bytes(ptr, scope.ByteArray(bytes));
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override unsafe bool ReleaseHandle()
+        {
+            Interop.Methods.random_free(ptr);
+            return true;
+        }
+    }
+}

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -23,6 +23,10 @@ namespace Temporalio.Bridge.Interop
     {
     }
 
+    internal partial struct Random
+    {
+    }
+
     internal partial struct Runtime
     {
     }
@@ -375,6 +379,23 @@ namespace Temporalio.Bridge.Interop
 
         [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void client_rpc_call([NativeTypeName("struct Client *")] Client* client, [NativeTypeName("const struct RpcCallOptions *")] RpcCallOptions* options, void* user_data, [NativeTypeName("ClientRpcCallCallback")] IntPtr callback);
+
+        [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("struct Random *")]
+        public static extern Random* random_new([NativeTypeName("uint64_t")] ulong seed);
+
+        [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void random_free([NativeTypeName("struct Random *")] Random* random);
+
+        [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("int32_t")]
+        public static extern int random_int32_range([NativeTypeName("struct Random *")] Random* random, [NativeTypeName("int32_t")] int min, [NativeTypeName("int32_t")] int max, [NativeTypeName("bool")] byte max_inclusive);
+
+        [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern double random_double_range([NativeTypeName("struct Random *")] Random* random, double min, double max, [NativeTypeName("bool")] byte max_inclusive);
+
+        [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void random_fill_bytes([NativeTypeName("struct Random *")] Random* random, [NativeTypeName("struct ByteArrayRef")] ByteArrayRef bytes);
 
         [DllImport("temporal_sdk_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct RuntimeOrFail")]

--- a/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
+++ b/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
@@ -18,6 +18,8 @@ typedef struct Client Client;
 
 typedef struct EphemeralServer EphemeralServer;
 
+typedef struct Random Random;
+
 typedef struct Runtime Runtime;
 
 typedef struct Worker Worker;
@@ -271,6 +273,16 @@ void client_rpc_call(struct Client *client,
                      const struct RpcCallOptions *options,
                      void *user_data,
                      ClientRpcCallCallback callback);
+
+struct Random *random_new(uint64_t seed);
+
+void random_free(struct Random *random);
+
+int32_t random_int32_range(struct Random *random, int32_t min, int32_t max, bool max_inclusive);
+
+double random_double_range(struct Random *random, double min, double max, bool max_inclusive);
+
+void random_fill_bytes(struct Random *random, struct ByteArrayRef bytes);
 
 struct RuntimeOrFail runtime_new(const struct RuntimeOptions *options);
 

--- a/src/Temporalio/Bridge/src/client.rs
+++ b/src/Temporalio/Bridge/src/client.rs
@@ -141,7 +141,10 @@ pub extern "C" fn client_free(client: *mut Client) {
 #[no_mangle]
 pub extern "C" fn client_update_metadata(client: *mut Client, metadata: ByteArrayRef) {
     let client = unsafe { &*client };
-    client.core.get_client().set_headers(metadata.to_string_map_on_newlines());
+    client
+        .core
+        .get_client()
+        .set_headers(metadata.to_string_map_on_newlines());
 }
 
 #[repr(C)]

--- a/src/Temporalio/Bridge/src/lib.rs
+++ b/src/Temporalio/Bridge/src/lib.rs
@@ -9,6 +9,7 @@
 )]
 
 pub mod client;
+pub mod random;
 pub mod runtime;
 pub mod testing;
 pub mod worker;
@@ -24,6 +25,10 @@ pub struct ByteArrayRef {
 impl ByteArrayRef {
     fn to_slice(&self) -> &[u8] {
         unsafe { std::slice::from_raw_parts(self.data, self.size) }
+    }
+
+    fn to_slice_mut(&self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.data as *mut u8, self.size) }
     }
 
     fn to_vec(&self) -> Vec<u8> {

--- a/src/Temporalio/Bridge/src/random.rs
+++ b/src/Temporalio/Bridge/src/random.rs
@@ -1,0 +1,61 @@
+use crate::ByteArrayRef;
+use rand::{Rng, SeedableRng};
+use rand_pcg::Pcg64Mcg;
+
+pub struct Random {
+    // We choose this algorithm because it is 64-bit fast and a well supported,
+    // deterministic, portable standard. We do not need the security of a CSPRNG
+    // like ChaCha20.
+    rand: Pcg64Mcg,
+}
+
+#[no_mangle]
+pub extern "C" fn random_new(seed: u64) -> *mut Random {
+    Box::into_raw(Box::new(Random {
+        rand: Pcg64Mcg::seed_from_u64(seed),
+    }))
+}
+
+#[no_mangle]
+pub extern "C" fn random_free(random: *mut Random) {
+    unsafe {
+        let _ = Box::from_raw(random);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn random_int32_range(
+    random: *mut Random,
+    min: i32,
+    max: i32,
+    max_inclusive: bool,
+) -> i32 {
+    let random = unsafe { &mut *random };
+    if max_inclusive {
+        random.rand.gen_range(min..=max)
+    } else {
+        random.rand.gen_range(min..max)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn random_double_range(
+    random: *mut Random,
+    min: f64,
+    max: f64,
+    max_inclusive: bool,
+) -> f64 {
+    let random = unsafe { &mut *random };
+    if max_inclusive {
+        random.rand.gen_range(min..=max)
+    } else {
+        random.rand.gen_range(min..max)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn random_fill_bytes(random: *mut Random, bytes: ByteArrayRef) {
+    let random = unsafe { &mut *random };
+    // Confirmed with the algorithm this won't fail, so try_fill not needed
+    random.rand.fill(bytes.to_slice_mut());
+}

--- a/src/Temporalio/Common/DeterministicRandom.cs
+++ b/src/Temporalio/Common/DeterministicRandom.cs
@@ -1,0 +1,60 @@
+#pragma warning disable CA1001 // We know that we have an underlying random handle we instead dispose on destruct
+using System;
+
+namespace Temporalio.Common
+{
+    /// <summary>
+    /// Implementation of <see cref="Random" /> that is deterministic and supports a 64-bit seed,
+    /// unlike the standard implementation which is only 32-bit. Internally this uses a
+    /// well-known/tested PCG-based algorithm (specifically, 128-bit MCG PCG-XSL-RR aka pcg64_fast),
+    /// see https://www.pcg-random.org/. Changing of this internal algorithm in any way is
+    /// considered a backwards incompatible alteration.
+    /// </summary>
+    public class DeterministicRandom : Random
+    {
+        private readonly Bridge.DeterministicRandom underlying;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeterministicRandom" /> class.
+        /// </summary>
+        /// <param name="seed">Seed for this random.</param>
+        public DeterministicRandom(ulong seed) => underlying = new(seed);
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="DeterministicRandom"/> class.
+        /// </summary>
+        ~DeterministicRandom() => underlying.Dispose();
+
+        /// <inheritdoc />
+        public override int Next() => Next(int.MaxValue);
+
+        /// <inheritdoc />
+        public override int Next(int maxValue) => Next(0, maxValue);
+
+        /// <inheritdoc />
+        public override int Next(int minValue, int maxValue) =>
+            underlying.RandomInt32(minValue, maxValue, false);
+
+        /// <inheritdoc />
+        public override double NextDouble() => Sample();
+
+        /// <inheritdoc />
+        public override void NextBytes(byte[] buffer) => underlying.RandomFillBytes(buffer);
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Intentionally not implemented. Currently filling byte spans spans is unsupported.
+        /// </summary>
+        /// <param name="buffer">Buffer.</param>
+        public override void NextBytes(Span<byte> buffer) =>
+            // Internally this defaults to looping over the buffer and filling with (byte)Next()
+            // which is not the same as NextBytes(buffer) above. Rather than implement ByteArrayRef
+            // for spans in the bridge at this time, we will just forbid the use of spans here until
+            // we do implement it.
+            throw new NotImplementedException("Spans not implemented at this time");
+#endif
+
+        /// <inheritdoc />
+        protected override double Sample() => underlying.RandomDouble(0, 1, false);
+    }
+}

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -157,8 +157,7 @@ namespace Temporalio.Worker
             pendingTaskStackTraces = workflowStackTrace == WorkflowStackTrace.None ? null : new();
             logger = details.LoggerFactory.CreateLogger($"Temporalio.Workflow:{start.WorkflowType}");
             replaySafeLogger = new(logger);
-            // We accept overflowing for seed (uint64 -> int32)
-            Random = new(unchecked((int)details.Start.RandomnessSeed));
+            Random = new(details.Start.RandomnessSeed);
             TracingEventsEnabled = !details.DisableTracingEvents;
         }
 
@@ -233,7 +232,7 @@ namespace Temporalio.Worker
         public IDictionary<string, WorkflowQueryDefinition> Queries => mutableQueries.Value;
 
         /// <inheritdoc />
-        public Random Random { get; private set; }
+        public DeterministicRandom Random { get; private set; }
 
         /// <inheritdoc />
         public IDictionary<string, WorkflowSignalDefinition> Signals => mutableSignals.Value;
@@ -981,7 +980,7 @@ namespace Temporalio.Worker
         }
 
         private void ApplyUpdateRandomSeed(UpdateRandomSeed update) =>
-            Random = new(unchecked((int)update.RandomnessSeed));
+            Random = new(update.RandomnessSeed);
 
         private void OnQueryDefinitionAdded(string name, WorkflowQueryDefinition defn)
         {

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -61,7 +61,7 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Gets value for <see cref="Workflow.Random" />.
         /// </summary>
-        Random Random { get; }
+        DeterministicRandom Random { get; }
 
         /// <summary>
         /// Gets value for <see cref="Workflow.Signals" />.

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -96,10 +96,7 @@ namespace Temporalio.Workflows
         /// recreated with a different seed in special cases (e.g. workflow reset). Do not use any
         /// other randomization inside workflow code.
         /// </remarks>
-        public static Random Random => Context.Random;
-
-        // TODO(cretz): Document that this is immutable from user POV but internally is mutated on
-        // upsert
+        public static DeterministicRandom Random => Context.Random;
 
         /// <summary>
         /// Gets the workflow search attributes.

--- a/tests/Temporalio.Tests/Common/DeterministicRandomTests.cs
+++ b/tests/Temporalio.Tests/Common/DeterministicRandomTests.cs
@@ -1,0 +1,58 @@
+namespace Temporalio.Tests.Common;
+
+using Temporalio.Common;
+using Xunit;
+
+public class DeterministicRandomTests
+{
+    [Fact]
+    public void DeterministicRandom_RandomCalls_AreDeterministic()
+    {
+        // Create some ints, doubles, and bytes. Confirm that they are not the same, and that they
+        // are not the same for different seed but are the same for the same seed.
+        var rand = new DeterministicRandom(1234);
+        var randDiff = new DeterministicRandom(2345);
+        var randSame = new DeterministicRandom(1234);
+
+        // Ints
+        var int1 = rand.Next();
+        Assert.InRange(int1, 0, int.MaxValue - 1);
+        var int2 = rand.Next();
+        Assert.InRange(int2, 0, int.MaxValue - 1);
+        Assert.NotEqual(int1, int2);
+        Assert.NotEqual(int1, randDiff.Next());
+        Assert.NotEqual(int2, randDiff.Next());
+        Assert.Equal(int1, randSame.Next());
+        Assert.Equal(int2, randSame.Next());
+
+        // Doubles
+        var double1 = rand.NextDouble();
+        Assert.InRange(double1, 0, 1.1);
+        var double2 = rand.NextDouble();
+        Assert.InRange(double2, 0, 1.1);
+        Assert.NotEqual(double1, double2);
+        Assert.NotEqual(double1, randDiff.NextDouble());
+        Assert.NotEqual(double2, randDiff.NextDouble());
+        Assert.Equal(double1, randSame.NextDouble());
+        Assert.Equal(double2, randSame.NextDouble());
+
+        // Bytes
+        var bytes1 = new byte[30];
+        var bytes2 = new byte[30];
+        var bytes3 = new byte[30];
+        var bytes4 = new byte[30];
+        var bytes5 = new byte[30];
+        var bytes6 = new byte[30];
+        rand.NextBytes(bytes1);
+        rand.NextBytes(bytes2);
+        Assert.NotEqual(bytes1, bytes2);
+        randDiff.NextBytes(bytes3);
+        Assert.NotEqual(bytes1, bytes3);
+        randDiff.NextBytes(bytes4);
+        Assert.NotEqual(bytes2, bytes4);
+        randSame.NextBytes(bytes5);
+        Assert.Equal(bytes1, bytes5);
+        randSame.NextBytes(bytes6);
+        Assert.Equal(bytes2, bytes6);
+    }
+}


### PR DESCRIPTION
## What was changed

.NET PRNG only accepts 32-bit seeds. This changes the workflow random to use a Rust-based random which supports 64-bit seeds.

## Checklist

1. Closes #90