### PR TITLE
Client keep alive support

### DIFF
--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -115,6 +115,15 @@ namespace Temporalio.Bridge.Interop
         public UIntPtr max_retries;
     }
 
+    internal partial struct ClientKeepAliveOptions
+    {
+        [NativeTypeName("uint64_t")]
+        public ulong interval_millis;
+
+        [NativeTypeName("uint64_t")]
+        public ulong timeout_millis;
+    }
+
     internal unsafe partial struct ClientOptions
     {
         [NativeTypeName("struct ByteArrayRef")]
@@ -137,6 +146,9 @@ namespace Temporalio.Bridge.Interop
 
         [NativeTypeName("const struct ClientRetryOptions *")]
         public ClientRetryOptions* retry_options;
+
+        [NativeTypeName("const struct ClientKeepAliveOptions *")]
+        public ClientKeepAliveOptions* keep_alive_options;
     }
 
     internal unsafe partial struct ByteArray

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -233,6 +233,10 @@ namespace Temporalio.Bridge
                     options.RpcRetry == null
                         ? null
                         : scope.Pointer(options.RpcRetry.ToInteropOptions()),
+                keep_alive_options =
+                    options.KeepAlive == null
+                        ? null
+                        : scope.Pointer(options.KeepAlive.ToInteropOptions()),
             };
         }
 
@@ -284,6 +288,19 @@ namespace Temporalio.Bridge
                 max_retries = (UIntPtr)options.MaxRetries,
             };
         }
+
+        /// <summary>
+        /// Convert keep alive options.
+        /// </summary>
+        /// <param name="options">Options to convert.</param>
+        /// <returns>Converted options.</returns>
+        public static Interop.ClientKeepAliveOptions ToInteropOptions(
+            this Temporalio.Client.KeepAliveOptions options) =>
+            new()
+            {
+                interval_millis = (ulong)options.Interval.TotalMilliseconds,
+                timeout_millis = (ulong)options.Timeout.TotalMilliseconds,
+            };
 
         /// <summary>
         /// Convert start local options options.

--- a/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
+++ b/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
@@ -77,6 +77,11 @@ typedef struct ClientRetryOptions {
   uintptr_t max_retries;
 } ClientRetryOptions;
 
+typedef struct ClientKeepAliveOptions {
+  uint64_t interval_millis;
+  uint64_t timeout_millis;
+} ClientKeepAliveOptions;
+
 typedef struct ClientOptions {
   struct ByteArrayRef target_url;
   struct ByteArrayRef client_name;
@@ -85,6 +90,7 @@ typedef struct ClientOptions {
   struct ByteArrayRef identity;
   const struct ClientTlsOptions *tls_options;
   const struct ClientRetryOptions *retry_options;
+  const struct ClientKeepAliveOptions *keep_alive_options;
 } ClientOptions;
 
 typedef struct ByteArray {

--- a/src/Temporalio/Bridge/src/runtime.rs
+++ b/src/Temporalio/Bridge/src/runtime.rs
@@ -169,7 +169,8 @@ impl Runtime {
         if let Some(v) = unsafe { options.telemetry.as_ref() } {
             if let Some(v) = unsafe { v.metrics.as_ref() } {
                 let _guard = core.tokio_handle().enter();
-                core.telemetry_mut().attach_late_init_metrics(create_meter(v, custom_meter)?);
+                core.telemetry_mut()
+                    .attach_late_init_metrics(create_meter(v, custom_meter)?);
             }
         }
         Ok(Runtime {
@@ -223,7 +224,10 @@ impl TryFrom<&TelemetryOptions> for CoreTelemetryOptions {
     }
 }
 
-fn create_meter(options: &MetricsOptions, custom_meter: Option<CustomMetricMeterRef>) -> anyhow::Result<Arc<dyn CoreMeter>> {
+fn create_meter(
+    options: &MetricsOptions,
+    custom_meter: Option<CustomMetricMeterRef>,
+) -> anyhow::Result<Arc<dyn CoreMeter>> {
     // OTel, Prom, or custom
     if let Some(otel_options) = unsafe { options.opentelemetry.as_ref() } {
         if !options.prometheus.is_null() || custom_meter.is_some() {

--- a/src/Temporalio/Client/KeepAliveOptions.cs
+++ b/src/Temporalio/Client/KeepAliveOptions.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Temporalio.Client
+{
+    /// <summary>
+    /// Keep alive options for Temporal connections.
+    /// </summary>
+    public class KeepAliveOptions : ICloneable
+    {
+        /// <summary>
+        /// Gets or sets the interval to send HTTP2 keep alive pings.
+        /// </summary>
+        public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Gets or sets the timeout that the keep alive must be responded to within or the
+        /// connection will be closed.
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(15);
+
+        /// <summary>
+        /// Create a shallow copy of these options.
+        /// </summary>
+        /// <returns>A shallow copy of these options.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -52,6 +52,14 @@ namespace Temporalio.Client
         public RpcRetryOptions? RpcRetry { get; set; }
 
         /// <summary>
+        /// Gets or sets keep alive options for this connection.
+        /// </summary>
+        /// <remarks>
+        /// Default enabled, set to null to disable.
+        /// </remarks>
+        public KeepAliveOptions? KeepAlive { get; set; } = new();
+
+        /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).
         /// </summary>
         /// <remarks>
@@ -94,6 +102,10 @@ namespace Temporalio.Client
             if (RpcRetry != null)
             {
                 copy.RpcRetry = (RpcRetryOptions)RpcRetry.Clone();
+            }
+            if (KeepAlive != null)
+            {
+                copy.KeepAlive = (KeepAliveOptions)KeepAlive.Clone();
             }
             return copy;
         }


### PR DESCRIPTION
## What was changed

Added `Temporalio.Client.KeepAliveOptions` and parameters for connection, defaulting to 30s interval w/ 15s timeout but also allowing disabling.

There's not a great way to unit test this without slowing down unit tests

## Checklist

1. Closes #125
