### PR TITLE
Fix issue with unconfigured metric meter

### DIFF
--- a/src/Temporalio/Bridge/MetricMeter.cs
+++ b/src/Temporalio/Bridge/MetricMeter.cs
@@ -10,18 +10,11 @@ namespace Temporalio.Bridge
     /// </summary>
     internal class MetricMeter : SafeHandle
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetricMeter"/> class.
-        /// </summary>
-        /// <param name="runtime">Runtime.</param>
-        public MetricMeter(Runtime runtime)
+        private unsafe MetricMeter(Interop.MetricMeter* ptr)
             : base(IntPtr.Zero, true)
         {
-            unsafe
-            {
-                Ptr = Interop.Methods.metric_meter_new(runtime.Ptr);
-                SetHandle((IntPtr)Ptr);
-            }
+            Ptr = ptr;
+            SetHandle((IntPtr)Ptr);
             DefaultAttributes = new(this, Enumerable.Empty<KeyValuePair<string, object>>());
         }
 
@@ -37,6 +30,24 @@ namespace Temporalio.Bridge
         /// Gets the pointer to the meter.
         /// </summary>
         internal unsafe Interop.MetricMeter* Ptr { get; private init; }
+
+        /// <summary>
+        /// Create a new metric meter from runtime if any configured.
+        /// </summary>
+        /// <param name="runtime">Runtime.</param>
+        /// <returns>Meter or null if none configured.</returns>
+        public static MetricMeter? CreateFromRuntime(Runtime runtime)
+        {
+            unsafe
+            {
+                var ptr = Interop.Methods.metric_meter_new(runtime.Ptr);
+                if (ptr == null)
+                {
+                    return null;
+                }
+                return new(ptr);
+            }
+        }
 
         /// <inheritdoc />
         protected override unsafe bool ReleaseHandle()

--- a/src/Temporalio/Bridge/Runtime.cs
+++ b/src/Temporalio/Bridge/Runtime.cs
@@ -68,7 +68,7 @@ namespace Temporalio.Bridge
                     SetHandle((IntPtr)Ptr);
                 }
             }
-            MetricMeter = new(() => new(this));
+            MetricMeter = new(() => Bridge.MetricMeter.CreateFromRuntime(this));
         }
 
         /// <inheritdoc />
@@ -80,9 +80,9 @@ namespace Temporalio.Bridge
         internal unsafe Interop.Runtime* Ptr { get; private init; }
 
         /// <summary>
-        /// Gets the lazy metric meter for this runtime.
+        /// Gets the lazy metric meter for this runtime. Can be null.
         /// </summary>
-        internal Lazy<MetricMeter> MetricMeter { get; private init; }
+        internal Lazy<MetricMeter?> MetricMeter { get; private init; }
 
         /// <summary>
         /// Read a JSON object into string keys and raw JSON values.

--- a/src/Temporalio/Common/MetricMeterBridge.cs
+++ b/src/Temporalio/Common/MetricMeterBridge.cs
@@ -66,7 +66,14 @@ namespace Temporalio.Common
         /// <param name="runtime">Runtime to base on.</param>
         /// <returns>Lazy meter.</returns>
         internal static Lazy<MetricMeter> LazyFromRuntime(Bridge.Runtime runtime) => new(() =>
-            new MetricMeterBridge(runtime.MetricMeter.Value, runtime.MetricMeter.Value.DefaultAttributes));
+        {
+            // If there is not one on the bridge runtime, use a noop
+            if (runtime.MetricMeter.Value is { } bridgeMeter)
+            {
+                return new MetricMeterBridge(bridgeMeter, bridgeMeter.DefaultAttributes);
+            }
+            return MetricMeterNoop.Instance;
+        });
 
         private static void AssertValidMetricType<T>()
         {

--- a/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
+++ b/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using Temporalio.Bridge;
 using Temporalio.Client;
+using Temporalio.Common;
 using Temporalio.Runtime;
 using Temporalio.Worker;
 using Temporalio.Workflows;
@@ -159,6 +160,17 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
             new Dictionary<string, object>()
                 { { "service_name", "temporal-core-sdk" }, { "string-tag", "gaugeval" } },
             metricValues[0].Tags);
+    }
+
+    [Fact]
+    public async Task Runtime_NoMetricMeter_WorksProperly()
+    {
+        // Create runtime with no telemetry
+        var runtime = new TemporalRuntime(new());
+
+        // Try to record a counter just to ensure it doesn't fail
+        runtime.MetricMeter.CreateCounter<int>("counter1").Add(123);
+        Assert.IsType<MetricMeterNoop>(runtime.MetricMeter);
     }
 
     [Fact]


### PR DESCRIPTION
## What was changed

It was a bug today that if you used a runtime metric meter but had never configured one, you'd get a scary segfault. This fixes that to set a no-op meter.

## Checklist

1. Closes #135