### PR TITLE
Alternative CreateTemporalActivityDefinition

### DIFF
--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -70,7 +70,7 @@ namespace Temporalio.Extensions.Hosting
 #endif
                 try
                 {
-                    object? result = null;
+                    object? result;
                     try
                     {
                         // Invoke static or non-static
@@ -86,9 +86,9 @@ namespace Temporalio.Extensions.Hosting
                         ExceptionDispatchInfo.Capture(e.InnerException!).Throw();
 #else
                         ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+#endif
                         // Unreachable
                         throw new InvalidOperationException("Unreachable");
-#endif
                     }
 
                     // In order to make sure the scope lasts the life of the activity, we need to

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -107,7 +107,7 @@ namespace Temporalio.Extensions.Hosting
                             result = ValueTuple.Create();
                         }
                     }
-                    return result!;
+                    return result;
                 }
                 finally
                 {

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -64,9 +64,7 @@ namespace Temporalio.Extensions.Hosting
             {
                 // Wrap in a scope (even for statics to keep logic simple)
 #if NET6_0_OR_GREATER
-#pragma warning disable CA2007 // Invalid for AsyncServiceScope, ServiceProvider is not accessible via ConfiguredAsyncDisposable object type.
                 var scope = provider.CreateAsyncScope();
-#pragma warning restore CA2007
 #else
                 var scope = provider.CreateScope();
 #endif

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -41,11 +41,7 @@ namespace Temporalio.Extensions.Hosting
             type.
                 GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance).
                 Where(method => method.IsDefined(typeof(ActivityAttribute))).
-#if NET6_0_OR_GREATER
-                Select(method => provider.AsyncCreateTemporalActivityDefinition(type, method)).
-#else
                 Select(method => provider.CreateTemporalActivityDefinition(type, method)).
-#endif
                 ToList();
 
         /// <summary>
@@ -59,27 +55,44 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="method">Method to create activity definition from.</param>
         /// <returns>Created definition.</returns>
         public static ActivityDefinition CreateTemporalActivityDefinition(
-            this IServiceProvider provider, Type instanceType, MethodInfo method)
+            this IServiceProvider provider,
+            Type instanceType,
+            MethodInfo method)
         {
             // Invoker can be async (i.e. returns Task<object?>)
-            Func<object?[], Task<object?>> invoker = async args =>
+            async Task<object?> Invoker(object?[] args)
             {
                 // Wrap in a scope (even for statics to keep logic simple)
-                using (var scope = provider.CreateScope())
+#if NET6_0_OR_GREATER
+#pragma warning disable CA2007 // Invalid for AsyncServiceScope, ServiceProvider is not accessible via ConfiguredAsyncDisposable object type.
+                var scope = provider.CreateAsyncScope();
+#pragma warning restore CA2007
+#else
+                var scope = provider.CreateScope();
+#endif
+                try
                 {
                     object? result = null;
                     try
                     {
                         // Invoke static or non-static
-                        var instance = method.IsStatic ? null : scope.ServiceProvider.GetRequiredService(instanceType);
+                        var instance = method.IsStatic
+                            ? null
+                            : scope.ServiceProvider.GetRequiredService(instanceType);
+
                         result = method.Invoke(instance, args);
                     }
                     catch (TargetInvocationException e)
                     {
+#if NET6_0_OR_GREATER
                         ExceptionDispatchInfo.Capture(e.InnerException!).Throw();
+#else
+                        ExceptionDispatchInfo.Capture(e.InnerException).Throw();
                         // Unreachable
                         throw new InvalidOperationException("Unreachable");
+#endif
                     }
+
                     // In order to make sure the scope lasts the life of the activity, we need to
                     // wait on the task if it's a task
                     if (result is Task resultTask)
@@ -96,71 +109,18 @@ namespace Temporalio.Extensions.Hosting
                             result = ValueTuple.Create();
                         }
                     }
-                    return result;
+                    return result!;
                 }
-            };
-            return ActivityDefinition.Create(method, invoker);
-        }
-
+                finally
+                {
 #if NET6_0_OR_GREATER
-        /// <summary>
-        /// Create activity definition for the given activity-attributed method on the given
-        /// instance type. If the method is non-static, this will use the service provider to get
-        /// the instance to call the method on.
-        /// </summary>
-        /// <param name="provider">Service provider for creating the instance if the method is
-        /// non-static.</param>
-        /// <param name="instanceType">Type of the instance.</param>
-        /// <param name="method">Method to create activity definition from.</param>
-        /// <returns>Created definition.</returns>
-        public static ActivityDefinition AsyncCreateTemporalActivityDefinition(
-            this IServiceProvider provider,
-            Type instanceType,
-            MethodInfo method)
-        {
-            // Invoker can be async (i.e. returns Task<object?>)
-            async Task<object?> Invoker(object?[] args)
-            {
-                // Wrap in a scope (even for statics to keep logic simple)
-#pragma warning disable CA2007 // Invalid for AsyncServiceScope, ServiceProvider is not accessible via ConfiguredAsyncDisposable object type.
-                await using var scope = provider.CreateAsyncScope();
-#pragma warning restore CA2007
-
-                object? result = null;
-                try
-                {
-                    // Invoke static or non-static
-                    var instance = method.IsStatic
-                        ? null
-                        : scope.ServiceProvider.GetRequiredService(instanceType);
-
-                    result = method.Invoke(instance, args);
+                    await scope.DisposeAsync().ConfigureAwait(false);
+#else
+                    scope.Dispose();
+#endif
                 }
-                catch (TargetInvocationException e)
-                {
-                    ExceptionDispatchInfo.Capture(e.InnerException!).Throw();
-                }
-
-                // In order to make sure the scope lasts the life of the activity, we need to
-                // wait on the task if it's a task
-                if (result is Task resultTask)
-                {
-                    await resultTask.ConfigureAwait(false);
-                    // We have to use reflection to extract value if it's a Task<>
-                    var resultTaskType = resultTask.GetType();
-                    if (resultTaskType.IsGenericType)
-                    {
-                        result = resultTaskType.GetProperty("Result")!.GetValue(resultTask);
-                    }
-                    else
-                    {
-                        result = ValueTuple.Create();
-                    }
-                }
-                return result!;
             }
             return ActivityDefinition.Create(method, Invoker);
         }
-#endif
     }
 }

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -41,7 +41,11 @@ namespace Temporalio.Extensions.Hosting
             type.
                 GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance).
                 Where(method => method.IsDefined(typeof(ActivityAttribute))).
+#if NET6_0_OR_GREATER
+                Select(method => provider.AsyncCreateTemporalActivityDefinition(type, method)).
+#else
                 Select(method => provider.CreateTemporalActivityDefinition(type, method)).
+#endif
                 ToList();
 
         /// <summary>
@@ -58,12 +62,12 @@ namespace Temporalio.Extensions.Hosting
             this IServiceProvider provider, Type instanceType, MethodInfo method)
         {
             // Invoker can be async (i.e. returns Task<object?>)
-            Func<object?[], Task<object>> invoker = async args =>
+            Func<object?[], Task<object?>> invoker = async args =>
             {
                 // Wrap in a scope (even for statics to keep logic simple)
                 using (var scope = provider.CreateScope())
                 {
-                    object? result;
+                    object? result = null;
                     try
                     {
                         // Invoke static or non-static
@@ -97,5 +101,66 @@ namespace Temporalio.Extensions.Hosting
             };
             return ActivityDefinition.Create(method, invoker);
         }
+
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Create activity definition for the given activity-attributed method on the given
+        /// instance type. If the method is non-static, this will use the service provider to get
+        /// the instance to call the method on.
+        /// </summary>
+        /// <param name="provider">Service provider for creating the instance if the method is
+        /// non-static.</param>
+        /// <param name="instanceType">Type of the instance.</param>
+        /// <param name="method">Method to create activity definition from.</param>
+        /// <returns>Created definition.</returns>
+        public static ActivityDefinition AsyncCreateTemporalActivityDefinition(
+            this IServiceProvider provider,
+            Type instanceType,
+            MethodInfo method)
+        {
+            // Invoker can be async (i.e. returns Task<object?>)
+            async Task<object?> Invoker(object?[] args)
+            {
+                // Wrap in a scope (even for statics to keep logic simple)
+#pragma warning disable CA2007 // Invalid for AsyncServiceScope, ServiceProvider is not accessible via ConfiguredAsyncDisposable object type.
+                await using var scope = provider.CreateAsyncScope();
+#pragma warning restore CA2007
+
+                object? result = null;
+                try
+                {
+                    // Invoke static or non-static
+                    var instance = method.IsStatic
+                        ? null
+                        : scope.ServiceProvider.GetRequiredService(instanceType);
+
+                    result = method.Invoke(instance, args);
+                }
+                catch (TargetInvocationException e)
+                {
+                    ExceptionDispatchInfo.Capture(e.InnerException!).Throw();
+                }
+
+                // In order to make sure the scope lasts the life of the activity, we need to
+                // wait on the task if it's a task
+                if (result is Task resultTask)
+                {
+                    await resultTask.ConfigureAwait(false);
+                    // We have to use reflection to extract value if it's a Task<>
+                    var resultTaskType = resultTask.GetType();
+                    if (resultTaskType.IsGenericType)
+                    {
+                        result = resultTaskType.GetProperty("Result")!.GetValue(resultTask);
+                    }
+                    else
+                    {
+                        result = ValueTuple.Create();
+                    }
+                }
+                return result!;
+            }
+            return ActivityDefinition.Create(method, Invoker);
+        }
+#endif
     }
 }

--- a/src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj
+++ b/src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj
@@ -8,7 +8,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj
+++ b/src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj
@@ -8,7 +8,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What Changed
Allow the usage of AsyncServiceProvider in the ServiceProviderExtensions for NET6+ during `CreateTemporalActivityDefinitions`.

- Backwards compatible.
- Choose the package to run as NET6.0. Preprocess directives are only looking for `NET6_0_OR_GREATER` making it very easy to change to NET6+.

Compiler recommend converting `delegate` variable...
```csharp
Func<object?[], Task<object?>> invoker = async args =>
```
...to a `local` and  `async` function.
```csharp
async Task<object?> Invoker(object?[] args)
```
and I fully [agree](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions). After feedback, this went through the rounds as being compatible.

## Why?
Uses an `AsyncServiceScope` which allows the `IAsyncDisposable` interface to be invoked when created by `CreateAsyncScope` from the `IServiceProvider`.

This is a more modern way to handle IAsyncDisposable classes that are used in Dependency Injection. Without it, you can trigger these types of exceptions.
```plaintext
Unhandled exception. System.InvalidOperationException: 'MyClass' type only implements IAsyncDisposable. Use DisposeAsync to dispose the container.
```
 Also handles `IDisposable` the same as it did before.

## Checklist

### 1. Closes

Should close issue #204 

### 2. Testing

Ran all UnitTests locally to ensure backwards compatibility. Future testing needed when the main `Temporalio` is brought up to be compatible with NET6 or NET8.  

224/224 Passing.  
![image](https://github.com/temporalio/sdk-dotnet/assets/1414138/0776635d-bf41-4653-aedd-e2f6aed9a7a8)

### 3. Any docs updates needed?

I do not believe so. This code follows typical usage as presented by Microsoft internally to AspNetCore/BackgroundServices or through the `dotnet/runtime`.