### PR TITLE
Improved docs for RetryPolicy.NonRetryableErrorTypes

### DIFF
--- a/src/Temporalio/Common/RetryPolicy.cs
+++ b/src/Temporalio/Common/RetryPolicy.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Google.Protobuf.WellKnownTypes;
-using Temporalio.Exceptions;
 
 namespace Temporalio.Common
 {
@@ -34,7 +33,7 @@ namespace Temporalio.Common
         /// <summary>
         /// Gets or sets the collection of error types that are not retryable.
         /// </summary>
-        /// <remarks>Refers to the <see cref="ApplicationFailureException.ErrorType"/> property.</remarks>
+        /// <remarks>Refers to the <see cref="Temporalio.Exceptions.ApplicationFailureException.ErrorType"/> property.</remarks>
         public IReadOnlyCollection<string>? NonRetryableErrorTypes { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Common/RetryPolicy.cs
+++ b/src/Temporalio/Common/RetryPolicy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Google.Protobuf.WellKnownTypes;
+using Temporalio.Exceptions;
 
 namespace Temporalio.Common
 {
@@ -33,6 +34,7 @@ namespace Temporalio.Common
         /// <summary>
         /// Gets or sets the collection of error types that are not retryable.
         /// </summary>
+        /// <remarks>Refers to the <see cref="ApplicationFailureException.ErrorType"/> property.</remarks>
         public IReadOnlyCollection<string>? NonRetryableErrorTypes { get; set; }
 
         /// <summary>


### PR DESCRIPTION
## What was changed
Extended XML docs for RetryPolicy.NonRetryableErrorTypes property.

## Why?
Wanted to make it obvious that values from NonRetryableErrorTypes property are matched against ApplicationFailureException.ErrorType property.