### PR TITLE
Required wait update stage and polling improvements

### DIFF
--- a/src/Temporalio/Client/Interceptors/StartWorkflowUpdateInput.cs
+++ b/src/Temporalio/Client/Interceptors/StartWorkflowUpdateInput.cs
@@ -11,7 +11,7 @@ namespace Temporalio.Client.Interceptors
     /// <param name="FirstExecutionRunId">Workflow first execution run ID if any.</param>
     /// <param name="Update">Update name.</param>
     /// <param name="Args">Update arguments.</param>
-    /// <param name="Options">Options if any.</param>
+    /// <param name="Options">Options.</param>
     /// <param name="Headers">Headers if any. These will be encoded using the codec before sent
     /// to the server.</param>
     /// <remarks>
@@ -24,6 +24,6 @@ namespace Temporalio.Client.Interceptors
         string? FirstExecutionRunId,
         string Update,
         IReadOnlyCollection<object?> Args,
-        WorkflowUpdateOptions? Options,
+        WorkflowUpdateStartOptions Options,
         IDictionary<string, Payload>? Headers);
 }

--- a/src/Temporalio/Client/WorkflowUpdateOptions.cs
+++ b/src/Temporalio/Client/WorkflowUpdateOptions.cs
@@ -22,7 +22,7 @@ namespace Temporalio.Client
         public WorkflowUpdateOptions(string id) => Id = id;
 
         /// <summary>
-        /// Gets or sets the unique workflow identifier. If not set, this is defaulted to a GUID.
+        /// Gets or sets the unique update identifier. If not set, this is defaulted to a GUID.
         /// This must be unique within the scope of a workflow execution (i.e. namespace +
         /// workflow ID + run ID).
         /// </summary>

--- a/src/Temporalio/Client/WorkflowUpdateOptions.cs
+++ b/src/Temporalio/Client/WorkflowUpdateOptions.cs
@@ -1,30 +1,37 @@
 using System;
-using Temporalio.Api.Enums.V1;
 
 namespace Temporalio.Client
 {
     /// <summary>
-    /// Options for starting an update on a <see cref="WorkflowHandle" />.
+    /// Options for executing an update on a <see cref="WorkflowHandle" />.
     /// </summary>
     /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
     public class WorkflowUpdateOptions : ICloneable
     {
         /// <summary>
-        /// Gets or sets the unique identifier for the update. This is optional and is defaulted to
-        /// a GUID if not set. This must be unique within the scope of a workflow execution (i.e.
-        /// namespace + workflow ID + run ID).
+        /// Initializes a new instance of the <see cref="WorkflowUpdateOptions"/> class.
         /// </summary>
-        public string? UpdateID { get; set; }
+        public WorkflowUpdateOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowUpdateOptions"/> class.
+        /// </summary>
+        /// <param name="id">Update ID.</param>
+        public WorkflowUpdateOptions(string id) => Id = id;
+
+        /// <summary>
+        /// Gets or sets the unique workflow identifier. If not set, this is defaulted to a GUID.
+        /// This must be unique within the scope of a workflow execution (i.e. namespace +
+        /// workflow ID + run ID).
+        /// </summary>
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets RPC options for starting the workflow.
         /// </summary>
         public RpcOptions? Rpc { get; set; }
-
-        /// <summary>
-        /// Gets or sets the stage to wait for on start. Internal only.
-        /// </summary>
-        internal UpdateWorkflowExecutionLifecycleStage WaitForStage { get; set; }
 
         /// <summary>
         /// Create a shallow copy of these options.

--- a/src/Temporalio/Client/WorkflowUpdateStage.cs
+++ b/src/Temporalio/Client/WorkflowUpdateStage.cs
@@ -1,0 +1,34 @@
+using Temporalio.Api.Enums.V1;
+
+namespace Temporalio.Client
+{
+    /// <summary>
+    /// Stage that an update can reach. This is used when starting an update to set the stage to
+    /// wait for before returning.
+    /// </summary>
+    public enum WorkflowUpdateStage
+    {
+        /// <summary>
+        /// Unset stage. This is an invalid value on start.
+        /// </summary>
+        None = UpdateWorkflowExecutionLifecycleStage.Unspecified,
+
+        /// <summary>
+        /// Admitted stage. This stage is reached when the server receives the update to process.
+        /// This is currently an invalid value on start.
+        /// </summary>
+        Admitted = UpdateWorkflowExecutionLifecycleStage.Admitted,
+
+        /// <summary>
+        /// Accepted stage. This stage is reached when a workflow has received the update and either
+        /// accepted or rejected it.
+        /// </summary>
+        Accepted = UpdateWorkflowExecutionLifecycleStage.Accepted,
+
+        /// <summary>
+        /// Completed stage. This stage is reached when a workflow has completed processing the
+        /// update with either a success or failure.
+        /// </summary>
+        Completed = UpdateWorkflowExecutionLifecycleStage.Completed,
+    }
+}

--- a/src/Temporalio/Client/WorkflowUpdateStage.cs
+++ b/src/Temporalio/Client/WorkflowUpdateStage.cs
@@ -21,7 +21,7 @@ namespace Temporalio.Client
 
         /// <summary>
         /// Accepted stage. This stage is reached when a workflow has received the update and either
-        /// accepted or rejected it.
+        /// accepted (i.e. it has passed validation) or rejected it.
         /// </summary>
         Accepted = UpdateWorkflowExecutionLifecycleStage.Accepted,
 

--- a/src/Temporalio/Client/WorkflowUpdateStartOptions.cs
+++ b/src/Temporalio/Client/WorkflowUpdateStartOptions.cs
@@ -1,0 +1,37 @@
+namespace Temporalio.Client
+{
+    /// <summary>
+    /// Options for starting an update on a <see cref="WorkflowHandle" />.
+    /// </summary>
+    /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
+    public class WorkflowUpdateStartOptions : WorkflowUpdateOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowUpdateStartOptions"/> class.
+        /// </summary>
+        public WorkflowUpdateStartOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowUpdateStartOptions"/> class.
+        /// </summary>
+        /// <param name="waitForStage">Stage to wait for.</param>
+        public WorkflowUpdateStartOptions(WorkflowUpdateStage waitForStage) =>
+            WaitForStage = waitForStage;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowUpdateStartOptions"/> class.
+        /// </summary>
+        /// <param name="id">Update ID.</param>
+        /// <param name="waitForStage">Stage to wait for.</param>
+        public WorkflowUpdateStartOptions(string id, WorkflowUpdateStage waitForStage)
+            : base(id) => WaitForStage = waitForStage;
+
+        /// <summary>
+        /// Gets or sets the stage to wait for on start. This is required and cannot be set to
+        /// <c>None</c> or <c>Admitted</c> at this time.
+        /// </summary>
+        public WorkflowUpdateStage WaitForStage { get; set; }
+    }
+}


### PR DESCRIPTION
## What was changed

* Created new `WorkflowUpdateStartOptions` as an extension of `WorkflowUpdateOptions` that has a required `WaitForStage`
* Created new `WorkflowUpdateStage` enum representing its proto equivalent
* Changed start update calls to _require_ `WorkflowUpdateStartOptions` (:boom: breaking change)
* Disallow `None` or `Admitted` wait stage on start, user must specify one
* Updated start to continually start until stage reached or stage accepted, then poll if needed to reach complete
* Added test to confirm workflow and update completed in same task

## Checklist

1. Closes #198
1. Closes #199
1. Closes #231
