### PR TITLE
Eager workflow start

### DIFF
--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -462,6 +462,7 @@ namespace Temporalio.Client
                     RequestId = Guid.NewGuid().ToString(),
                     WorkflowIdReusePolicy = input.Options.IdReusePolicy,
                     RetryPolicy = input.Options.RetryPolicy?.ToProto(),
+                    RequestEagerExecution = input.Options.RequestEagerStart,
                 };
                 if (input.Args.Count > 0)
                 {

--- a/src/Temporalio/Client/WorkflowOptions.cs
+++ b/src/Temporalio/Client/WorkflowOptions.cs
@@ -103,6 +103,14 @@ namespace Temporalio.Client
         public IReadOnlyCollection<object?>? StartSignalArgs { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the workflow will request eager start. This
+        /// potentially reduces the latency to start the workflow by encouraging the server to
+        /// start it on a local worker running this same client.
+        /// </summary>
+        /// <remarks>WARNING: Eager workflow start is experimental.</remarks>
+        public bool RequestEagerStart { get; set; }
+
+        /// <summary>
         /// Gets or sets RPC options for starting the workflow.
         /// </summary>
         public RpcOptions? Rpc { get; set; }


### PR DESCRIPTION
## What was changed

Add eager workflow start option. There's no good way to test (sure we could make sure it comes back from server, but that doesn't verify behavior that server actually did eagerly route it, and it'd require a secret variable).

## Checklist

1. Closes #183