### PR TITLE
Feature/di client provider

### DIFF
--- a/src/Temporalio.Extensions.Hosting/ITemporalClientProvider.cs
+++ b/src/Temporalio.Extensions.Hosting/ITemporalClientProvider.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using Temporalio.Client;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Interface for providing a lazily instantiated <see cref="ITemporalClient" />.
+    /// </summary>
+    public interface ITemporalClientProvider
+    {
+        /// <summary>
+        /// Get the client.
+        /// </summary>
+        Task<ITemporalClient> GetClient();
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/README.md
+++ b/src/Temporalio.Extensions.Hosting/README.md
@@ -57,8 +57,9 @@ When this extension is depended upon, two overloads for `AddHostedTemporalWorker
 
 One overload of `AddHostedTemporalWorker`, used in the quick start sample above, accepts the client target host, the
 client namespace, and the worker task queue. This form will connect to a client for the worker. The other overload of
-`AddHostedTemporalWorker` only accepts the worker task queue. In the latter, an `ITemporalClient` can either be set on
-the services container and therefore reused across workers, or the resulting builder can have client options set.
+`AddHostedTemporalWorker` only accepts the worker task queue. In the latter, an `ITemporalClient` or
+`ITemporalClientProvider` can be set on the services container and therefore reused across workers, or the resulting
+builder can have client options set.
 
 When called, these register a `TemporalWorkerServiceOptions` options class with the container and return a
 `ITemporalWorkerServiceOptionsBuilder` for configuring the worker service options.


### PR DESCRIPTION
## What was changed
added start of `ITemporalClientProvider` concept as mentioned in https://github.com/temporalio/sdk-dotnet/issues/44#issuecomment-1501953442 by @cretz

## Why?
I have the need for a lazily instantiated client. I need to pull certs / connection information at runtime (from DI'd components). This seems like an innocuous enough change that was already being considered.