### PR TITLE
Properly ignore unknown fields when parsing history JSON

### DIFF
--- a/src/Temporalio/Common/WorkflowHistory.cs
+++ b/src/Temporalio/Common/WorkflowHistory.cs
@@ -22,6 +22,9 @@ namespace Temporalio.Common
         private static readonly JsonSerializerOptions JsonSerializerOptions =
             new() { Converters = { JsonCommonTypeConverter.Instance } };
 
+        private static readonly JsonParser ProtoJsonParser = new(
+            JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+
         /// <summary>
         /// Interface for fixes to apply.
         /// </summary>
@@ -71,7 +74,7 @@ namespace Temporalio.Common
             // serialize the altered, then deserialize again using Proto JSON
             HistoryJsonFixer.Fix(historyObj);
             var fixedJson = JsonSerializer.Serialize(historyObj);
-            var history = JsonParser.Default.Parse<History>(fixedJson);
+            var history = ProtoJsonParser.Parse<History>(fixedJson);
             return new(workflowId, history.Events);
         }
 


### PR DESCRIPTION
## What was changed

We weren't properly ignoring unknown fields when parsing history JSON for replay, we are now. There is an argument to be made for/against whether we _should_, but other SDKs do.

## Checklist

1. Closes #173