### PR TITLE
Support duration and float metrics

### DIFF
--- a/src/Temporalio/Bridge/Api/WorkflowActivation/WorkflowActivation.cs
+++ b/src/Temporalio/Bridge/Api/WorkflowActivation/WorkflowActivation.cs
@@ -193,6 +193,7 @@ namespace Temporalio.Bridge.Api.WorkflowActivation {
   /// * Signal and update handlers should be invoked before workflow routines are iterated. That is to
   ///   say before the users' main workflow function and anything spawned by it is allowed to continue.
   /// * Queries always go last (and, in fact, always come in their own activation)
+  /// * Evictions also always come in their own activation
   ///
   /// The downside of this reordering is that a signal or update handler may not observe that some
   /// other event had already happened (ex: an activity completed) when it is first invoked, though it
@@ -204,11 +205,9 @@ namespace Temporalio.Bridge.Api.WorkflowActivation {
   ///
   /// ## Evictions
   ///
-  /// Activations that contain only a `remove_from_cache` job should not cause the workflow code
-  /// to be invoked and may be responded to with an empty command list. Eviction jobs may also
-  /// appear with other jobs, but will always appear last in the job list. In this case it is
-  /// expected that the workflow code will be invoked, and the response produced as normal, but
-  /// the caller should evict the run after doing so.
+  /// Evictions appear as an activations that contains only a `remove_from_cache` job. Such activations
+  /// should not cause the workflow code to be invoked and may be responded to with an empty command
+  /// list.
   /// </summary>
   internal sealed partial class WorkflowActivation : pb::IMessage<WorkflowActivation>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
@@ -853,7 +852,8 @@ namespace Temporalio.Bridge.Api.WorkflowActivation {
     /// <summary>Field number for the "query_workflow" field.</summary>
     public const int QueryWorkflowFieldNumber = 5;
     /// <summary>
-    /// A request to query the workflow was received.
+    /// A request to query the workflow was received. It is guaranteed that queries (one or more)
+    /// always come in their own activation after other mutating jobs.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -1005,11 +1005,9 @@ namespace Temporalio.Bridge.Api.WorkflowActivation {
     /// <summary>Field number for the "remove_from_cache" field.</summary>
     public const int RemoveFromCacheFieldNumber = 50;
     /// <summary>
-    /// Remove the workflow identified by the [WorkflowActivation] containing this job from the cache
-    /// after performing the activation.
-    ///
-    /// If other job variant are present in the list, this variant will be the last job in the
-    /// job list. The string value is a reason for eviction.
+    /// Remove the workflow identified by the [WorkflowActivation] containing this job from the
+    /// cache after performing the activation. It is guaranteed that this will be the only job
+    /// in the activation if present.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]

--- a/src/Temporalio/Bridge/Cargo.lock
+++ b/src/Temporalio/Bridge/Cargo.lock
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -2388,11 +2388,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "base64",
  "derive_builder",
  "derive_more",
  "futures",
  "futures-retry",
  "http 0.2.11",
+ "hyper 0.14.28",
  "once_cell",
  "parking_lot",
  "prost-types",

--- a/src/Temporalio/Bridge/Metric.cs
+++ b/src/Temporalio/Bridge/Metric.cs
@@ -4,23 +4,23 @@ using System.Runtime.InteropServices;
 namespace Temporalio.Bridge
 {
     /// <summary>
-    /// Core-owned metric for integers.
+    /// Core-owned metric.
     /// </summary>
-    internal class MetricInteger : SafeHandle
+    internal class Metric : SafeHandle
     {
-        private readonly unsafe Interop.MetricInteger* ptr;
+        private readonly unsafe Interop.Metric* ptr;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MetricInteger"/> class.
+        /// Initializes a new instance of the <see cref="Metric"/> class.
         /// </summary>
         /// <param name="meter">Core meter.</param>
         /// <param name="kind">Metric kind.</param>
         /// <param name="name">Metric name.</param>
         /// <param name="unit">Metric unit.</param>
         /// <param name="description">Metric description.</param>
-        public MetricInteger(
+        public Metric(
             MetricMeter meter,
-            Interop.MetricIntegerKind kind,
+            Interop.MetricKind kind,
             string name,
             string? unit,
             string? description)
@@ -30,14 +30,14 @@ namespace Temporalio.Bridge
             {
                 unsafe
                 {
-                    var options = new Interop.MetricIntegerOptions()
+                    var options = new Interop.MetricOptions()
                     {
                         name = scope.ByteArray(name),
                         description = scope.ByteArray(description ?? string.Empty),
                         unit = scope.ByteArray(unit ?? string.Empty),
                         kind = kind,
                     };
-                    ptr = Interop.Methods.metric_integer_new(meter.Ptr, scope.Pointer(options));
+                    ptr = Interop.Methods.metric_new(meter.Ptr, scope.Pointer(options));
                     SetHandle((IntPtr)ptr);
                 }
             }
@@ -51,18 +51,44 @@ namespace Temporalio.Bridge
         /// </summary>
         /// <param name="value">Value to record.</param>
         /// <param name="attributes">Attributes to set.</param>
-        public void Record(ulong value, MetricAttributes attributes)
+        public void RecordInteger(ulong value, MetricAttributes attributes)
         {
             unsafe
             {
-                Interop.Methods.metric_integer_record(ptr, value, attributes.Ptr);
+                Interop.Methods.metric_record_integer(ptr, value, attributes.Ptr);
+            }
+        }
+
+        /// <summary>
+        /// Record a value for the metric.
+        /// </summary>
+        /// <param name="value">Value to record.</param>
+        /// <param name="attributes">Attributes to set.</param>
+        public void RecordFloat(double value, MetricAttributes attributes)
+        {
+            unsafe
+            {
+                Interop.Methods.metric_record_float(ptr, value, attributes.Ptr);
+            }
+        }
+
+        /// <summary>
+        /// Record a value for the metric.
+        /// </summary>
+        /// <param name="valueMs">Value to record.</param>
+        /// <param name="attributes">Attributes to set.</param>
+        public void RecordDuration(ulong valueMs, MetricAttributes attributes)
+        {
+            unsafe
+            {
+                Interop.Methods.metric_record_duration(ptr, valueMs, attributes.Ptr);
             }
         }
 
         /// <inheritdoc />
         protected override unsafe bool ReleaseHandle()
         {
-            Interop.Methods.metric_integer_free(ptr);
+            Interop.Methods.metric_free(ptr);
             return true;
         }
     }

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -92,6 +92,7 @@ namespace Temporalio.Bridge
                         ? 0
                         : options.MetricsExportInterval.Value.TotalMilliseconds),
                 metric_temporality = temporality,
+                durations_as_seconds = (byte)(options.UseSecondsForDuration ? 1 : 0),
             };
         }
 
@@ -114,6 +115,7 @@ namespace Temporalio.Bridge
                 bind_address = scope.ByteArray(options.BindAddress),
                 counters_total_suffix = (byte)(options.HasCounterTotalSuffix ? 1 : 0),
                 unit_suffix = (byte)(options.HasUnitSuffix ? 1 : 0),
+                durations_as_seconds = (byte)(options.UseSecondsForDuration ? 1 : 0),
             };
         }
 
@@ -181,7 +183,8 @@ namespace Temporalio.Bridge
             else if (options.CustomMetricMeter != null)
             {
                 // This object pins itself in memory and is only freed on the Rust side
-                customMeter = new CustomMetricMeter(options.CustomMetricMeter).Ptr;
+                customMeter = new CustomMetricMeter(
+                    options.CustomMetricMeter, options.CustomMetricMeterOptions ?? new()).Ptr;
             }
             else
             {

--- a/src/Temporalio/Common/MetricMeter.cs
+++ b/src/Temporalio/Common/MetricMeter.cs
@@ -25,7 +25,8 @@ namespace Temporalio.Common
         /// Create a new histogram. Performance is better if this histogram is reused instead of
         /// recreating it.
         /// </summary>
-        /// <typeparam name="T">Type of value for the metric. Currently this must be an integer
+        /// <typeparam name="T">Type of value for the metric. Currently this must be an integer,
+        /// float, or <see cref="System.TimeSpan"/> type.
         /// type.</typeparam>
         /// <param name="name">Name for the histogram.</param>
         /// <param name="unit">Unit for the histogram if any.</param>
@@ -39,8 +40,8 @@ namespace Temporalio.Common
         /// Create a new gauge. Performance is better if this gauge is reused instead of recreating
         /// it.
         /// </summary>
-        /// <typeparam name="T">Type of value for the metric. Currently this must be an integer
-        /// type.</typeparam>
+        /// <typeparam name="T">Type of value for the metric. Currently this must be an integer or
+        /// float type.</typeparam>
         /// <param name="name">Name for the gauge.</param>
         /// <param name="unit">Unit for the gauge if any.</param>
         /// <param name="description">Description for the gauge if any.</param>

--- a/src/Temporalio/Runtime/CustomMetricMeterOptions.cs
+++ b/src/Temporalio/Runtime/CustomMetricMeterOptions.cs
@@ -1,0 +1,40 @@
+namespace Temporalio.Runtime
+{
+    /// <summary>
+    /// Options for custom metric meter.
+    /// </summary>
+    public class CustomMetricMeterOptions
+    {
+        /// <summary>
+        /// Format for duration values in metrics.
+        /// </summary>
+        public enum DurationFormat
+        {
+            /// <summary>
+            /// Format the value as <c>long</c> milliseconds.
+            /// </summary>
+            IntegerMilliseconds,
+
+            /// <summary>
+            /// Format the value as <c>double</c> seconds.
+            /// </summary>
+            FloatSeconds,
+
+            /// <summary>
+            /// Format the value as <see cref="System.TimeSpan" />.
+            /// </summary>
+            TimeSpan,
+        }
+
+        /// <summary>
+        /// Gets or sets how histogram duration values are given to the interface.
+        /// </summary>
+        public DurationFormat HistogramDurationFormat { get; set; } = DurationFormat.IntegerMilliseconds;
+
+        /// <summary>
+        /// Create a shallow copy of these options.
+        /// </summary>
+        /// <returns>A shallow copy of these options and any transitive options fields.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio/Runtime/ICustomMetricMeter.cs
+++ b/src/Temporalio/Runtime/ICustomMetricMeter.cs
@@ -11,7 +11,7 @@ namespace Temporalio.Runtime
         /// Create a metric counter.
         /// </summary>
         /// <typeparam name="T">The type of counter value. Currently this is always
-        /// <c>long</c>.</typeparam>
+        /// <c>long</c>, but the types can change in the future.</typeparam>
         /// <param name="name">Name for the metric.</param>
         /// <param name="unit">Unit for the metric if any.</param>
         /// <param name="description">Description for the metric if any.</param>
@@ -23,12 +23,19 @@ namespace Temporalio.Runtime
         /// <summary>
         /// Create a metric histogram.
         /// </summary>
-        /// <typeparam name="T">The type of histogram value. Currently this is always
-        /// <c>long</c>.</typeparam>
+        /// <typeparam name="T">The type of histogram value. Currently this can be <c>long</c>,
+        /// <c>double</c>, or <see cref="System.TimeSpan" />, but the types can change in the
+        /// future.</typeparam>
         /// <param name="name">Name for the metric.</param>
         /// <param name="unit">Unit for the metric if any.</param>
         /// <param name="description">Description for the metric if any.</param>
         /// <returns>Histogram to be called with updates.</returns>
+        /// <remarks>
+        /// By default all histograms are set as a <c>long</c> of milliseconds unless
+        /// <see cref="MetricsOptions.CustomMetricMeterOptions"/> is set to <c>FloatSeconds</c>.
+        /// Similarly, if the unit for a histogram is "duration", it is changed to "ms" unless that
+        /// same setting is set, at which point the unit is changed to "s".
+        /// </remarks>
         ICustomMetricHistogram<T> CreateHistogram<T>(
             string name, string? unit, string? description)
             where T : struct;
@@ -36,8 +43,8 @@ namespace Temporalio.Runtime
         /// <summary>
         /// Create a metric gauge.
         /// </summary>
-        /// <typeparam name="T">The type of gauge value. Currently this is always
-        /// <c>long</c>.</typeparam>
+        /// <typeparam name="T">The type of gauge value. Currently this can be <c>long</c> or
+        /// <c>double</c>, but the types can change in the future.</typeparam>
         /// <param name="name">Name for the metric.</param>
         /// <param name="unit">Unit for the metric if any.</param>
         /// <param name="description">Description for the metric if any.</param>

--- a/src/Temporalio/Runtime/MetricsOptions.cs
+++ b/src/Temporalio/Runtime/MetricsOptions.cs
@@ -45,6 +45,12 @@ namespace Temporalio.Runtime
         public ICustomMetricMeter? CustomMetricMeter { get; set; }
 
         /// <summary>
+        /// Gets or sets the custom metric meter options. Only applies if
+        /// <see cref="CustomMetricMeter"/> is not null.
+        /// </summary>
+        public CustomMetricMeterOptions? CustomMetricMeterOptions { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the service name is set on metrics.
         /// </summary>
         public bool AttachServiceName { get; set; } = true;

--- a/src/Temporalio/Runtime/OpenTelemetryOptions.cs
+++ b/src/Temporalio/Runtime/OpenTelemetryOptions.cs
@@ -52,6 +52,12 @@ namespace Temporalio.Runtime
         public OpenTelemetryMetricTemporality MetricTemporality { get; set; } = OpenTelemetryMetricTemporality.Cumulative;
 
         /// <summary>
+        /// Gets or sets a value indicating whether duration values will be emitted as float
+        /// seconds. If false, it is integer milliseconds.
+        /// </summary>
+        public bool UseSecondsForDuration { get; set; }
+
+        /// <summary>
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>

--- a/src/Temporalio/Runtime/PrometheusOptions.cs
+++ b/src/Temporalio/Runtime/PrometheusOptions.cs
@@ -36,6 +36,12 @@ namespace Temporalio.Runtime
         public bool HasUnitSuffix { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether duration values will be emitted as float
+        /// seconds. If false, it is integer milliseconds.
+        /// </summary>
+        public bool UseSecondsForDuration { get; set; }
+
+        /// <summary>
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>

--- a/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
+++ b/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
@@ -97,15 +97,15 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
             (metrics[0].Name, metrics[0].Unit, metrics[0].Description));
         var metricValues = metrics[0].Values.ToList();
         Assert.Equal(4, metricValues.Count);
-        Assert.Equal(123, metricValues[0].Value);
+        Assert.Equal(123L, metricValues[0].Value);
         Assert.Equal(
             new Dictionary<string, object>() { { "service_name", "temporal-core-sdk" } },
             metricValues[0].Tags);
-        Assert.Equal(234, metricValues[1].Value);
+        Assert.Equal(234L, metricValues[1].Value);
         Assert.Equal(
             new Dictionary<string, object>() { { "service_name", "temporal-core-sdk" } },
             metricValues[1].Tags);
-        Assert.Equal(345, metricValues[2].Value);
+        Assert.Equal(345L, metricValues[2].Value);
         Assert.Equal(
             new Dictionary<string, object>()
             {
@@ -116,7 +116,7 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
                 { "bool-tag", false },
             },
             metricValues[2].Tags);
-        Assert.Equal(456, metricValues[3].Value);
+        Assert.Equal(456L, metricValues[3].Value);
         Assert.Equal(
             new Dictionary<string, object>()
             {
@@ -134,7 +134,7 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
             (metrics[1].Name, metrics[1].Unit, metrics[1].Description));
         metricValues = metrics[1].Values.ToList();
         Assert.Single(metricValues);
-        Assert.Equal(567, metricValues[0].Value);
+        Assert.Equal(567L, metricValues[0].Value);
         Assert.Equal(
             new Dictionary<string, object>() { { "service_name", "temporal-core-sdk" } },
             metricValues[0].Tags);
@@ -144,7 +144,7 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
             (metrics[2].Name, metrics[2].Unit, metrics[2].Description));
         metricValues = metrics[2].Values.ToList();
         Assert.Single(metricValues);
-        Assert.Equal(678, metricValues[0].Value);
+        Assert.Equal(678L, metricValues[0].Value);
         Assert.Equal(
             new Dictionary<string, object>()
                 { { "service_name", "temporal-core-sdk" }, { "string-tag", "histval" } },
@@ -155,7 +155,7 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
             (metrics[3].Name, metrics[3].Unit, metrics[3].Description));
         metricValues = metrics[3].Values.ToList();
         Assert.Single(metricValues);
-        Assert.Equal(789, metricValues[0].Value);
+        Assert.Equal(789L, metricValues[0].Value);
         Assert.Equal(
             new Dictionary<string, object>()
                 { { "service_name", "temporal-core-sdk" }, { "string-tag", "gaugeval" } },


### PR DESCRIPTION
## What was changed

* Allow `MetricMeter.CreateHistogram` to provide floating point types or `TimeSpan` in addition to already-supported integer types
* Allow `MetricMeter.CreateGauge` to provide floating point types in addition to already-supported integer types
* Added `OpenTelemetryOptions.UseSecondsForDuration` option to have OTel metrics use float seconds instead of ms
* Added `PrometheusOptions.UseSecondsForDuration` option to have Prom metrics use float seconds instead of ms
* `ICustomMetricMeter.CreateHistogram` now supports `double` and `TimeSpan` (for those creating custom meter impls)
  * Minor 💥 compat break, but only if the caller starts creating histograms for floats/durations or sets non-default duration format option
* `ICustomMetricMeter.CreateGauge` now supports `double` (for those creating custom meter impls)
  * Minor 💥 compat break, but only if the caller starts creating gauges for floats
* Added `MetricsOptions.CustomMetricMeterOptions` which accepts an option type whose only field is `HistogramDurationFormat` to specify whether meter impls will get duration metrics as integer milliseconds, float seconds, or time spans
* Tests

## Checklist

1. Closes #209