### PR TITLE
Use .Net 6.0 LTS for Microsoft.Extensions.Hosting

### DIFF
--- a/src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj
+++ b/src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#169 reduce Microsoft.Extensions.Hosting to .net 6 to allow current LTS support