### PR TITLE
Use Debugger.IsAttached to affect default for debug mode

### DIFF
--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Temporalio.Activities;
@@ -193,7 +194,8 @@ namespace Temporalio.Worker
 
         /// <summary>
         /// Gets or sets a value indicating whether deadlock detection will be disabled for all
-        /// workflows. If unset, this value defaults to true only if the <c>TEMPORAL_DEBUG</c>
+        /// workflows. If unset, this value defaults to true only if
+        /// <see cref="Debugger.IsAttached" /> is <c>true</c> or the <c>TEMPORAL_DEBUG</c>
         /// environment variable is <c>true</c> or <c>1</c>.
         /// </summary>
         /// <remarks>
@@ -203,7 +205,8 @@ namespace Temporalio.Worker
         /// </remarks>
         public bool DebugMode { get; set; } =
             string.Equals(DebugModeEnvironmentVariable, "true", StringComparison.OrdinalIgnoreCase) ||
-            DebugModeEnvironmentVariable == "1";
+            DebugModeEnvironmentVariable == "1" ||
+            Debugger.IsAttached;
 
         /// <summary>
         /// Gets or sets a value indicating whether workflow tracing event listener will be disabled


### PR DESCRIPTION
## What was changed

In addition to env var, now also let [Debugger.IsAttached](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debugger.isattached) affect the default of `DebugMode` worker option.

## Checklist

1. Closes #157
