### PR TITLE
Rename ID to Id 💥 BREAKING CHANGE

### DIFF
--- a/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
+++ b/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
@@ -112,14 +112,14 @@ namespace Temporalio.Extensions.OpenTelemetry
         /// <summary>
         /// Create tag collection for the given workflow ID.
         /// </summary>
-        /// <param name="workflowID">Workflow ID.</param>
+        /// <param name="workflowId">Workflow ID.</param>
         /// <returns>Tags.</returns>
         protected virtual IEnumerable<KeyValuePair<string, object?>> CreateWorkflowTags(
-            string workflowID)
+            string workflowId)
         {
-            if (Options.TagNameWorkflowID is string name)
+            if (Options.TagNameWorkflowId is string name)
             {
-                return new KeyValuePair<string, object?>[] { new(name, workflowID) };
+                return new KeyValuePair<string, object?>[] { new(name, workflowId) };
             }
             return Enumerable.Empty<KeyValuePair<string, object?>>();
         }
@@ -134,13 +134,13 @@ namespace Temporalio.Extensions.OpenTelemetry
             var info = Workflow.Info;
             // Can't just append to other enumerable, Append is >= 4.7.1 only
             var ret = new List<KeyValuePair<string, object?>>(2);
-            if (Options.TagNameWorkflowID is string wfName)
+            if (Options.TagNameWorkflowId is string wfName)
             {
-                ret.Add(new(wfName, info.WorkflowID));
+                ret.Add(new(wfName, info.WorkflowId));
             }
-            if (Options.TagNameRunID is string runName)
+            if (Options.TagNameRunId is string runName)
             {
-                ret.Add(new(runName, info.RunID));
+                ret.Add(new(runName, info.RunId));
             }
             return ret;
         }
@@ -154,17 +154,17 @@ namespace Temporalio.Extensions.OpenTelemetry
         {
             var info = ActivityExecutionContext.Current.Info;
             var ret = new List<KeyValuePair<string, object?>>(3);
-            if (Options.TagNameWorkflowID is string wfName)
+            if (Options.TagNameWorkflowId is string wfName)
             {
-                ret.Add(new(wfName, info.WorkflowID));
+                ret.Add(new(wfName, info.WorkflowId));
             }
-            if (Options.TagNameRunID is string runName)
+            if (Options.TagNameRunId is string runName)
             {
-                ret.Add(new(runName, info.WorkflowRunID));
+                ret.Add(new(runName, info.WorkflowRunId));
             }
-            if (Options.TagNameActivityID is string actName)
+            if (Options.TagNameActivityId is string actName)
             {
-                ret.Add(new(actName, info.ActivityID));
+                ret.Add(new(actName, info.ActivityId));
             }
             return ret;
         }
@@ -184,7 +184,7 @@ namespace Temporalio.Extensions.OpenTelemetry
                     $"{namePrefix}:{input.Workflow}",
                     kind: ActivityKind.Client,
                     parentContext: default,
-                    tags: root.CreateWorkflowTags(input.Options.ID!)))
+                    tags: root.CreateWorkflowTags(input.Options.Id!)))
                 {
                     if (HeadersFromContext(input.Headers) is Dictionary<string, Payload> headers)
                     {
@@ -200,7 +200,7 @@ namespace Temporalio.Extensions.OpenTelemetry
                     $"SignalWorkflow:{input.Signal}",
                     kind: ActivityKind.Client,
                     parentContext: default,
-                    tags: root.CreateWorkflowTags(input.ID)))
+                    tags: root.CreateWorkflowTags(input.Id)))
                 {
                     if (HeadersFromContext(input.Headers) is Dictionary<string, Payload> headers)
                     {
@@ -216,7 +216,7 @@ namespace Temporalio.Extensions.OpenTelemetry
                     $"QueryWorkflow:{input.Query}",
                     kind: ActivityKind.Client,
                     parentContext: default,
-                    tags: root.CreateWorkflowTags(input.ID)))
+                    tags: root.CreateWorkflowTags(input.Id)))
                 {
                     if (HeadersFromContext(input.Headers) is Dictionary<string, Payload> headers)
                     {

--- a/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptorOptions.cs
+++ b/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptorOptions.cs
@@ -21,17 +21,17 @@ namespace Temporalio.Extensions.OpenTelemetry
         /// <summary>
         /// Gets or sets the tag name for workflow IDs. If null, no tag is created.
         /// </summary>
-        public string? TagNameWorkflowID { get; set; } = "temporalWorkflowID";
+        public string? TagNameWorkflowId { get; set; } = "temporalWorkflowID";
 
         /// <summary>
         /// Gets or sets the tag name for run IDs. If null, no tag is created.
         /// </summary>
-        public string? TagNameRunID { get; set; } = "temporalRunID";
+        public string? TagNameRunId { get; set; } = "temporalRunID";
 
         /// <summary>
         /// Gets or sets the tag name for activity IDs. If null, no tag is created.
         /// </summary>
-        public string? TagNameActivityID { get; set; } = "temporalActivityID";
+        public string? TagNameActivityId { get; set; } = "temporalActivityID";
 
         /// <summary>
         /// Create a shallow copy of these options.

--- a/src/Temporalio/Activities/ActivityInfo.cs
+++ b/src/Temporalio/Activities/ActivityInfo.cs
@@ -11,7 +11,7 @@ namespace Temporalio.Activities
     /// <summary>
     /// Information about an activity.
     /// </summary>
-    /// <param name="ActivityID">ID for the activity.</param>
+    /// <param name="ActivityId">ID for the activity.</param>
     /// <param name="ActivityType">Type name for the activity.</param>
     /// <param name="Attempt">Attempt the activity is on.</param>
     /// <param name="CurrentAttemptScheduledTime">When the current attempt was scheduled.</param>
@@ -25,16 +25,16 @@ namespace Temporalio.Activities
     /// <param name="StartedTime">When the activity started.</param>
     /// <param name="TaskQueue">Task queue this activity is on.</param>
     /// <param name="TaskToken">Task token uniquely identifying this activity.</param>
-    /// <param name="WorkflowID">Workflow ID that started this activity.</param>
+    /// <param name="WorkflowId">Workflow ID that started this activity.</param>
     /// <param name="WorkflowNamespace">Namespace this activity is on.</param>
-    /// <param name="WorkflowRunID">Workflow run ID that started this activity.</param>
+    /// <param name="WorkflowRunId">Workflow run ID that started this activity.</param>
     /// <param name="WorkflowType">Workflow type name that started this activity.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record ActivityInfo(
-        string ActivityID,
+        string ActivityId,
         string ActivityType,
         int Attempt,
         DateTime CurrentAttemptScheduledTime,
@@ -48,9 +48,9 @@ namespace Temporalio.Activities
         DateTime StartedTime,
         string TaskQueue,
         byte[] TaskToken,
-        string WorkflowID,
+        string WorkflowId,
         string WorkflowNamespace,
-        string WorkflowRunID,
+        string WorkflowRunId,
         string WorkflowType)
     {
         /// <summary>
@@ -60,12 +60,12 @@ namespace Temporalio.Activities
         /// </summary>
         internal Dictionary<string, object> LoggerScope { get; } = new()
         {
-            ["ActivityID"] = ActivityID,
+            ["ActivityId"] = ActivityId,
             ["ActivityType"] = ActivityType,
             ["Attempt"] = Attempt,
             ["WorkflowNamespace"] = WorkflowNamespace,
-            ["WorkflowID"] = WorkflowID,
-            ["WorkflowRunID"] = WorkflowRunID,
+            ["WorkflowId"] = WorkflowId,
+            ["WorkflowRunId"] = WorkflowRunId,
             ["WorkflowType"] = WorkflowType,
         };
 

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -339,16 +339,16 @@ namespace Temporalio.Bridge
             {
                 throw new ArgumentException("Task queue must be provided in worker options");
             }
-            var buildID = options.BuildID;
-            if (buildID == null)
+            var buildId = options.BuildId;
+            if (buildId == null)
             {
                 if (options.UseWorkerVersioning)
                 {
-                    throw new ArgumentException("BuildID must be explicitly set when UseWorkerVersioning is true");
+                    throw new ArgumentException("BuildId must be explicitly set when UseWorkerVersioning is true");
                 }
                 var entryAssembly = Assembly.GetEntryAssembly() ??
                     throw new ArgumentException("Unable to get assembly manifest ID for build ID");
-                buildID = entryAssembly.ManifestModule.ModuleVersionId.ToString();
+                buildId = entryAssembly.ManifestModule.ModuleVersionId.ToString();
             }
             // We have to disable remote activities if a user asks _or_ if we are not running an
             // activity worker at all. Otherwise shutdown will not proceed properly.
@@ -357,7 +357,7 @@ namespace Temporalio.Bridge
             {
                 namespace_ = scope.ByteArray(namespace_),
                 task_queue = scope.ByteArray(options.TaskQueue),
-                build_id = scope.ByteArray(buildID),
+                build_id = scope.ByteArray(buildId),
                 identity_override = scope.ByteArray(options.Identity),
                 max_cached_workflows = (uint)options.MaxCachedWorkflows,
                 max_outstanding_workflow_tasks = (uint)options.MaxConcurrentWorkflowTasks,
@@ -389,18 +389,18 @@ namespace Temporalio.Bridge
         public static Interop.WorkerOptions ToInteropOptions(
             this Temporalio.Worker.WorkflowReplayerOptions options, Scope scope)
         {
-            var buildID = options.BuildID;
-            if (buildID == null)
+            var buildId = options.BuildId;
+            if (buildId == null)
             {
                 var entryAssembly = Assembly.GetEntryAssembly() ??
                     throw new ArgumentException("Unable to get assembly manifest ID for build ID");
-                buildID = entryAssembly.ManifestModule.ModuleVersionId.ToString();
+                buildId = entryAssembly.ManifestModule.ModuleVersionId.ToString();
             }
             return new()
             {
                 namespace_ = scope.ByteArray(options.Namespace),
                 task_queue = scope.ByteArray(options.TaskQueue),
-                build_id = scope.ByteArray(buildID),
+                build_id = scope.ByteArray(buildId),
                 identity_override = scope.ByteArray(options.Identity),
                 max_cached_workflows = 2,
                 max_outstanding_workflow_tasks = 2,

--- a/src/Temporalio/Bridge/Worker.cs
+++ b/src/Temporalio/Bridge/Worker.cs
@@ -261,15 +261,15 @@ namespace Temporalio.Bridge
         /// <summary>
         /// Request workflow eviction.
         /// </summary>
-        /// <param name="runID">Run ID of the workflow to evict.</param>
-        public void RequestWorkflowEviction(string runID)
+        /// <param name="runId">Run ID of the workflow to evict.</param>
+        public void RequestWorkflowEviction(string runId)
         {
             using (var scope = new Scope())
             {
                 unsafe
                 {
                     Interop.Methods.worker_request_workflow_eviction(
-                        Ptr, scope.ByteArray(runID));
+                        Ptr, scope.ByteArray(runId));
                 }
             }
         }

--- a/src/Temporalio/Bridge/WorkerReplayer.cs
+++ b/src/Temporalio/Bridge/WorkerReplayer.cs
@@ -63,9 +63,9 @@ namespace Temporalio.Bridge
         /// <summary>
         /// Push history to the replayer.
         /// </summary>
-        /// <param name="workflowID">ID of the workflow.</param>
+        /// <param name="workflowId">ID of the workflow.</param>
         /// <param name="history">History proto for the workflow.</param>
-        public void PushHistory(string workflowID, History history)
+        public void PushHistory(string workflowId, History history)
         {
             using (var scope = new Scope())
             {
@@ -74,7 +74,7 @@ namespace Temporalio.Bridge
                     Interop.Methods.worker_replay_push(
                         Worker.Ptr,
                         Ptr,
-                        scope.ByteArray(workflowID),
+                        scope.ByteArray(workflowId),
                         scope.ByteArray(history.ToByteArray()));
                 }
             }

--- a/src/Temporalio/Client/AsyncActivityHandle.cs
+++ b/src/Temporalio/Client/AsyncActivityHandle.cs
@@ -71,11 +71,11 @@ namespace Temporalio.Client
         /// <summary>
         /// Reference to an activity by its workflow ID, workflow run ID, and activity ID.
         /// </summary>
-        /// <param name="WorkflowID">ID for the activity's workflow.</param>
-        /// <param name="RunID">Run ID for the activity's workflow.</param>
-        /// <param name="ActivityID">ID for the activity.</param>
-        public record IDReference(
-            string WorkflowID, string? RunID, string ActivityID) : Reference;
+        /// <param name="WorkflowId">ID for the activity's workflow.</param>
+        /// <param name="RunId">Run ID for the activity's workflow.</param>
+        /// <param name="ActivityId">ID for the activity.</param>
+        public record IdReference(
+            string WorkflowId, string? RunId, string ActivityId) : Reference;
 
         /// <summary>
         /// Reference to an activity by its task token.

--- a/src/Temporalio/Client/ITemporalClient.AsyncActivity.cs
+++ b/src/Temporalio/Client/ITemporalClient.AsyncActivity.cs
@@ -12,11 +12,11 @@ namespace Temporalio.Client
         /// <summary>
         /// Get a handle to complete an activity asynchronously using its qualified identifiers.
         /// </summary>
-        /// <param name="workflowID">ID for the activity's workflow.</param>
-        /// <param name="runID">Run ID for the activity's workflow.</param>
-        /// <param name="activityID">ID for the activity.</param>
+        /// <param name="workflowId">ID for the activity's workflow.</param>
+        /// <param name="runId">Run ID for the activity's workflow.</param>
+        /// <param name="activityId">ID for the activity.</param>
         /// <returns>Async activity handle.</returns>
         public AsyncActivityHandle GetAsyncActivityHandle(
-            string workflowID, string runID, string activityID);
+            string workflowId, string runId, string activityId);
     }
 }

--- a/src/Temporalio/Client/ITemporalClient.Schedules.cs
+++ b/src/Temporalio/Client/ITemporalClient.Schedules.cs
@@ -12,7 +12,7 @@ namespace Temporalio.Client
         /// <summary>
         /// Create a schedule and return its handle.
         /// </summary>
-        /// <param name="scheduleID">Unique ID for the schedule.</param>
+        /// <param name="scheduleId">Unique ID for the schedule.</param>
         /// <param name="schedule">Schedule to create.</param>
         /// <param name="options">Options for creating the schedule.</param>
         /// <returns>Handle to the created schedule.</returns>
@@ -21,14 +21,14 @@ namespace Temporalio.Client
         /// already exists.
         /// </remarks>
         Task<ScheduleHandle> CreateScheduleAsync(
-            string scheduleID, Schedule schedule, ScheduleOptions? options = null);
+            string scheduleId, Schedule schedule, ScheduleOptions? options = null);
 
         /// <summary>
         /// Gets the schedule handle for the given ID.
         /// </summary>
-        /// <param name="scheduleID">Schedule ID to get the handle for.</param>
+        /// <param name="scheduleId">Schedule ID to get the handle for.</param>
         /// <returns>Schedule handle.</returns>
-        ScheduleHandle GetScheduleHandle(string scheduleID);
+        ScheduleHandle GetScheduleHandle(string scheduleId);
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>

--- a/src/Temporalio/Client/ITemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/ITemporalClient.Workflow.cs
@@ -57,26 +57,26 @@ namespace Temporalio.Client
         /// Get a workflow handle for an existing workflow with unknown return type.
         /// </summary>
         /// <param name="id">ID of the workflow.</param>
-        /// <param name="runID">Run ID of the workflow or null for latest.</param>
-        /// <param name="firstExecutionRunID">
+        /// <param name="runId">Run ID of the workflow or null for latest.</param>
+        /// <param name="firstExecutionRunId">
         /// Optional first execution ID used for cancellation and termination.
         /// </param>
         /// <returns>Created workflow handle.</returns>
         WorkflowHandle GetWorkflowHandle(
-            string id, string? runID = null, string? firstExecutionRunID = null);
+            string id, string? runId = null, string? firstExecutionRunId = null);
 
         /// <summary>
         /// Get a workflow handle for an existing workflow with known type.
         /// </summary>
         /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
         /// <param name="id">ID of the workflow.</param>
-        /// <param name="runID">Run ID of the workflow or null for latest.</param>
-        /// <param name="firstExecutionRunID">
+        /// <param name="runId">Run ID of the workflow or null for latest.</param>
+        /// <param name="firstExecutionRunId">
         /// Optional first execution ID used for cancellation and termination.
         /// </param>
         /// <returns>Created workflow handle.</returns>
         WorkflowHandle<TWorkflow> GetWorkflowHandle<TWorkflow>(
-            string id, string? runID = null, string? firstExecutionRunID = null);
+            string id, string? runId = null, string? firstExecutionRunId = null);
 
         /// <summary>
         /// Get a workflow handle for an existing workflow with known type and return type.
@@ -84,13 +84,13 @@ namespace Temporalio.Client
         /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
         /// <typeparam name="TResult">Result type of the workflow.</typeparam>
         /// <param name="id">ID of the workflow.</param>
-        /// <param name="runID">Run ID of the workflow or null for latest.</param>
-        /// <param name="firstExecutionRunID">
+        /// <param name="runId">Run ID of the workflow or null for latest.</param>
+        /// <param name="firstExecutionRunId">
         /// Optional first execution ID used for cancellation and termination.
         /// </param>
         /// <returns>Created workflow handle.</returns>
         WorkflowHandle<TWorkflow, TResult> GetWorkflowHandle<TWorkflow, TResult>(
-            string id, string? runID = null, string? firstExecutionRunID = null);
+            string id, string? runId = null, string? firstExecutionRunId = null);
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>

--- a/src/Temporalio/Client/ITemporalClientExtensions.cs
+++ b/src/Temporalio/Client/ITemporalClientExtensions.cs
@@ -153,7 +153,7 @@ namespace Temporalio.Client
             await foreach (var exec in client.ListWorkflowsAsync(query, listOptions))
             {
                 yield return await client.GetWorkflowHandle(
-                    exec.ID, exec.RunID).FetchHistoryAsync(historyFetchOptions).ConfigureAwait(false);
+                    exec.Id, exec.RunId).FetchHistoryAsync(historyFetchOptions).ConfigureAwait(false);
             }
         }
 #endif

--- a/src/Temporalio/Client/Interceptors/BackfillScheduleInput.cs
+++ b/src/Temporalio/Client/Interceptors/BackfillScheduleInput.cs
@@ -6,7 +6,7 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.BackfillScheduleAsync" />.
     /// </summary>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     /// <param name="Backfills">Backfills.</param>
     /// <param name="RpcOptions">RPC options.</param>
     /// <remarks>
@@ -14,7 +14,7 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record BackfillScheduleInput(
-        string ID,
+        string Id,
         IReadOnlyCollection<ScheduleBackfill> Backfills,
         RpcOptions? RpcOptions);
 }

--- a/src/Temporalio/Client/Interceptors/CancelWorkflowInput.cs
+++ b/src/Temporalio/Client/Interceptors/CancelWorkflowInput.cs
@@ -3,17 +3,17 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.CancelWorkflowAsync" />.
     /// </summary>
-    /// <param name="ID">Workflow ID.</param>
-    /// <param name="RunID">Workflow run ID if any.</param>
-    /// <param name="FirstExecutionRunID">Run that started the workflow chain to cancel.</param>
+    /// <param name="Id">Workflow ID.</param>
+    /// <param name="RunId">Workflow run ID if any.</param>
+    /// <param name="FirstExecutionRunId">Run that started the workflow chain to cancel.</param>
     /// <param name="Options">Options passed in to cancel.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record CancelWorkflowInput(
-        string ID,
-        string? RunID,
-        string? FirstExecutionRunID,
+        string Id,
+        string? RunId,
+        string? FirstExecutionRunId,
         WorkflowCancelOptions? Options);
 }

--- a/src/Temporalio/Client/Interceptors/CreateScheduleInput.cs
+++ b/src/Temporalio/Client/Interceptors/CreateScheduleInput.cs
@@ -5,7 +5,7 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.CreateScheduleAsync" />.
     /// </summary>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     /// <param name="Schedule">Schedule.</param>
     /// <param name="Options">Schedule options.</param>
     /// <remarks>
@@ -13,7 +13,7 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record CreateScheduleInput(
-        string ID,
+        string Id,
         Schedule Schedule,
         ScheduleOptions? Options);
 }

--- a/src/Temporalio/Client/Interceptors/DeleteScheduleInput.cs
+++ b/src/Temporalio/Client/Interceptors/DeleteScheduleInput.cs
@@ -3,13 +3,13 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.DeleteScheduleAsync" />.
     /// </summary>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     /// <param name="RpcOptions">RPC options.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record DeleteScheduleInput(
-        string ID,
+        string Id,
         RpcOptions? RpcOptions);
 }

--- a/src/Temporalio/Client/Interceptors/DescribeScheduleInput.cs
+++ b/src/Temporalio/Client/Interceptors/DescribeScheduleInput.cs
@@ -3,13 +3,13 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.DescribeScheduleAsync" />.
     /// </summary>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     /// <param name="RpcOptions">RPC options.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record DescribeScheduleInput(
-        string ID,
+        string Id,
         RpcOptions? RpcOptions);
 }

--- a/src/Temporalio/Client/Interceptors/DescribeWorkflowInput.cs
+++ b/src/Temporalio/Client/Interceptors/DescribeWorkflowInput.cs
@@ -3,15 +3,15 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.DescribeWorkflowAsync" />.
     /// </summary>
-    /// <param name="ID">Workflow ID.</param>
-    /// <param name="RunID">Workflow run ID if any.</param>
+    /// <param name="Id">Workflow ID.</param>
+    /// <param name="RunId">Workflow run ID if any.</param>
     /// <param name="Options">Options passed in to describe.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record DescribeWorkflowInput(
-        string ID,
-        string? RunID,
+        string Id,
+        string? RunId,
         WorkflowDescribeOptions? Options);
 }

--- a/src/Temporalio/Client/Interceptors/FetchWorkflowHistoryEventPageInput.cs
+++ b/src/Temporalio/Client/Interceptors/FetchWorkflowHistoryEventPageInput.cs
@@ -5,8 +5,8 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.FetchWorkflowHistoryEventPageAsync" />.
     /// </summary>
-    /// <param name="ID">ID of the workflow.</param>
-    /// <param name="RunID">Optional run ID of the workflow.</param>
+    /// <param name="Id">ID of the workflow.</param>
+    /// <param name="RunId">Optional run ID of the workflow.</param>
     /// <param name="PageSize">Optional page size.</param>
     /// <param name="NextPageToken">Next page token if any to continue pagination.</param>
     /// <param name="WaitNewEvent">If true, wait for new events before returning.</param>
@@ -18,8 +18,8 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record FetchWorkflowHistoryEventPageInput(
-        string ID,
-        string? RunID,
+        string Id,
+        string? RunId,
         int? PageSize,
         byte[]? NextPageToken,
         bool WaitNewEvent,

--- a/src/Temporalio/Client/Interceptors/PauseScheduleInput.cs
+++ b/src/Temporalio/Client/Interceptors/PauseScheduleInput.cs
@@ -3,7 +3,7 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.PauseScheduleAsync" />.
     /// </summary>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     /// <param name="Note">Pause note.</param>
     /// <param name="RpcOptions">RPC options.</param>
     /// <remarks>
@@ -11,7 +11,7 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record PauseScheduleInput(
-        string ID,
+        string Id,
         string? Note,
         RpcOptions? RpcOptions);
 }

--- a/src/Temporalio/Client/Interceptors/QueryWorkflowInput.cs
+++ b/src/Temporalio/Client/Interceptors/QueryWorkflowInput.cs
@@ -6,8 +6,8 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.QueryWorkflowAsync" />.
     /// </summary>
-    /// <param name="ID">Workflow ID.</param>
-    /// <param name="RunID">Workflow run ID if any.</param>
+    /// <param name="Id">Workflow ID.</param>
+    /// <param name="RunId">Workflow run ID if any.</param>
     /// <param name="Query">Query name.</param>
     /// <param name="Args">Query arguments.</param>
     /// <param name="Options">Options if any.</param>
@@ -18,8 +18,8 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record QueryWorkflowInput(
-        string ID,
-        string? RunID,
+        string Id,
+        string? RunId,
         string Query,
         IReadOnlyCollection<object?> Args,
         WorkflowQueryOptions? Options,

--- a/src/Temporalio/Client/Interceptors/SignalWorkflowInput.cs
+++ b/src/Temporalio/Client/Interceptors/SignalWorkflowInput.cs
@@ -6,8 +6,8 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.SignalWorkflowAsync" />.
     /// </summary>
-    /// <param name="ID">Workflow ID.</param>
-    /// <param name="RunID">Workflow run ID if any.</param>
+    /// <param name="Id">Workflow ID.</param>
+    /// <param name="RunId">Workflow run ID if any.</param>
     /// <param name="Signal">Signal name.</param>
     /// <param name="Args">Signal arguments.</param>
     /// <param name="Options">Options if any.</param>
@@ -18,8 +18,8 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record SignalWorkflowInput(
-        string ID,
-        string? RunID,
+        string Id,
+        string? RunId,
         string Signal,
         IReadOnlyCollection<object?> Args,
         WorkflowSignalOptions? Options,

--- a/src/Temporalio/Client/Interceptors/TerminateWorkflowInput.cs
+++ b/src/Temporalio/Client/Interceptors/TerminateWorkflowInput.cs
@@ -3,9 +3,9 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.TerminateWorkflowAsync" />.
     /// </summary>
-    /// <param name="ID">Workflow ID.</param>
-    /// <param name="RunID">Workflow run ID if any.</param>
-    /// <param name="FirstExecutionRunID">Run that started the workflow chain to terminate.</param>
+    /// <param name="Id">Workflow ID.</param>
+    /// <param name="RunId">Workflow run ID if any.</param>
+    /// <param name="FirstExecutionRunId">Run that started the workflow chain to terminate.</param>
     /// <param name="Reason">Reason for termination.</param>
     /// <param name="Options">Options passed in to terminate.</param>
     /// <remarks>
@@ -13,9 +13,9 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record TerminateWorkflowInput(
-        string ID,
-        string? RunID,
-        string? FirstExecutionRunID,
+        string Id,
+        string? RunId,
+        string? FirstExecutionRunId,
         string? Reason,
         WorkflowTerminateOptions? Options);
 }

--- a/src/Temporalio/Client/Interceptors/TriggerScheduleInput.cs
+++ b/src/Temporalio/Client/Interceptors/TriggerScheduleInput.cs
@@ -5,13 +5,13 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.TriggerScheduleAsync" />.
     /// </summary>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     /// <param name="Options">Trigger options.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record TriggerScheduleInput(
-        string ID,
+        string Id,
         ScheduleTriggerOptions? Options);
 }

--- a/src/Temporalio/Client/Interceptors/UnpauseScheduleInput.cs
+++ b/src/Temporalio/Client/Interceptors/UnpauseScheduleInput.cs
@@ -3,7 +3,7 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.UnpauseScheduleAsync" />.
     /// </summary>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     /// <param name="Note">Unpause note.</param>
     /// <param name="RpcOptions">RPC options.</param>
     /// <remarks>
@@ -11,7 +11,7 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record UnpauseScheduleInput(
-        string ID,
+        string Id,
         string? Note,
         RpcOptions? RpcOptions);
 }

--- a/src/Temporalio/Client/Interceptors/UpdateScheduleInput.cs
+++ b/src/Temporalio/Client/Interceptors/UpdateScheduleInput.cs
@@ -7,7 +7,7 @@ namespace Temporalio.Client.Interceptors
     /// <summary>
     /// Input for <see cref="ClientOutboundInterceptor.UpdateScheduleAsync" />.
     /// </summary>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     /// <param name="Updater">Updater.</param>
     /// <param name="RpcOptions">RPC options.</param>
     /// <remarks>
@@ -15,7 +15,7 @@ namespace Temporalio.Client.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record UpdateScheduleInput(
-        string ID,
+        string Id,
         Func<ScheduleUpdateInput, Task<ScheduleUpdate?>> Updater,
         RpcOptions? RpcOptions);
 }

--- a/src/Temporalio/Client/Schedules/ScheduleActionExecutionStartWorkflow.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleActionExecutionStartWorkflow.cs
@@ -3,11 +3,11 @@ namespace Temporalio.Client.Schedules
     /// <summary>
     /// Action execution representing a scheduled workflow start.
     /// </summary>
-    /// <param name="WorkflowID">Workflow ID.</param>
-    /// <param name="FirstExecutionRunID">Run ID.</param>
+    /// <param name="WorkflowId">Workflow ID.</param>
+    /// <param name="FirstExecutionRunId">Run ID.</param>
     public record ScheduleActionExecutionStartWorkflow(
-        string WorkflowID,
-        string FirstExecutionRunID) : ScheduleActionExecution
+        string WorkflowId,
+        string FirstExecutionRunId) : ScheduleActionExecution
     {
         /// <summary>
         /// Convert from proto.
@@ -16,6 +16,6 @@ namespace Temporalio.Client.Schedules
         /// <returns>Converted value.</returns>
         internal static ScheduleActionExecutionStartWorkflow FromProto(
             Api.Common.V1.WorkflowExecution proto) =>
-            new(WorkflowID: proto.WorkflowId, FirstExecutionRunID: proto.RunId);
+            new(WorkflowId: proto.WorkflowId, FirstExecutionRunId: proto.RunId);
     }
 }

--- a/src/Temporalio/Client/Schedules/ScheduleActionStartWorkflow.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleActionStartWorkflow.cs
@@ -118,7 +118,7 @@ namespace Temporalio.Client.Schedules
             DataConverter dataConverter)
         {
             // Disallow some options
-            if (Options.IDReusePolicy != Api.Enums.V1.WorkflowIdReusePolicy.AllowDuplicate)
+            if (Options.IdReusePolicy != Api.Enums.V1.WorkflowIdReusePolicy.AllowDuplicate)
             {
                 throw new ArgumentException("ID reuse policy cannot change from default for scheduled workflow");
             }
@@ -148,7 +148,7 @@ namespace Temporalio.Client.Schedules
 
             var workflow = new Api.Workflow.V1.NewWorkflowExecutionInfo()
             {
-                WorkflowId = Options.ID ??
+                WorkflowId = Options.Id ??
                     throw new ArgumentException("ID required on workflow action"),
                 WorkflowType = new() { Name = Workflow },
                 TaskQueue = new()

--- a/src/Temporalio/Client/Schedules/ScheduleDescription.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleDescription.cs
@@ -25,7 +25,7 @@ namespace Temporalio.Client.Schedules
         internal ScheduleDescription(
             string id, DescribeScheduleResponse rawDescription, DataConverter dataConverter)
         {
-            ID = id;
+            Id = id;
             RawDescription = rawDescription;
             // Search attribute conversion is cheap so it doesn't need to lock on publication. But
             // memo conversion may use remote codec so it should only ever be created once lazily.
@@ -46,7 +46,7 @@ namespace Temporalio.Client.Schedules
         /// <summary>
         /// Gets the ID of the schedule.
         /// </summary>
-        public string ID { get; private init; }
+        public string Id { get; private init; }
 
         /// <summary>
         /// Gets information about the schedule.

--- a/src/Temporalio/Client/Schedules/ScheduleHandle.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleHandle.cs
@@ -8,10 +8,10 @@ namespace Temporalio.Client.Schedules
     /// Handle for interacting with a schedule.
     /// </summary>
     /// <param name="Client">Client used for schedule handle calls.</param>
-    /// <param name="ID">Schedule ID.</param>
+    /// <param name="Id">Schedule ID.</param>
     public record ScheduleHandle(
         ITemporalClient Client,
-        string ID)
+        string Id)
     {
         /// <summary>
         /// Backfill this schedule by going through the specified time periods as if they passed
@@ -28,7 +28,7 @@ namespace Temporalio.Client.Schedules
                 throw new ArgumentException("At least one backfill required");
             }
             return Client.OutboundInterceptor.BackfillScheduleAsync(new(
-                ID: ID, Backfills: backfills, RpcOptions: rpcOptions));
+                Id: Id, Backfills: backfills, RpcOptions: rpcOptions));
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Temporalio.Client.Schedules
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Task for completion.</returns>
         public Task DeleteAsync(RpcOptions? rpcOptions = null) =>
-            Client.OutboundInterceptor.DeleteScheduleAsync(new(ID: ID, RpcOptions: rpcOptions));
+            Client.OutboundInterceptor.DeleteScheduleAsync(new(Id: Id, RpcOptions: rpcOptions));
 
         /// <summary>
         /// Fetch this schedule's description.
@@ -45,7 +45,7 @@ namespace Temporalio.Client.Schedules
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Schedule description.</returns>
         public Task<ScheduleDescription> DescribeAsync(RpcOptions? rpcOptions = null) =>
-            Client.OutboundInterceptor.DescribeScheduleAsync(new(ID: ID, RpcOptions: rpcOptions));
+            Client.OutboundInterceptor.DescribeScheduleAsync(new(Id: Id, RpcOptions: rpcOptions));
 
         /// <summary>
         /// Pause this schedule.
@@ -55,7 +55,7 @@ namespace Temporalio.Client.Schedules
         /// <returns>Task for completion.</returns>
         public Task PauseAsync(string? note = null, RpcOptions? rpcOptions = null) =>
             Client.OutboundInterceptor.PauseScheduleAsync(
-                new(ID: ID, Note: note, RpcOptions: rpcOptions));
+                new(Id: Id, Note: note, RpcOptions: rpcOptions));
 
         /// <summary>
         /// Trigger an action on this schedule to happen immediately.
@@ -63,7 +63,7 @@ namespace Temporalio.Client.Schedules
         /// <param name="options">Options for triggering.</param>
         /// <returns>Task for completion.</returns>
         public Task TriggerAsync(ScheduleTriggerOptions? options = null) =>
-            Client.OutboundInterceptor.TriggerScheduleAsync(new(ID: ID, Options: options));
+            Client.OutboundInterceptor.TriggerScheduleAsync(new(Id: Id, Options: options));
 
         /// <summary>
         /// Unpause this schedule.
@@ -73,7 +73,7 @@ namespace Temporalio.Client.Schedules
         /// <returns>Task for completion.</returns>
         public Task UnpauseAsync(string? note = null, RpcOptions? rpcOptions = null) =>
             Client.OutboundInterceptor.UnpauseScheduleAsync(
-                new(ID: ID, Note: note, RpcOptions: rpcOptions));
+                new(Id: Id, Note: note, RpcOptions: rpcOptions));
 
         /// <summary>
         /// Update this schedule. This is done via a callback which can be called multiple times in
@@ -102,6 +102,6 @@ namespace Temporalio.Client.Schedules
             Func<ScheduleUpdateInput, Task<ScheduleUpdate?>> updater,
             RpcOptions? rpcOptions = null) =>
             Client.OutboundInterceptor.UpdateScheduleAsync(
-                new(ID: ID, Updater: updater, RpcOptions: rpcOptions));
+                new(Id: Id, Updater: updater, RpcOptions: rpcOptions));
     }
 }

--- a/src/Temporalio/Client/Schedules/ScheduleListDescription.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleListDescription.cs
@@ -46,7 +46,7 @@ namespace Temporalio.Client.Schedules
         /// <summary>
         /// Gets the schedule ID.
         /// </summary>
-        public string ID => RawEntry.ScheduleId;
+        public string Id => RawEntry.ScheduleId;
 
         /// <summary>
         /// Gets the schedule.

--- a/src/Temporalio/Client/TemporalClient.AsyncActivity.cs
+++ b/src/Temporalio/Client/TemporalClient.AsyncActivity.cs
@@ -16,9 +16,9 @@ namespace Temporalio.Client
 
         /// <inheritdoc />
         public AsyncActivityHandle GetAsyncActivityHandle(
-            string workflowID, string runID, string activityID) =>
-            new(this, new AsyncActivityHandle.IDReference(
-                WorkflowID: workflowID, RunID: runID, ActivityID: activityID));
+            string workflowId, string runId, string activityId) =>
+            new(this, new AsyncActivityHandle.IdReference(
+                WorkflowId: workflowId, RunId: runId, ActivityId: activityId));
 
         internal partial class Impl
         {
@@ -37,16 +37,16 @@ namespace Temporalio.Client
                         },
                     };
                 }
-                if (input.Activity is AsyncActivityHandle.IDReference idRef)
+                if (input.Activity is AsyncActivityHandle.IdReference idRef)
                 {
                     var resp = await Client.Connection.WorkflowService.RecordActivityTaskHeartbeatByIdAsync(
                         new()
                         {
                             Namespace = Client.Options.Namespace,
                             Identity = Client.Connection.Options.Identity,
-                            WorkflowId = idRef.WorkflowID,
-                            RunId = idRef.RunID ?? string.Empty,
-                            ActivityId = idRef.ActivityID,
+                            WorkflowId = idRef.WorkflowId,
+                            RunId = idRef.RunId ?? string.Empty,
+                            ActivityId = idRef.ActivityId,
                             Details = details,
                         },
                         DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);
@@ -82,16 +82,16 @@ namespace Temporalio.Client
             {
                 var result = await Client.Options.DataConverter.ToPayloadAsync(
                     input.Result).ConfigureAwait(false);
-                if (input.Activity is AsyncActivityHandle.IDReference idRef)
+                if (input.Activity is AsyncActivityHandle.IdReference idRef)
                 {
                     await Client.Connection.WorkflowService.RespondActivityTaskCompletedByIdAsync(
                         new()
                         {
                             Namespace = Client.Options.Namespace,
                             Identity = Client.Connection.Options.Identity,
-                            WorkflowId = idRef.WorkflowID,
-                            RunId = idRef.RunID ?? string.Empty,
-                            ActivityId = idRef.ActivityID,
+                            WorkflowId = idRef.WorkflowId,
+                            RunId = idRef.RunId ?? string.Empty,
+                            ActivityId = idRef.ActivityId,
                             Result = new() { Payloads_ = { { result } } },
                         },
                         DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);
@@ -132,16 +132,16 @@ namespace Temporalio.Client
                         },
                     };
                 }
-                if (input.Activity is AsyncActivityHandle.IDReference idRef)
+                if (input.Activity is AsyncActivityHandle.IdReference idRef)
                 {
                     await Client.Connection.WorkflowService.RespondActivityTaskFailedByIdAsync(
                         new()
                         {
                             Namespace = Client.Options.Namespace,
                             Identity = Client.Connection.Options.Identity,
-                            WorkflowId = idRef.WorkflowID,
-                            RunId = idRef.RunID ?? string.Empty,
-                            ActivityId = idRef.ActivityID,
+                            WorkflowId = idRef.WorkflowId,
+                            RunId = idRef.RunId ?? string.Empty,
+                            ActivityId = idRef.ActivityId,
                             Failure = failure,
                             LastHeartbeatDetails = lastHeartbeatDetails,
                         },
@@ -182,16 +182,16 @@ namespace Temporalio.Client
                         },
                     };
                 }
-                if (input.Activity is AsyncActivityHandle.IDReference idRef)
+                if (input.Activity is AsyncActivityHandle.IdReference idRef)
                 {
                     await Client.Connection.WorkflowService.RespondActivityTaskCanceledByIdAsync(
                         new()
                         {
                             Namespace = Client.Options.Namespace,
                             Identity = Client.Connection.Options.Identity,
-                            WorkflowId = idRef.WorkflowID,
-                            RunId = idRef.RunID ?? string.Empty,
-                            ActivityId = idRef.ActivityID,
+                            WorkflowId = idRef.WorkflowId,
+                            RunId = idRef.RunId ?? string.Empty,
+                            ActivityId = idRef.ActivityId,
                             Details = details,
                         },
                         DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);

--- a/src/Temporalio/Client/TemporalClient.Schedules.cs
+++ b/src/Temporalio/Client/TemporalClient.Schedules.cs
@@ -20,14 +20,14 @@ namespace Temporalio.Client
     {
         /// <inheritdoc />
         public Task<ScheduleHandle> CreateScheduleAsync(
-            string scheduleID, Schedule schedule, ScheduleOptions? options = null) =>
+            string scheduleId, Schedule schedule, ScheduleOptions? options = null) =>
             OutboundInterceptor.CreateScheduleAsync(new(
-                ID: scheduleID,
+                Id: scheduleId,
                 Schedule: schedule,
                 Options: options));
 
         /// <inheritdoc />
-        public ScheduleHandle GetScheduleHandle(string scheduleID) => new(this, scheduleID);
+        public ScheduleHandle GetScheduleHandle(string scheduleId) => new(this, scheduleId);
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <inheritdoc />
@@ -44,7 +44,7 @@ namespace Temporalio.Client
                 var req = new CreateScheduleRequest()
                 {
                     Namespace = Client.Options.Namespace,
-                    ScheduleId = input.ID,
+                    ScheduleId = input.Id,
                     Schedule = await input.Schedule.ToProtoAsync(Client.Options.DataConverter).ConfigureAwait(false),
                     Identity = Client.Connection.Options.Identity,
                     RequestId = Guid.NewGuid().ToString(),
@@ -90,7 +90,7 @@ namespace Temporalio.Client
                 {
                     await Client.Connection.WorkflowService.CreateScheduleAsync(
                         req, DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);
-                    return new(Client, input.ID);
+                    return new(Client, input.Id);
                 }
                 catch (RpcException e) when (e.Code == RpcException.StatusCode.AlreadyExists)
                 {
@@ -104,7 +104,7 @@ namespace Temporalio.Client
                     new()
                     {
                         Namespace = Client.Options.Namespace,
-                        ScheduleId = input.ID,
+                        ScheduleId = input.Id,
                         Patch = new()
                         {
                             BackfillRequest = { input.Backfills.Select(b => b.ToProto()) },
@@ -120,7 +120,7 @@ namespace Temporalio.Client
                     new()
                     {
                         Namespace = Client.Options.Namespace,
-                        ScheduleId = input.ID,
+                        ScheduleId = input.Id,
                         Identity = Client.Connection.Options.Identity,
                     },
                     DefaultRetryOptions(input.RpcOptions));
@@ -133,10 +133,10 @@ namespace Temporalio.Client
                     new()
                     {
                         Namespace = Client.Options.Namespace,
-                        ScheduleId = input.ID,
+                        ScheduleId = input.Id,
                     },
                     DefaultRetryOptions(input.RpcOptions)).ConfigureAwait(false);
-                return new(input.ID, desc, Client.Options.DataConverter);
+                return new(input.Id, desc, Client.Options.DataConverter);
             }
 
             /// <inheritdoc />
@@ -145,7 +145,7 @@ namespace Temporalio.Client
                     new()
                     {
                         Namespace = Client.Options.Namespace,
-                        ScheduleId = input.ID,
+                        ScheduleId = input.Id,
                         Patch = new() { Pause = input.Note ?? "Paused via .NET SDK" },
                         Identity = Client.Connection.Options.Identity,
                         RequestId = Guid.NewGuid().ToString(),
@@ -158,7 +158,7 @@ namespace Temporalio.Client
                     new()
                     {
                         Namespace = Client.Options.Namespace,
-                        ScheduleId = input.ID,
+                        ScheduleId = input.Id,
                         Patch = new()
                         {
                             TriggerImmediately = new()
@@ -177,7 +177,7 @@ namespace Temporalio.Client
                     new()
                     {
                         Namespace = Client.Options.Namespace,
-                        ScheduleId = input.ID,
+                        ScheduleId = input.Id,
                         Patch = new() { Unpause = input.Note ?? "Unpaused via .NET SDK" },
                         Identity = Client.Connection.Options.Identity,
                         RequestId = Guid.NewGuid().ToString(),
@@ -189,7 +189,7 @@ namespace Temporalio.Client
             {
                 // TODO(cretz): This is supposed to be a retry-conflict loop, but we do not yet have
                 // a way to know update failure is due to conflict token mismatch
-                var desc = await DescribeScheduleAsync(new(input.ID, input.RpcOptions)).ConfigureAwait(false);
+                var desc = await DescribeScheduleAsync(new(input.Id, input.RpcOptions)).ConfigureAwait(false);
                 var update = await input.Updater(new(Description: desc)).ConfigureAwait(false);
                 if (update == null)
                 {
@@ -199,7 +199,7 @@ namespace Temporalio.Client
                     new()
                     {
                         Namespace = Client.Options.Namespace,
-                        ScheduleId = input.ID,
+                        ScheduleId = input.Id,
                         Schedule = await update.Schedule.ToProtoAsync(Client.Options.DataConverter).ConfigureAwait(false),
                         Identity = Client.Connection.Options.Identity,
                         RequestId = Guid.NewGuid().ToString(),

--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -57,18 +57,18 @@ namespace Temporalio.Client
 
         /// <inheritdoc />
         public WorkflowHandle GetWorkflowHandle(
-            string id, string? runID = null, string? firstExecutionRunID = null) =>
-            new(Client: this, ID: id, RunID: runID, FirstExecutionRunID: firstExecutionRunID);
+            string id, string? runId = null, string? firstExecutionRunId = null) =>
+            new(Client: this, Id: id, RunId: runId, FirstExecutionRunId: firstExecutionRunId);
 
         /// <inheritdoc />
         public WorkflowHandle<TWorkflow> GetWorkflowHandle<TWorkflow>(
-            string id, string? runID = null, string? firstExecutionRunID = null) =>
-            new(Client: this, ID: id, RunID: runID, FirstExecutionRunID: firstExecutionRunID);
+            string id, string? runId = null, string? firstExecutionRunId = null) =>
+            new(Client: this, Id: id, RunId: runId, FirstExecutionRunId: firstExecutionRunId);
 
         /// <inheritdoc />
         public WorkflowHandle<TWorkflow, TResult> GetWorkflowHandle<TWorkflow, TResult>(
-            string id, string? runID = null, string? firstExecutionRunID = null) =>
-            new(Client: this, ID: id, RunID: runID, FirstExecutionRunID: firstExecutionRunID);
+            string id, string? runId = null, string? firstExecutionRunId = null) =>
+            new(Client: this, Id: id, RunId: runId, FirstExecutionRunId: firstExecutionRunId);
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <inheritdoc />
@@ -101,7 +101,7 @@ namespace Temporalio.Client
                         {
                             throw new WorkflowAlreadyStartedException(
                                 e.Message,
-                                input.Options.ID!,
+                                input.Options.Id!,
                                 failure.RunId);
                         }
                     }
@@ -117,8 +117,8 @@ namespace Temporalio.Client
                     Namespace = Client.Options.Namespace,
                     WorkflowExecution = new()
                     {
-                        WorkflowId = input.ID,
-                        RunId = input.RunID ?? string.Empty,
+                        WorkflowId = input.Id,
+                        RunId = input.RunId ?? string.Empty,
                     },
                     SignalName = input.Signal,
                     Identity = Client.Connection.Options.Identity,
@@ -156,8 +156,8 @@ namespace Temporalio.Client
                     Namespace = Client.Options.Namespace,
                     Execution = new()
                     {
-                        WorkflowId = input.ID,
-                        RunId = input.RunID ?? string.Empty,
+                        WorkflowId = input.Id,
+                        RunId = input.RunId ?? string.Empty,
                     },
                     Query = new() { QueryType = input.Query },
                 };
@@ -230,8 +230,8 @@ namespace Temporalio.Client
                         Namespace = Client.Options.Namespace,
                         Execution = new()
                         {
-                            WorkflowId = input.ID,
-                            RunId = input.RunID ?? string.Empty,
+                            WorkflowId = input.Id,
+                            RunId = input.RunId ?? string.Empty,
                         },
                     },
                     DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);
@@ -247,10 +247,10 @@ namespace Temporalio.Client
                         Namespace = Client.Options.Namespace,
                         WorkflowExecution = new()
                         {
-                            WorkflowId = input.ID,
-                            RunId = input.RunID ?? string.Empty,
+                            WorkflowId = input.Id,
+                            RunId = input.RunId ?? string.Empty,
                         },
-                        FirstExecutionRunId = input.FirstExecutionRunID ?? string.Empty,
+                        FirstExecutionRunId = input.FirstExecutionRunId ?? string.Empty,
                         Identity = Client.Connection.Options.Identity,
                         RequestId = Guid.NewGuid().ToString(),
                     },
@@ -265,11 +265,11 @@ namespace Temporalio.Client
                     Namespace = Client.Options.Namespace,
                     WorkflowExecution = new()
                     {
-                        WorkflowId = input.ID,
-                        RunId = input.RunID ?? string.Empty,
+                        WorkflowId = input.Id,
+                        RunId = input.RunId ?? string.Empty,
                     },
                     Reason = input.Reason ?? string.Empty,
-                    FirstExecutionRunId = input.FirstExecutionRunID ?? string.Empty,
+                    FirstExecutionRunId = input.FirstExecutionRunId ?? string.Empty,
                     Identity = Client.Connection.Options.Identity,
                 };
                 if (input.Options?.Details != null && input.Options?.Details.Count > 0)
@@ -292,8 +292,8 @@ namespace Temporalio.Client
                     Namespace = Client.Options.Namespace,
                     Execution = new()
                     {
-                        WorkflowId = input.ID,
-                        RunId = input.RunID ?? string.Empty,
+                        WorkflowId = input.Id,
+                        RunId = input.RunId ?? string.Empty,
                     },
                     MaximumPageSize = input.PageSize ?? 0,
                     NextPageToken = input.NextPageToken == null ?
@@ -383,7 +383,7 @@ namespace Temporalio.Client
                 var req = new StartWorkflowExecutionRequest()
                 {
                     Namespace = Client.Options.Namespace,
-                    WorkflowId = input.Options.ID ??
+                    WorkflowId = input.Options.Id ??
                         throw new ArgumentException("ID required to start workflow"),
                     WorkflowType = new WorkflowType() { Name = input.Workflow },
                     TaskQueue = new TaskQueue()
@@ -393,7 +393,7 @@ namespace Temporalio.Client
                     },
                     Identity = Client.Connection.Options.Identity,
                     RequestId = Guid.NewGuid().ToString(),
-                    WorkflowIdReusePolicy = input.Options.IDReusePolicy,
+                    WorkflowIdReusePolicy = input.Options.IdReusePolicy,
                     RetryPolicy = input.Options.RetryPolicy?.ToProto(),
                 };
                 if (input.Args.Count > 0)
@@ -465,9 +465,9 @@ namespace Temporalio.Client
                         req, DefaultRetryOptions(input.Options.Rpc)).ConfigureAwait(false);
                     return new WorkflowHandle<TWorkflow, TResult>(
                         Client: Client,
-                        ID: req.WorkflowId,
-                        ResultRunID: resp.RunId,
-                        FirstExecutionRunID: resp.RunId);
+                        Id: req.WorkflowId,
+                        ResultRunId: resp.RunId,
+                        FirstExecutionRunId: resp.RunId);
                 }
 
                 // Since it's signal with start, convert and run
@@ -503,8 +503,8 @@ namespace Temporalio.Client
                 // Notice we do _not_ set first execution run ID for signal with start
                 return new WorkflowHandle<TWorkflow, TResult>(
                     Client: Client,
-                    ID: req.WorkflowId,
-                    ResultRunID: signalResp.RunId);
+                    Id: req.WorkflowId,
+                    ResultRunId: signalResp.RunId);
             }
         }
     }

--- a/src/Temporalio/Client/WorkflowExecution.cs
+++ b/src/Temporalio/Client/WorkflowExecution.cs
@@ -57,7 +57,7 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets the ID for the workflow.
         /// </summary>
-        public string ID => RawInfo.Execution.WorkflowId;
+        public string Id => RawInfo.Execution.WorkflowId;
 
         /// <summary>
         /// Gets the workflow memo dictionary, lazily creating when accessed.
@@ -67,17 +67,17 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets the ID for the parent workflow if this was started as a child.
         /// </summary>
-        public string? ParentID => RawInfo.ParentExecution?.WorkflowId;
+        public string? ParentId => RawInfo.ParentExecution?.WorkflowId;
 
         /// <summary>
         /// Gets the run ID for the parent workflow if this was started as a child.
         /// </summary>
-        public string? ParentRunID => RawInfo.ParentExecution?.RunId;
+        public string? ParentRunId => RawInfo.ParentExecution?.RunId;
 
         /// <summary>
         /// Gets the run ID for the workflow.
         /// </summary>
-        public string RunID => RawInfo.Execution.RunId;
+        public string RunId => RawInfo.Execution.RunId;
 
         /// <summary>
         /// Gets when the workflow was created.

--- a/src/Temporalio/Client/WorkflowOptions.cs
+++ b/src/Temporalio/Client/WorkflowOptions.cs
@@ -6,7 +6,7 @@ using Temporalio.Common;
 namespace Temporalio.Client
 {
     /// <summary>
-    /// Options for starting a workflow. <see cref="ID" /> and <see cref="TaskQueue" /> are
+    /// Options for starting a workflow. <see cref="Id" /> and <see cref="TaskQueue" /> are
     /// required.
     /// </summary>
     public class WorkflowOptions : ICloneable
@@ -25,14 +25,14 @@ namespace Temporalio.Client
         /// <param name="taskQueue">Task queue to start workflow on.</param>
         public WorkflowOptions(string id, string taskQueue)
         {
-            ID = id;
+            Id = id;
             TaskQueue = taskQueue;
         }
 
         /// <summary>
         /// Gets or sets the unique workflow identifier. This is required.
         /// </summary>
-        public string? ID { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the task queue to run the workflow on. This is required.
@@ -58,7 +58,7 @@ namespace Temporalio.Client
         /// Gets or sets how already-existing IDs are treated. Default is
         /// <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
         /// </summary>
-        public WorkflowIdReusePolicy IDReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
+        public WorkflowIdReusePolicy IdReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
 
         /// <summary>
         /// Gets or sets the retry policy for the workflow. If unset, workflow never retries.

--- a/src/Temporalio/Common/WorkflowHistory.cs
+++ b/src/Temporalio/Common/WorkflowHistory.cs
@@ -15,9 +15,9 @@ namespace Temporalio.Common
     /// <summary>
     /// History for a workflow.
     /// </summary>
-    /// <param name="ID">ID of the workflow.</param>
+    /// <param name="Id">ID of the workflow.</param>
     /// <param name="Events">Collection of events.</param>
-    public record WorkflowHistory(string ID, IReadOnlyCollection<HistoryEvent> Events)
+    public record WorkflowHistory(string Id, IReadOnlyCollection<HistoryEvent> Events)
     {
         private static readonly JsonSerializerOptions JsonSerializerOptions =
             new() { Converters = { JsonCommonTypeConverter.Instance } };
@@ -52,27 +52,27 @@ namespace Temporalio.Common
         /// Create workflow history from the given JSON. While this works with "ToJson" from this
         /// class, it also works with CLI and UI exported JSON.
         /// </summary>
-        /// <param name="workflowID">Workflow ID.</param>
+        /// <param name="workflowId">Workflow ID.</param>
         /// <param name="json">JSON to create history from.</param>
         /// <returns>Created history.</returns>
-        public static WorkflowHistory FromJson(string workflowID, string json)
+        public static WorkflowHistory FromJson(string workflowId, string json)
         {
             var historyRaw = JsonSerializer.Deserialize<object?>(json, JsonSerializerOptions);
             if (historyRaw is not Dictionary<string, object?> historyObj)
             {
                 throw new ArgumentException("JSON is not expected history object");
             }
-            return FromJson(workflowID, historyObj);
+            return FromJson(workflowId, historyObj);
         }
 
-        private static WorkflowHistory FromJson(string workflowID, Dictionary<string, object?> historyObj)
+        private static WorkflowHistory FromJson(string workflowId, Dictionary<string, object?> historyObj)
         {
             // Unfortunately due to enum incorrectness in UI/tctl/Go, we have to parse, alter,
             // serialize the altered, then deserialize again using Proto JSON
             HistoryJsonFixer.Fix(historyObj);
             var fixedJson = JsonSerializer.Serialize(historyObj);
             var history = JsonParser.Default.Parse<History>(fixedJson);
-            return new(workflowID, history.Events);
+            return new(workflowId, history.Events);
         }
 
         /// <summary>

--- a/src/Temporalio/Exceptions/ActivityFailureException.cs
+++ b/src/Temporalio/Exceptions/ActivityFailureException.cs
@@ -48,7 +48,7 @@ namespace Temporalio.Exceptions
         /// <summary>
         /// Gets the identifier of the activity that failed.
         /// </summary>
-        public string ActivityID => Failure!.ActivityFailureInfo.ActivityId;
+        public string ActivityId => Failure!.ActivityFailureInfo.ActivityId;
 
         /// <summary>
         /// Gets the retry state for the failure.

--- a/src/Temporalio/Exceptions/ChildWorkflowFailureException.cs
+++ b/src/Temporalio/Exceptions/ChildWorkflowFailureException.cs
@@ -36,13 +36,13 @@ namespace Temporalio.Exceptions
         /// <summary>
         /// Gets the ID of the failed child workflow.
         /// </summary>
-        public string WorkflowID =>
+        public string WorkflowId =>
             Failure!.ChildWorkflowExecutionFailureInfo.WorkflowExecution.WorkflowId;
 
         /// <summary>
         /// Gets the run ID of the failed child workflow.
         /// </summary>
-        public string RunID => Failure!.ChildWorkflowExecutionFailureInfo.WorkflowExecution.RunId;
+        public string RunId => Failure!.ChildWorkflowExecutionFailureInfo.WorkflowExecution.RunId;
 
         /// <summary>
         /// Gets the child workflow name or "type" that failed.

--- a/src/Temporalio/Exceptions/WorkflowAlreadyStartedException.cs
+++ b/src/Temporalio/Exceptions/WorkflowAlreadyStartedException.cs
@@ -9,23 +9,23 @@ namespace Temporalio.Exceptions
         /// Initializes a new instance of the <see cref="WorkflowAlreadyStartedException"/> class.
         /// </summary>
         /// <param name="message">Error message.</param>
-        /// <param name="workflowID">Already started workflow ID.</param>
-        /// <param name="runID">Already started run ID.</param>
-        public WorkflowAlreadyStartedException(string message, string workflowID, string runID)
+        /// <param name="workflowId">Already started workflow ID.</param>
+        /// <param name="runId">Already started run ID.</param>
+        public WorkflowAlreadyStartedException(string message, string workflowId, string runId)
             : base(message)
         {
-            WorkflowID = workflowID;
-            RunID = runID;
+            WorkflowId = workflowId;
+            RunId = runId;
         }
 
         /// <summary>
         /// Gets the workflow ID that was already started.
         /// </summary>
-        public string WorkflowID { get; private init; }
+        public string WorkflowId { get; private init; }
 
         /// <summary>
         /// Gets the run ID that was already started.
         /// </summary>
-        public string RunID { get; private init; }
+        public string RunId { get; private init; }
     }
 }

--- a/src/Temporalio/Exceptions/WorkflowContinuedAsNewException.cs
+++ b/src/Temporalio/Exceptions/WorkflowContinuedAsNewException.cs
@@ -8,14 +8,14 @@ namespace Temporalio.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkflowContinuedAsNewException"/> class.
         /// </summary>
-        /// <param name="newRunID">New run ID.</param>
-        public WorkflowContinuedAsNewException(string newRunID)
+        /// <param name="newRunId">New run ID.</param>
+        public WorkflowContinuedAsNewException(string newRunId)
             : base("Workflow continued as new") =>
-            NewRunID = newRunID;
+            NewRunId = newRunId;
 
         /// <summary>
         /// Gets the run ID of the new run.
         /// </summary>
-        public string NewRunID { get; private init; }
+        public string NewRunId { get; private init; }
     }
 }

--- a/src/Temporalio/Testing/ActivityEnvironment.cs
+++ b/src/Temporalio/Testing/ActivityEnvironment.cs
@@ -20,7 +20,7 @@ namespace Temporalio.Testing
         /// Default activity info.
         /// </summary>
         public static readonly ActivityInfo DefaultInfo = new(
-            ActivityID: "test",
+            ActivityId: "test",
             ActivityType: "unknown",
             Attempt: 1,
             CurrentAttemptScheduledTime: new(1970, 1, 1, 1, 1, 1, DateTimeKind.Utc),
@@ -34,9 +34,9 @@ namespace Temporalio.Testing
             StartedTime: new(1970, 1, 1, 1, 1, 1, DateTimeKind.Utc),
             TaskQueue: "test",
             TaskToken: System.Text.Encoding.ASCII.GetBytes("test"),
-            WorkflowID: "test",
+            WorkflowId: "test",
             WorkflowNamespace: "default",
-            WorkflowRunID: "test-run",
+            WorkflowRunId: "test-run",
             WorkflowType: "test");
 
         /// <summary>

--- a/src/Temporalio/Testing/TimeSkippingClientInterceptor.cs
+++ b/src/Temporalio/Testing/TimeSkippingClientInterceptor.cs
@@ -60,10 +60,10 @@ namespace Temporalio.Testing
                 WorkflowHandle<TWorkflow, TResult> underlying)
                 : base(
                     Client: underlying.Client,
-                    ID: underlying.ID,
-                    RunID: underlying.RunID,
-                    ResultRunID: underlying.ResultRunID,
-                    FirstExecutionRunID: underlying.FirstExecutionRunID) => this.env = env;
+                    Id: underlying.Id,
+                    RunId: underlying.RunId,
+                    ResultRunId: underlying.ResultRunId,
+                    FirstExecutionRunId: underlying.FirstExecutionRunId) => this.env = env;
 
             /// <inheritdoc />
             public override Task<TLocalResult> GetResultAsync<TLocalResult>(

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -164,7 +164,7 @@ namespace Temporalio.Worker
             // Create info
             var start = tsk.Start;
             var info = new ActivityInfo(
-                ActivityID: start.ActivityId,
+                ActivityId: start.ActivityId,
                 ActivityType: start.ActivityType,
                 Attempt: (int)start.Attempt,
                 CurrentAttemptScheduledTime: start.CurrentAttemptScheduledTime.ToDateTime(),
@@ -178,9 +178,9 @@ namespace Temporalio.Worker
                 StartedTime: start.StartedTime.ToDateTime(),
                 TaskQueue: worker.Options.TaskQueue!,
                 TaskToken: tsk.TaskToken.ToByteArray(),
-                WorkflowID: start.WorkflowExecution.WorkflowId,
+                WorkflowId: start.WorkflowExecution.WorkflowId,
                 WorkflowNamespace: start.WorkflowNamespace,
-                WorkflowRunID: start.WorkflowExecution.RunId,
+                WorkflowRunId: start.WorkflowExecution.RunId,
                 WorkflowType: start.WorkflowType);
             // Create context
             var cancelTokenSource = new CancellationTokenSource();

--- a/src/Temporalio/Worker/Interceptors/CancelExternalWorkflowInput.cs
+++ b/src/Temporalio/Worker/Interceptors/CancelExternalWorkflowInput.cs
@@ -3,13 +3,13 @@ namespace Temporalio.Worker.Interceptors
     /// <summary>
     /// Input for <see cref="WorkflowOutboundInterceptor.CancelExternalWorkflowAsync" />.
     /// </summary>
-    /// <param name="ID">Workflow ID.</param>
-    /// <param name="RunID">Workflow run ID if any.</param>
+    /// <param name="Id">Workflow ID.</param>
+    /// <param name="RunId">Workflow run ID if any.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record CancelExternalWorkflowInput(
-        string ID,
-        string? RunID);
+        string Id,
+        string? RunId);
 }

--- a/src/Temporalio/Worker/Interceptors/HandleQueryInput.cs
+++ b/src/Temporalio/Worker/Interceptors/HandleQueryInput.cs
@@ -7,7 +7,7 @@ namespace Temporalio.Worker.Interceptors
     /// <summary>
     /// Input for <see cref="WorkflowInboundInterceptor.HandleQuery" />.
     /// </summary>
-    /// <param name="ID">Query ID.</param>
+    /// <param name="Id">Query ID.</param>
     /// <param name="Query">Query name.</param>
     /// <param name="Definition">Query definition.</param>
     /// <param name="Args">Query arguments.</param>
@@ -17,7 +17,7 @@ namespace Temporalio.Worker.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record HandleQueryInput(
-        string ID,
+        string Id,
         string Query,
         WorkflowQueryDefinition Definition,
         object?[] Args,

--- a/src/Temporalio/Worker/Interceptors/SignalChildWorkflowInput.cs
+++ b/src/Temporalio/Worker/Interceptors/SignalChildWorkflowInput.cs
@@ -7,7 +7,7 @@ namespace Temporalio.Worker.Interceptors
     /// <summary>
     /// Input for <see cref="WorkflowOutboundInterceptor.SignalChildWorkflowAsync" />.
     /// </summary>
-    /// <param name="ID">Workflow ID.</param>
+    /// <param name="Id">Workflow ID.</param>
     /// <param name="Signal">Signal name.</param>
     /// <param name="Args">Signal arguments.</param>
     /// <param name="Options">Options if any.</param>
@@ -18,7 +18,7 @@ namespace Temporalio.Worker.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record SignalChildWorkflowInput(
-        string ID,
+        string Id,
         string Signal,
         IReadOnlyCollection<object?> Args,
         ChildWorkflowSignalOptions? Options,

--- a/src/Temporalio/Worker/Interceptors/SignalExternalWorkflowInput.cs
+++ b/src/Temporalio/Worker/Interceptors/SignalExternalWorkflowInput.cs
@@ -7,8 +7,8 @@ namespace Temporalio.Worker.Interceptors
     /// <summary>
     /// Input for <see cref="WorkflowOutboundInterceptor.SignalExternalWorkflowAsync" />.
     /// </summary>
-    /// <param name="ID">Workflow ID.</param>
-    /// <param name="RunID">Workflow run ID if any.</param>
+    /// <param name="Id">Workflow ID.</param>
+    /// <param name="RunId">Workflow run ID if any.</param>
     /// <param name="Signal">Signal name.</param>
     /// <param name="Args">Signal arguments.</param>
     /// <param name="Options">Options if any.</param>
@@ -19,8 +19,8 @@ namespace Temporalio.Worker.Interceptors
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record SignalExternalWorkflowInput(
-        string ID,
-        string? RunID,
+        string Id,
+        string? RunId,
         string Signal,
         IReadOnlyCollection<object?> Args,
         ExternalWorkflowSignalOptions? Options,

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -69,12 +69,12 @@ namespace Temporalio.Worker
         /// If unset, the default is
         /// <c>Assembly.GetEntryAssembly().ManifestModule.ModuleVersionId</c>.
         /// </summary>
-        public string? BuildID { get; set; }
+        public string? BuildId { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this worker opts into the worker versioning feature. This ensures it
         /// only receives workflow tasks for workflows which it claims to be compatible with. The
-        /// <see cref="BuildID"/> field is used as this worker's version when enabled, and must be set.
+        /// <see cref="BuildId"/> field is used as this worker's version when enabled, and must be set.
         /// </summary>
         public bool UseWorkerVersioning { get; set; }
 

--- a/src/Temporalio/Worker/WorkflowReplayer.cs
+++ b/src/Temporalio/Worker/WorkflowReplayer.cs
@@ -170,7 +170,7 @@ namespace Temporalio.Worker
                             DebugMode: options.DebugMode,
                             DisableWorkflowTracingEventListener: options.DisableWorkflowTracingEventListener,
                             WorkflowStackTrace: WorkflowStackTrace.None),
-                        (runID, removeFromCache) => SetResult(removeFromCache));
+                        (runId, removeFromCache) => SetResult(removeFromCache));
                 }
                 catch
                 {
@@ -229,7 +229,7 @@ namespace Temporalio.Worker
             {
                 lastHistory = history;
                 pendingResult = new();
-                bridgeReplayer.PushHistory(history.ID, new() { Events = { history.Events } });
+                bridgeReplayer.PushHistory(history.Id, new() { Events = { history.Events } });
                 return pendingResult.Task;
             }
 

--- a/src/Temporalio/Worker/WorkflowReplayerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowReplayerOptions.cs
@@ -47,7 +47,7 @@ namespace Temporalio.Worker
         /// If unset, the default is
         /// <c>Assembly.GetEntryAssembly().ManifestModule.ModuleVersionId</c>.
         /// </summary>
-        public string? BuildID { get; set; }
+        public string? BuildId { get; set; }
 
         /// <summary>
         /// Gets or sets the identity for this worker.

--- a/src/Temporalio/Worker/WorkflowTracingEventListener.cs
+++ b/src/Temporalio/Worker/WorkflowTracingEventListener.cs
@@ -24,8 +24,8 @@ namespace Temporalio.Worker
         private const bool TrackTaskEvents = false;
 
         private const string TplEventSourceName = "System.Threading.Tasks.TplEventSource";
-        private const int TplTaskWithSchedulerEventIDBegin = 7;
-        private const int TplTaskWithSchedulerEventIDEnd = 11;
+        private const int TplTaskWithSchedulerEventIdBegin = 7;
+        private const int TplTaskWithSchedulerEventIdEnd = 11;
         private const EventKeywords TplTasksKeywords = (EventKeywords)2;
 
         private const string FrameworkEventSourceName = "System.Diagnostics.Eventing.FrameworkEventSource";
@@ -202,11 +202,11 @@ namespace Temporalio.Worker
             }
         }
 
-        private static int TaskIDOfEvent(EventWrittenEventArgs evt)
+        private static int TaskIdOfEvent(EventWrittenEventArgs evt)
         {
-            if (PayloadOfEvent(evt, "TaskID") is int taskID)
+            if (PayloadOfEvent(evt, "TaskId") is int taskId)
             {
-                return taskID;
+                return taskId;
             }
             return -1;
         }
@@ -226,8 +226,8 @@ namespace Temporalio.Worker
                 TrackTaskEvent(evt);
             }
 
-            if (evt.EventId >= TplTaskWithSchedulerEventIDBegin &&
-                evt.EventId <= TplTaskWithSchedulerEventIDEnd &&
+            if (evt.EventId >= TplTaskWithSchedulerEventIdBegin &&
+                evt.EventId <= TplTaskWithSchedulerEventIdEnd &&
                 instance.Id != evt.Payload?[0] as int?)
             {
                 // Dump failure event
@@ -269,17 +269,17 @@ namespace Temporalio.Worker
 
         private void TrackTaskEvent(EventWrittenEventArgs evt)
         {
-            var taskID = TaskIDOfEvent(evt);
-            if (taskID < 0)
+            var taskId = TaskIdOfEvent(evt);
+            if (taskId < 0)
             {
                 return;
             }
             lock (taskEvents!)
             {
-                if (!taskEvents!.TryGetValue(taskID, out var eventList))
+                if (!taskEvents!.TryGetValue(taskId, out var eventList))
                 {
                     eventList = new();
-                    taskEvents![taskID] = eventList;
+                    taskEvents![taskId] = eventList;
                 }
                 eventList.Add(new(evt));
             }
@@ -290,16 +290,16 @@ namespace Temporalio.Worker
             string prefix = "Task that failed: ",
             string indent = "")
         {
-            var taskID = TaskIDOfEvent(evt);
-            if (taskID < 0)
+            var taskId = TaskIdOfEvent(evt);
+            if (taskId < 0)
             {
                 return $"{prefix}: <unknown>";
             }
             var bld = new StringBuilder(indent).
-                Append(prefix).Append(taskID).Append(", events:").AppendLine();
+                Append(prefix).Append(taskId).Append(", events:").AppendLine();
             lock (taskEvents!)
             {
-                if (taskEvents!.TryGetValue(taskID, out var eventList))
+                if (taskEvents!.TryGetValue(taskId, out var eventList))
                 {
                     foreach (var taskEvent in eventList)
                     {
@@ -311,10 +311,10 @@ namespace Temporalio.Worker
             return bld.ToString();
         }
 
-        private record TaskEvent(int TaskID, EventWrittenEventArgs Event, string Stack)
+        private record TaskEvent(int TaskId, EventWrittenEventArgs Event, string Stack)
         {
             internal TaskEvent(EventWrittenEventArgs evt)
-                : this(TaskIDOfEvent(evt), evt, new System.Diagnostics.StackTrace().ToString())
+                : this(TaskIdOfEvent(evt), evt, new System.Diagnostics.StackTrace().ToString())
             {
             }
         }

--- a/src/Temporalio/Workflows/ActivityOptions.cs
+++ b/src/Temporalio/Workflows/ActivityOptions.cs
@@ -77,7 +77,7 @@ namespace Temporalio.Workflows
         /// users have a strong understanding of the system. Contact Temporal support to discuss the
         /// use case before setting this value.
         /// </summary>
-        public string? ActivityID { get; set; }
+        public string? ActivityId { get; set; }
 
         /// <summary>
         /// Gets or sets whether this Activity should run on a worker with a compatible Build Id or not when using the

--- a/src/Temporalio/Workflows/ChildWorkflowHandle.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowHandle.cs
@@ -15,12 +15,12 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Gets the ID of the child workflow.
         /// </summary>
-        public abstract string ID { get; }
+        public abstract string Id { get; }
 
         /// <summary>
         /// Gets the initial run ID of the child workflow.
         /// </summary>
-        public abstract string FirstExecutionRunID { get; }
+        public abstract string FirstExecutionRunId { get; }
 
         /// <summary>
         /// Wait for result of the child workflow, ignoring the return value.

--- a/src/Temporalio/Workflows/ChildWorkflowOptions.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowOptions.cs
@@ -15,7 +15,7 @@ namespace Temporalio.Workflows
         /// Gets or sets the workflow ID. If unset, default will be a deterministic-random
         /// identifier.
         /// </summary>
-        public string? ID { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the task queue. If unset, default will be the parent workflow task queue.
@@ -64,7 +64,7 @@ namespace Temporalio.Workflows
         /// Gets or sets how already-existing IDs are treated. Default is
         /// <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
         /// </summary>
-        public WorkflowIdReusePolicy IDReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
+        public WorkflowIdReusePolicy IdReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
 
         /// <summary>
         /// Gets or sets the cron schedule for the workflow.

--- a/src/Temporalio/Workflows/ExternalWorkflowHandle.cs
+++ b/src/Temporalio/Workflows/ExternalWorkflowHandle.cs
@@ -15,12 +15,12 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Gets the ID of the external workflow.
         /// </summary>
-        public abstract string ID { get; }
+        public abstract string Id { get; }
 
         /// <summary>
         /// Gets the initial run ID of the child workflow.
         /// </summary>
-        public abstract string? RunID { get; }
+        public abstract string? RunId { get; }
 
         /// <summary>
         /// Signal an external workflow via a lambda call to a WorkflowSignal attributed method.

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -127,19 +127,19 @@ namespace Temporalio.Workflows
         /// </summary>
         /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
         /// <param name="id">Workflow ID.</param>
-        /// <param name="runID">Optional workflow run ID.</param>
+        /// <param name="runId">Optional workflow run ID.</param>
         /// <returns>External workflow handle.</returns>
         ExternalWorkflowHandle<TWorkflow> GetExternalWorkflowHandle<TWorkflow>(
-            string id, string? runID = null);
+            string id, string? runId = null);
 
         /// <summary>
         /// Backing call for <see cref="Workflow.Patched" /> and
         /// <see cref="Workflow.DeprecatePatch" />.
         /// </summary>
-        /// <param name="patchID">Patch ID.</param>
+        /// <param name="patchId">Patch ID.</param>
         /// <param name="deprecated">Whether to deprecate.</param>
         /// <returns>Whether patched.</returns>
-        bool Patch(string patchID, bool deprecated);
+        bool Patch(string patchId, bool deprecated);
 
         /// <summary>
         /// Backing call for

--- a/src/Temporalio/Workflows/LocalActivityOptions.cs
+++ b/src/Temporalio/Workflows/LocalActivityOptions.cs
@@ -60,7 +60,7 @@ namespace Temporalio.Workflows
         /// users have a strong understanding of the system. Contact Temporal support to discuss the
         /// use case before setting this value.
         /// </summary>
-        public string? ActivityID { get; set; }
+        public string? ActivityId { get; set; }
 
         /// <summary>
         /// Gets or sets the local retry threshold. If unset, default is 1m.

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -226,14 +226,14 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Mark a patch as deprecated.
         /// </summary>
-        /// <param name="patchID">Patch ID.</param>
+        /// <param name="patchId">Patch ID.</param>
         /// <remarks>
         /// This marks a workflow that had <see cref="Patched" /> in a previous version of the code
         /// as no longer applicable because all workflows that use the old code path are done and
         /// will never be queried again. Therefore the old code path is removed as well.
         /// </remarks>
-        public static void DeprecatePatch(string patchID) =>
-            Context.Patch(patchID, deprecated: true);
+        public static void DeprecatePatch(string patchId) =>
+            Context.Patch(patchId, deprecated: true);
 
         /// <summary>
         /// Execute a static non-async activity with result via lambda.
@@ -751,21 +751,21 @@ namespace Temporalio.Workflows
         /// Get a handle to an external workflow for cancelling and issuing signals.
         /// </summary>
         /// <param name="id">Workflow ID.</param>
-        /// <param name="runID">Optional workflow run ID.</param>
+        /// <param name="runId">Optional workflow run ID.</param>
         /// <returns>External workflow handle.</returns>
         public static ExternalWorkflowHandle GetExternalWorkflowHandle(
-            string id, string? runID = null) => GetExternalWorkflowHandle<ValueTuple>(id, runID);
+            string id, string? runId = null) => GetExternalWorkflowHandle<ValueTuple>(id, runId);
 
         /// <summary>
         /// Get a handle to an external workflow for cancelling and issuing signals.
         /// </summary>
         /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
         /// <param name="id">Workflow ID.</param>
-        /// <param name="runID">Optional workflow run ID.</param>
+        /// <param name="runId">Optional workflow run ID.</param>
         /// <returns>External workflow handle.</returns>
         public static ExternalWorkflowHandle<TWorkflow> GetExternalWorkflowHandle<TWorkflow>(
-            string id, string? runID = null) =>
-            Context.GetExternalWorkflowHandle<TWorkflow>(id, runID);
+            string id, string? runId = null) =>
+            Context.GetExternalWorkflowHandle<TWorkflow>(id, runId);
 
         /// <summary>
         /// Deterministically create a new <see cref="Guid" /> similar to
@@ -788,7 +788,7 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Patch a workflow.
         /// </summary>
-        /// <param name="patchID">Patch ID.</param>
+        /// <param name="patchId">Patch ID.</param>
         /// <returns>True if this should take the newer patch, false if it should take the old
         /// path.</returns>
         /// <remarks>
@@ -802,7 +802,7 @@ namespace Temporalio.Workflows
         /// again. The old code path can be removed at that time too.
         /// </para>
         /// </remarks>
-        public static bool Patched(string patchID) => Context.Patch(patchID, deprecated: false);
+        public static bool Patched(string patchId) => Context.Patch(patchId, deprecated: false);
 
         /// <summary>
         /// Start a child workflow via lambda invoking the run method.

--- a/src/Temporalio/Workflows/WorkflowInfo.cs
+++ b/src/Temporalio/Workflows/WorkflowInfo.cs
@@ -8,19 +8,19 @@ namespace Temporalio.Workflows
     /// Information about the running workflow.
     /// </summary>
     /// <param name="Attempt">Current workflow attempt.</param>
-    /// <param name="ContinuedRunID">Run ID if this was continued.</param>
+    /// <param name="ContinuedRunId">Run ID if this was continued.</param>
     /// <param name="CronSchedule">Cron schedule if applicable.</param>
     /// <param name="ExecutionTimeout">Execution timeout for the workflow.</param>
     /// <param name="Headers">Headers from when the workflow was started.</param>
     /// <param name="Namespace">Namespace for the workflow.</param>
     /// <param name="Parent">Parent information for the workflow if this is a child.</param>
     /// <param name="RetryPolicy">Retry policy for the workflow.</param>
-    /// <param name="RunID">Run ID for the workflow.</param>
+    /// <param name="RunId">Run ID for the workflow.</param>
     /// <param name="RunTimeout">Run timeout for the workflow.</param>
     /// <param name="StartTime">Time when the workflow started.</param>
     /// <param name="TaskQueue">Task queue for the workflow.</param>
     /// <param name="TaskTimeout">Task timeout for the workflow.</param>
-    /// <param name="WorkflowID">ID for the workflow.</param>
+    /// <param name="WorkflowId">ID for the workflow.</param>
     /// <param name="WorkflowType">Workflow type name.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
@@ -28,19 +28,19 @@ namespace Temporalio.Workflows
     /// </remarks>
     public record WorkflowInfo(
         int Attempt,
-        string? ContinuedRunID,
+        string? ContinuedRunId,
         string? CronSchedule,
         TimeSpan? ExecutionTimeout,
         IReadOnlyDictionary<string, Api.Common.V1.Payload>? Headers,
         string Namespace,
         WorkflowInfo.ParentInfo? Parent,
         RetryPolicy? RetryPolicy,
-        string RunID,
+        string RunId,
         TimeSpan? RunTimeout,
         DateTime StartTime,
         string TaskQueue,
         TimeSpan TaskTimeout,
-        string WorkflowID,
+        string WorkflowId,
         string WorkflowType)
     {
         /// <summary>
@@ -52,9 +52,9 @@ namespace Temporalio.Workflows
         {
             ["Attempt"] = Attempt,
             ["Namespace"] = Namespace,
-            ["RunID"] = RunID,
+            ["RunId"] = RunId,
             ["TaskQueue"] = TaskQueue,
-            ["WorkflowID"] = WorkflowID,
+            ["WorkflowId"] = WorkflowId,
             ["WorkflowType"] = WorkflowType,
         };
 
@@ -62,11 +62,11 @@ namespace Temporalio.Workflows
         /// Information about a parent of a workflow.
         /// </summary>
         /// <param name="Namespace">Namespace for the parent.</param>
-        /// <param name="RunID">Run ID for the parent.</param>
-        /// <param name="WorkflowID">Workflow ID for the parent.</param>
+        /// <param name="RunId">Run ID for the parent.</param>
+        /// <param name="WorkflowId">Workflow ID for the parent.</param>
         public record ParentInfo(
             string Namespace,
-            string RunID,
-            string WorkflowID);
+            string RunId,
+            string WorkflowId);
     }
 }

--- a/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
@@ -80,7 +80,7 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
 
         // Describe it and check values
         var desc = await handle.DescribeAsync();
-        Assert.Equal(handle.ID, desc.ID);
+        Assert.Equal(handle.Id, desc.Id);
         var descAction = Assert.IsType<ScheduleActionStartWorkflow>(desc.Schedule.Action);
         Assert.Equal(action.Workflow, descAction.Workflow);
         var descParams = await Assert.IsType<EncodedRawValue>(descAction.Args.Single()).ToValueAsync<KSWorkflowParams>();
@@ -141,7 +141,7 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
         Assert.NotEqual(expectedUpdateTime, desc.Info.LastUpdatedAt);
         // Try to create a duplicate
         await Assert.ThrowsAsync<ScheduleAlreadyRunningException>(
-            () => Client.CreateScheduleAsync(handle.ID, newSched));
+            () => Client.CreateScheduleAsync(handle.Id, newSched));
 
         // Confirm paused
         Assert.True(desc.Schedule.State.Paused);
@@ -179,26 +179,26 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
         var exec = Assert.IsType<ScheduleActionExecutionStartWorkflow>(desc.Info.RecentActions.Single().Action);
         Assert.Equal(
             "some result",
-            await Client.GetWorkflowHandle(exec.WorkflowID, exec.FirstExecutionRunID).GetResultAsync<string>());
+            await Client.GetWorkflowHandle(exec.WorkflowId, exec.FirstExecutionRunId).GetResultAsync<string>());
 
         // Create 4 more schedules of the same type and confirm they are in the list eventually
-        var expectedIDs = new List<string>
+        var expectedIds = new List<string>
         {
-            handle.ID,
-            (await Client.CreateScheduleAsync($"{handle.ID}-1", newSched)).ID,
-            (await Client.CreateScheduleAsync($"{handle.ID}-2", newSched)).ID,
-            (await Client.CreateScheduleAsync($"{handle.ID}-3", newSched)).ID,
-            (await Client.CreateScheduleAsync($"{handle.ID}-4", newSched)).ID,
+            handle.Id,
+            (await Client.CreateScheduleAsync($"{handle.Id}-1", newSched)).Id,
+            (await Client.CreateScheduleAsync($"{handle.Id}-2", newSched)).Id,
+            (await Client.CreateScheduleAsync($"{handle.Id}-3", newSched)).Id,
+            (await Client.CreateScheduleAsync($"{handle.Id}-4", newSched)).Id,
         };
-        await AssertMore.EqualEventuallyAsync(expectedIDs, async () =>
+        await AssertMore.EqualEventuallyAsync(expectedIds, async () =>
         {
-            var actualIDs = new List<string>();
+            var actualIds = new List<string>();
             await foreach (var sched in Client.ListSchedulesAsync())
             {
-                actualIDs.Add(sched.ID);
+                actualIds.Add(sched.Id);
             }
-            actualIDs.Sort();
-            return actualIDs;
+            actualIds.Sort();
+            return actualIds;
         });
 
         // Delete when done
@@ -269,7 +269,7 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
         var exec = Assert.IsType<ScheduleActionExecutionStartWorkflow>(desc.Info.RecentActions.Single().Action);
         Assert.Equal(
             "some result",
-            await Client.GetWorkflowHandle(exec.WorkflowID, exec.FirstExecutionRunID).GetResultAsync<string>());
+            await Client.GetWorkflowHandle(exec.WorkflowId, exec.FirstExecutionRunId).GetResultAsync<string>());
 
         // Delete when done
         await DeleteAllSchedulesAsync();
@@ -339,7 +339,7 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
             {
                 try
                 {
-                    await Client.GetScheduleHandle(sched.ID).DeleteAsync();
+                    await Client.GetScheduleHandle(sched.Id).DeleteAsync();
                 }
                 catch (RpcException e) when (e.Code == RpcException.StatusCode.NotFound)
                 {

--- a/tests/Temporalio.Tests/Client/WorkflowHandleTests.cs
+++ b/tests/Temporalio.Tests/Client/WorkflowHandleTests.cs
@@ -175,9 +175,9 @@ public class WorkflowHandleTests : WorkflowEnvironmentTestBase
         var temp = desc.CloseTime!.Value;
         Assert.InRange(desc.CloseTime!.Value, beforeNow, afterNow);
         Assert.InRange(desc.ExecutionTime!.Value, beforeNow, afterNow);
-        Assert.Null(desc.ParentID);
-        Assert.Null(desc.ParentRunID);
-        Assert.Equal(handle.FirstExecutionRunID, desc.RunID);
+        Assert.Null(desc.ParentId);
+        Assert.Null(desc.ParentRunId);
+        Assert.Equal(handle.FirstExecutionRunId, desc.RunId);
         Assert.InRange(desc.StartTime, beforeNow, afterNow);
         Assert.Equal(WorkflowExecutionStatus.Completed, desc.Status);
         Assert.Equal(Env.KitchenSinkWorkerTaskQueue, desc.TaskQueue);

--- a/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
+++ b/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
@@ -64,20 +64,20 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
             });
 
         // Check activities
-        var workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.ID) };
+        var workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.Id) };
         var workflowRunTags = workflowTags.Append(
-            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunID!)).ToArray();
+            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunId!)).ToArray();
         var workflowChildRunTags = new[]
         {
-            ActivityAssertion.TagEqual("temporalWorkflowID", handle.ID + "_child"),
-            ActivityAssertion.TagNotEqual("temporalRunID", handle.ResultRunID!),
+            ActivityAssertion.TagEqual("temporalWorkflowID", handle.Id + "_child"),
+            ActivityAssertion.TagNotEqual("temporalRunID", handle.ResultRunId!),
         };
         var activityRunTags = workflowRunTags.Append(
             ActivityAssertion.TagEqual("temporalActivityID", "1")).ToArray();
         var activityChildRunTags = workflowChildRunTags.Append(
             ActivityAssertion.TagEqual("temporalActivityID", "1")).ToArray();
         var workflowContinueRunTags = workflowTags.Append(
-            ActivityAssertion.TagNotEqual("temporalRunID", handle.ResultRunID!)).ToArray();
+            ActivityAssertion.TagNotEqual("temporalRunID", handle.ResultRunId!)).ToArray();
         var activityContinueRunTags = workflowContinueRunTags.Append(
             ActivityAssertion.TagEqual("temporalActivityID", "1")).ToArray();
         AssertActivities(
@@ -220,9 +220,9 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
         // Simple workflow task failure
         var (handle, activities) = await ExecuteTracingWorkflowAsync(
             new(new TracingWorkflowAction[] { new(FailOnNonReplay: "fail1") }));
-        var workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.ID) };
+        var workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.Id) };
         var workflowRunTags = workflowTags.Append(
-            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunID!)).ToArray();
+            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunId!)).ToArray();
         AssertActivities(
             activities,
             // Client start
@@ -259,15 +259,15 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
                 Param: new(Array.Empty<TracingWorkflowAction>()),
                 FailOnNonReplayBeforeComplete: "fail4")),
         }));
-        workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.ID) };
+        workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.Id) };
         workflowRunTags = workflowTags.Append(
-            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunID!)).ToArray();
+            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunId!)).ToArray();
         var activityRunTags = workflowRunTags.Append(
             ActivityAssertion.TagEqual("temporalActivityID", "1")).ToArray();
         var workflowChildRunTags = new[]
         {
-            ActivityAssertion.TagEqual("temporalWorkflowID", handle.ID + "_child"),
-            ActivityAssertion.TagNotEqual("temporalRunID", handle.ResultRunID!),
+            ActivityAssertion.TagEqual("temporalWorkflowID", handle.Id + "_child"),
+            ActivityAssertion.TagNotEqual("temporalRunID", handle.ResultRunId!),
         };
         AssertActivities(
             activities,
@@ -343,9 +343,9 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
         var (handle, activities) = await ExecuteTracingWorkflowAsync(
             new(new TracingWorkflowAction[] { new(AppFail: "fail1") }),
             expectFail: true);
-        var workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.ID) };
+        var workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.Id) };
         var workflowRunTags = workflowTags.Append(
-            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunID!)).ToArray();
+            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunId!)).ToArray();
         AssertActivities(
             activities,
             // Client start
@@ -370,9 +370,9 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
             new(new TracingWorkflowAction[] { new(WaitUntilSignalCount: 1) }),
             afterStart: handle => handle.SignalAsync(wf => wf.SignalFailureAsync("fail2")),
             expectFail: true);
-        workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.ID) };
+        workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.Id) };
         workflowRunTags = workflowTags.Append(
-            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunID!)).ToArray();
+            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunId!)).ToArray();
         AssertActivities(
             activities,
             // Client start
@@ -410,9 +410,9 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
             new(Array.Empty<TracingWorkflowAction>()),
             afterStart: handle => Assert.ThrowsAsync<WorkflowQueryFailedException>(() =>
                 handle.QueryAsync(wf => wf.QueryFailure("fail3"))));
-        workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.ID) };
+        workflowTags = new[] { ActivityAssertion.TagEqual("temporalWorkflowID", handle.Id) };
         workflowRunTags = workflowTags.Append(
-            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunID!)).ToArray();
+            ActivityAssertion.TagEqual("temporalRunID", handle.ResultRunId!)).ToArray();
         AssertActivities(
             activities,
             // Client start
@@ -455,9 +455,9 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
 
     private static IEnumerable<string> DumpActivities(
         IReadOnlyCollection<Activity> activities,
-        ActivitySpanId ParentID = default,
+        ActivitySpanId ParentId = default,
         int IndentDepth = 0) =>
-        activities.Where(a => a.ParentSpanId == ParentID).SelectMany(activity =>
+        activities.Where(a => a.ParentSpanId == ParentId).SelectMany(activity =>
             Enumerable.Concat(
                 new[] { DumpActivity(activity, IndentDepth) },
                 DumpActivities(activities, activity.SpanId, IndentDepth + 1)));
@@ -604,7 +604,7 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
                 {
                     var handle = await Workflow.StartChildWorkflowAsync(
                         (TracingWorkflow wf) => wf.RunAsync(action.ChildWorkflow.Param),
-                        new() { ID = Workflow.Info.WorkflowID + action.ChildWorkflow.IDSuffix });
+                        new() { Id = Workflow.Info.WorkflowId + action.ChildWorkflow.IdSuffix });
                     if (action.ChildWorkflow.FailOnNonReplayBeforeComplete != null)
                     {
                         await RaiseOnNonReplayAsync(action.ChildWorkflow.FailOnNonReplayBeforeComplete);
@@ -615,7 +615,7 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
                     }
                     if (action.ChildWorkflow.ExternalSignal)
                     {
-                        var externalHandle = Workflow.GetExternalWorkflowHandle<TracingWorkflow>(handle.ID);
+                        var externalHandle = Workflow.GetExternalWorkflowHandle<TracingWorkflow>(handle.Id);
                         await externalHandle.SignalAsync(wf => wf.Signal2Async());
                     }
                     await handle.GetResultAsync();
@@ -741,7 +741,7 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
 
     public record TracingWorkflowActionChildWorkflow(
         TracingWorkflowParam Param,
-        string IDSuffix = "_child",
+        string IdSuffix = "_child",
         bool Signal = false,
         bool ExternalSignal = false,
         string? FailOnNonReplayBeforeComplete = null);

--- a/tests/Temporalio.Tests/IKitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/IKitchenSinkWorkflow.cs
@@ -61,7 +61,7 @@ public record KSAction(
 
 public record KSResultAction(
     [property: JsonPropertyName("value")] object? Value = null,
-    [property: JsonPropertyName("run_id")] bool RunID = false);
+    [property: JsonPropertyName("run_id")] bool RunId = false);
 
 public record KSErrorAction(
     [property: JsonPropertyName("message")] string? Message = null,

--- a/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
@@ -58,9 +58,9 @@ public class KitchenSinkWorkflow
     {
         if (action.Result != null)
         {
-            if (action.Result.RunID)
+            if (action.Result.RunId)
             {
-                return (true, Workflow.Info.RunID);
+                return (true, Workflow.Info.RunId);
             }
             return (true, action.Result.Value);
         }

--- a/tests/Temporalio.Tests/TestUtils.cs
+++ b/tests/Temporalio.Tests/TestUtils.cs
@@ -14,7 +14,7 @@ public static class TestUtils
 
     public record LogEntry(
         LogLevel Level,
-        EventId EventID,
+        EventId EventId,
         object? State,
         Exception? Exception,
         string Formatted);

--- a/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
@@ -243,13 +243,13 @@ public class ActivityWorkerTests : WorkflowEnvironmentTestBase
             gotCancellation = true;
             ActivityExecutionContext.Current.CancellationToken.ThrowIfCancellationRequested();
         }
-        var workflowID = string.Empty;
+        var workflowId = string.Empty;
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ExecuteActivityAsync(
             WaitUntilCancelledAsync,
             workerStoppingToken: workerStoppingSource.Token,
             afterStarted: async handle =>
             {
-                workflowID = handle.ID;
+                workflowId = handle.Id;
                 // Wait for activity to be reached, then stop the worker
                 await activityReached.Task.WaitAsync(TimeSpan.FromSeconds(20));
                 workerStoppingSource.Cancel();
@@ -257,7 +257,7 @@ public class ActivityWorkerTests : WorkflowEnvironmentTestBase
         Assert.True(gotCancellation);
         // Check the workflow error
         var wfErr = await Assert.ThrowsAsync<WorkflowFailedException>(
-            () => Client.GetWorkflowHandle(workflowID).GetResultAsync());
+            () => Client.GetWorkflowHandle(workflowId).GetResultAsync());
         var actErr = Assert.IsType<ActivityFailureException>(wfErr.InnerException);
         Assert.IsType<ApplicationFailureException>(actErr.InnerException);
     }

--- a/tests/Temporalio.Tests/Worker/WorkerVersioningTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkerVersioningTests.cs
@@ -78,15 +78,15 @@ public class WorkerVersioningTests : WorkflowEnvironmentTestBase
                         await handle2.GetResultAsync();
 
                         // Confirm task completion events have correct IDs
-                        await ConfirmTaskCompletionBuildIDs(handle, "1.0");
-                        await ConfirmTaskCompletionBuildIDs(handle2, "2.0");
+                        await ConfirmTaskCompletionBuildIds(handle, "1.0");
+                        await ConfirmTaskCompletionBuildIds(handle2, "2.0");
                     },
-                    new(taskQueue: taskQueue) { BuildID = "2.0", UseWorkerVersioning = true });
+                    new(taskQueue: taskQueue) { BuildId = "2.0", UseWorkerVersioning = true });
             },
-            new() { BuildID = "1.0", UseWorkerVersioning = true });
+            new() { BuildId = "1.0", UseWorkerVersioning = true });
     }
 
-    private static async Task ConfirmTaskCompletionBuildIDs(WorkflowHandle handle, string expectedBuildId)
+    private static async Task ConfirmTaskCompletionBuildIds(WorkflowHandle handle, string expectedBuildId)
     {
         await foreach (var evt in handle.FetchHistoryEventsAsync())
         {


### PR DESCRIPTION
## What was changed

Everywhere `ID` is used in an identifier, we are now using `Id` to follow proper .NET guidelines. This is a breaking change.

## Checklist

1. Closes #104