### PR TITLE
Use macos-12 GHA runners instead of macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-arm]
+        os: [ubuntu-latest, macos-12, windows-latest, ubuntu-arm]
         include:
           - os: windows-latest
             checkTarget: true


### PR DESCRIPTION
## What was changed

- In CI, use `macos-12` GHA runners instead of `macos-latest`, as `macos

## Why?

- GitHub Action’s runner `macos-latest` has just been updated to point to `macos-14`, which are M1-based machines, rather than `macos-12`, which were x64-based machines.

This is a breaking change at this time, as there is no binary distribution of protoc 3.x for that architecture.

    ```
    Run arduino/setup-protoc@v1
    Getting protoc version: v3.20.3
    Downloading archive: https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-osx-aarch_64.zip
    Error: Error: Failed to download version v3.20.3: Error, Unexpected HTTP response: 404 - 404
    ```