### PR TITLE
Fix issue with Rust cache using newer node version

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,7 +50,8 @@ jobs:
           toolchain: stable
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        # Fixed version due to https://github.com/Swatinem/rust-cache/issues/183#issuecomment-1893979126
+        uses: Swatinem/rust-cache@v2.7.0
         with:
           workspaces: src/Temporalio/Bridge
           key: ${{ matrix.os }}


### PR DESCRIPTION
## What was changed

We use older container for glibc compat when building binaries, but rust-cache doesn't work in that container by default anymore. So we fixate the rust-cache version. See https://github.com/Swatinem/rust-cache/issues/183#issuecomment-1893979126.

Tested in this issue by forcing this workflow to run in this PR under draft then removed that force.