### PR TITLE
Use build ID in the unique DI identifier for workers

### DIFF
--- a/src/Temporalio.Extensions.Hosting/ITemporalWorkerServiceOptionsBuilder.cs
+++ b/src/Temporalio.Extensions.Hosting/ITemporalWorkerServiceOptionsBuilder.cs
@@ -15,6 +15,11 @@ namespace Temporalio.Extensions.Hosting
         string TaskQueue { get; }
 
         /// <summary>
+        /// Gets the build ID for this worker service. If unset, versioning is disabled.
+        /// </summary>
+        string? BuildId { get; }
+
+        /// <summary>
         /// Gets the service collection being configured.
         /// </summary>
         IServiceCollection Services { get; }

--- a/src/Temporalio.Extensions.Hosting/TemporalHostingServiceCollectionExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalHostingServiceCollectionExtensions.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="taskQueue">Task queue for the worker.</param>
         /// <param name="buildId">
-        /// Build ID for the worker. Set to non-null to opt in to versioning. If versioning wanted,
-        /// this must be set here and not later via configure options. This is because the
+        /// Build ID for the worker. Set to non-null to opt in to versioning. If versioning is
+        /// wanted, this must be set here and not later via configure options. This is because the
         /// combination of task queue and build ID make up the unique identifier for a worker in the
         /// service collection.
         /// </param>
@@ -55,8 +55,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">Service collection to create hosted worker on.</param>
         /// <param name="taskQueue">Task queue for the worker.</param>
         /// <param name="buildId">
-        /// Build ID for the worker. Set to non-null to opt in to versioning. If versioning wanted,
-        /// this must be set here and not later via configure options. This is because the
+        /// Build ID for the worker. Set to non-null to opt in to versioning. If versioning is
+        /// wanted, this must be set here and not later via configure options. This is because the
         /// combination of task queue and build ID make up the unique identifier for a worker in the
         /// service collection.
         /// </param>

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptions.cs
@@ -41,5 +41,20 @@ namespace Temporalio.Extensions.Hosting
             }
             return options;
         }
+
+        /// <summary>
+        /// Get an options name for the given task queue and build ID.
+        /// </summary>
+        /// <param name="taskQueue">Task queue.</param>
+        /// <param name="buildId">Build ID.</param>
+        /// <returns>Unique string name for the options.</returns>
+        internal static string GetUniqueOptionsName(string taskQueue, string? buildId)
+        {
+            if (buildId == null)
+            {
+                return taskQueue;
+            }
+            return taskQueue + "!!__temporal__!!" + buildId;
+        }
     }
 }

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilder.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilder.cs
@@ -14,13 +14,29 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="taskQueue">Task queue for the worker.</param>
         /// <param name="services">Service collection being configured.</param>
         public TemporalWorkerServiceOptionsBuilder(string taskQueue, IServiceCollection services)
+            : this(taskQueue, null, services)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalWorkerServiceOptionsBuilder" />
+        /// class.
+        /// </summary>
+        /// <param name="taskQueue">Task queue for the worker.</param>
+        /// <param name="buildId">Build ID for the worker.</param>
+        /// <param name="services">Service collection being configured.</param>
+        public TemporalWorkerServiceOptionsBuilder(string taskQueue, string? buildId, IServiceCollection services)
         {
             TaskQueue = taskQueue;
+            BuildId = buildId;
             Services = services;
         }
 
         /// <inheritdoc />
         public string TaskQueue { get; private init; }
+
+        /// <inheritdoc />
+        public string? BuildId { get; private init; }
 
         /// <inheritdoc />
         public IServiceCollection Services { get; private init; }

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
@@ -175,7 +175,8 @@ namespace Temporalio.Extensions.Hosting
             this ITemporalWorkerServiceOptionsBuilder builder,
             bool disallowDuplicates = false)
         {
-            // To ensure the user isn't accidentally double, we can disallow duplicates
+            // To ensure the user isn't accidentally registering a duplicate task queue + build ID
+            // worker, we check here that there aren't duplicate options
             var optionsName = TemporalWorkerServiceOptions.GetUniqueOptionsName(
                     builder.TaskQueue, builder.BuildId);
             if (disallowDuplicates)


### PR DESCRIPTION
## What was changed

* Added build ID option when adding a worker to the service collection
* Made sure to reference options by task queue + build ID instead of just task queue
* Throw an exception if users try to create the same worker identifier twice or if they change the options from what the identifier expects


## Checklist

1. Closes #212
