### PR TITLE
Use DI logger factory in worker service and DI clients

### DIFF
--- a/src/Temporalio.Extensions.Hosting/TemporalHostingServiceCollectionExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalHostingServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Temporalio.Client;
 using Temporalio.Extensions.Hosting;
@@ -64,7 +65,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton{TService}(IServiceCollection, Func{IServiceProvider, TService})" />
         /// using a lazy client created with <see cref="TemporalClient.CreateLazy" />. The resulting
         /// builder can be used to configure the client as can any options approach that alters
-        /// <see cref="TemporalClientConnectOptions" />.
+        /// <see cref="TemporalClientConnectOptions" />. If a logging factory is on the container,
+        /// it will be set on the client.
         /// </summary>
         /// <param name="services">Service collection to add Temporal client to.</param>
         /// <param name="clientTargetHost">If set, the host to connect to.</param>
@@ -97,6 +99,13 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                 });
             }
+            builder.Configure<IServiceProvider>((options, provider) =>
+            {
+                if (provider.GetService<ILoggerFactory>() is { } loggerFactory)
+                {
+                    options.LoggerFactory = loggerFactory;
+                }
+            });
             return builder;
         }
 
@@ -105,7 +114,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton{TService}(IServiceCollection, Func{IServiceProvider, TService})" />
         /// using a lazy client created with <see cref="TemporalClient.CreateLazy" />. The action
         /// can be used to configure the client as can any options approach that alters
-        /// <see cref="TemporalClientConnectOptions" />.
+        /// <see cref="TemporalClientConnectOptions" />. If a logging factory is on the container,
+        /// it will be set on the client.
         /// </summary>
         /// <param name="services">Service collection to add Temporal client to.</param>
         /// <param name="configureClient">Action to configure client options.</param>

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerService.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerService.cs
@@ -77,8 +77,9 @@ namespace Temporalio.Extensions.Hosting
         /// </param>
         /// <param name="existingClient">Existing client to use if the options don't specify
         /// client connection options (connected when run if lazy and not connected).</param>
-        /// <param name="loggerFactory">Logger factory to use if there is no logger factory on the
-        /// existing client, or the client connect options, or the worker options.</param>
+        /// <param name="loggerFactory">Logger factory to use if not already on the worker options.
+        /// The worker options logger factory or this one will be also be used for the client if an
+        /// existing client does not exist (regardless of client options' logger factory).</param>
         [ActivatorUtilitiesConstructor]
         public TemporalWorkerService(
             string taskQueue,
@@ -99,14 +100,13 @@ namespace Temporalio.Extensions.Hosting
             }
 
             workerOptions = options;
-            // If a logging factory is provided and it is not on the client options already or
-            // worker options already, set it on the worker options
-            if (loggerFactory != null &&
-                workerOptions.LoggerFactory == null &&
-                newClientOptions?.LoggerFactory == null &&
-                existingClient?.Options?.LoggerFactory == null)
+
+            // Set logger factory on worker options if not already there
+            workerOptions.LoggerFactory ??= loggerFactory;
+            // Put logger factory, if present, on client options
+            if (newClientOptions != null && workerOptions.LoggerFactory != null)
             {
-                options.LoggerFactory = loggerFactory;
+                newClientOptions.LoggerFactory = workerOptions.LoggerFactory;
             }
         }
 


### PR DESCRIPTION
## What was changed

Made DI logger factory be used for worker (and created client) regardless of existing client or client options. Previously we were checking client options logger factory is not null which is never possible. The client options has a default logger factory always set so it's unreasonable to try to tell when it's unset. We feel this is a better option than making client logger factory nullable project-wide.

## Checklist

1. Closes #116