### PR TITLE
Make ctor for `DefaultPayloadConverter` public to expose `JsonSerializerOptions`

### DIFF
--- a/src/Temporalio/Converters/DefaultPayloadConverter.cs
+++ b/src/Temporalio/Converters/DefaultPayloadConverter.cs
@@ -56,7 +56,7 @@ namespace Temporalio.Converters
         /// instances, so only subclasses would call this.
         /// </remarks>
         /// <seealso cref="DefaultPayloadConverter()" />
-        protected DefaultPayloadConverter(JsonSerializerOptions jsonSerializerOptions)
+        public DefaultPayloadConverter(JsonSerializerOptions jsonSerializerOptions)
             : this(
                 new BinaryNullConverter(),
                 new BinaryPlainConverter(),

--- a/src/Temporalio/Converters/DefaultPayloadConverter.cs
+++ b/src/Temporalio/Converters/DefaultPayloadConverter.cs
@@ -51,10 +51,6 @@ namespace Temporalio.Converters
         /// Initializes a new instance of the <see cref="DefaultPayloadConverter"/> class.
         /// </summary>
         /// <param name="jsonSerializerOptions">Custom serializer options.</param>
-        /// <remarks>
-        /// This is protected because payload converters are referenced as class types, not
-        /// instances, so only subclasses would call this.
-        /// </remarks>
         /// <seealso cref="DefaultPayloadConverter()" />
         public DefaultPayloadConverter(JsonSerializerOptions jsonSerializerOptions)
             : this(
@@ -73,12 +69,8 @@ namespace Temporalio.Converters
         /// <param name="encodingConverters">
         /// Encoding converters to use. Duplicate encodings not allowed.
         /// </param>
-        /// <remarks>
-        /// This is protected because payload converters are referenced as class types, not
-        /// instances, so only subclasses would call this.
-        /// </remarks>
         /// <seealso cref="DefaultPayloadConverter()" />
-        protected DefaultPayloadConverter(params IEncodingConverter[] encodingConverters)
+        public DefaultPayloadConverter(params IEncodingConverter[] encodingConverters)
         {
             EncodingConverters = Array.AsReadOnly(encodingConverters);
             IndexedEncodingConverters = encodingConverters.ToDictionary(
@@ -87,7 +79,6 @@ namespace Temporalio.Converters
 
         // KeyedCollection not worth it and OrderedDictionary not generic. So we'll expose the
         // collection and maintain an internal dictionary.
-
         /// <summary>
         /// Gets the encoding converters tried, in order, when converting to payload.
         /// </summary>

--- a/src/Temporalio/Converters/DefaultPayloadConverter.cs
+++ b/src/Temporalio/Converters/DefaultPayloadConverter.cs
@@ -79,6 +79,7 @@ namespace Temporalio.Converters
 
         // KeyedCollection not worth it and OrderedDictionary not generic. So we'll expose the
         // collection and maintain an internal dictionary.
+
         /// <summary>
         /// Gets the encoding converters tried, in order, when converting to payload.
         /// </summary>


### PR DESCRIPTION
Resolves #225.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Made the ctor for `DefaultPayloadConverter` public to expose `JsonSerializerOptions`.

## Why?
This is to allow customizing the json serializer without creating a new Payload Converter and incurring additional configuration overhead.

## Checklist
<!--- add/delete as needed --->

1. Closes #225 

2. How was this tested:
The compiler + existing tests.

3. Any docs updates needed?
Do not think so. Maybe worth a mention of this capability via https://github.com/temporalio/samples-dotnet/issues/38
