### PR TITLE
Fix issue enumerating services in newer .NET DI library

### DIFF
--- a/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
@@ -80,6 +80,11 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
             services.
                 AddSingleton<ILoggerFactory>(loggerFactory).
                 AddScoped<DatabaseClient>().
+                // We are also adding the DB client as a keyed service to demonstrate keyed service
+                // support for our DI logic. This used to break because newer DI library versions
+                // disallowed accessing certain properties on keyed services which we access
+                // internally for dupe checks.
+                AddKeyedScoped<DatabaseClient>("client-keyed").
                 AddHostedTemporalWorker(taskQueue).
                 AddScopedActivities<DatabaseActivities>().
                 AddWorkflow<DatabaseWorkflow>();

--- a/tests/Temporalio.Tests/Temporalio.Tests.csproj
+++ b/tests/Temporalio.Tests/Temporalio.Tests.csproj
@@ -12,7 +12,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.4.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />


### PR DESCRIPTION
## What was changed

* Swallow exception unrelated to us when enumerating services to check for dupe worker
* Update DI test to cause the exception (which also means updating DI library in tests)

## Checklist

1. Closes #238