### PR TITLE
Fix wait condition evaluation issue

### DIFF
--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -196,8 +196,19 @@ namespace Temporalio.Workflows
         /// </remarks>
         public static DateTime UtcNow => Context.UtcNow;
 
+        /// <summary>
+        /// Gets an async local to override the context.
+        /// </summary>
+        /// <remarks>
+        /// This was only made available so WaitConditionAsync callbacks could have access to the
+        /// workflow context without running inside the task scheduler.
+        /// </remarks>
+        internal static AsyncLocal<IWorkflowContext?> OverrideContext { get; } = new();
+
         private static IWorkflowContext Context =>
-            TaskScheduler.Current as IWorkflowContext ?? throw new InvalidOperationException("Not in workflow");
+            TaskScheduler.Current as IWorkflowContext ??
+            OverrideContext.Value ??
+            throw new InvalidOperationException("Not in workflow");
 
         /// <summary>
         /// Create an exception via lambda invoking the run method that, when thrown out of the

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -4580,7 +4580,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 var handle = await Env.Client.StartWorkflowAsync(
                     (ConditionBounceWorkflow wf) => wf.RunAsync(),
                     new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
-                await AssertHasEventEventuallyAsync(handle, evt => evt.WorkflowTaskCompletedEventAttributes != null);
+                await AssertMore.HasEventEventuallyAsync(
+                    handle, evt => evt.WorkflowTaskCompletedEventAttributes != null);
                 await handle.SignalAsync(wf => wf.DoSignalAsync());
                 await handle.GetResultAsync();
             });

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -4543,6 +4543,50 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             new TemporalWorkerOptions().AddActivity(NextRetryDelayWorkflow.NextRetryDelayActivity));
     }
 
+    [Workflow]
+    public class ConditionBounceWorkflow
+    {
+        private int workflowCounter;
+        private int signalCounter;
+
+        [WorkflowRun]
+        public async Task RunAsync()
+        {
+            while (workflowCounter < 5)
+            {
+                var counterBefore = workflowCounter;
+                await Workflow.WaitConditionAsync(() => workflowCounter > counterBefore);
+                signalCounter++;
+            }
+        }
+
+        [WorkflowSignal]
+        public async Task DoSignalAsync()
+        {
+            while (signalCounter < 5)
+            {
+                workflowCounter++;
+                var counterBefore = signalCounter;
+                await Workflow.WaitConditionAsync(() => signalCounter > counterBefore);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_ConditionBounce_ProperlyReschedules()
+    {
+        await ExecuteWorkerAsync<ConditionBounceWorkflow>(
+            async worker =>
+            {
+                var handle = await Env.Client.StartWorkflowAsync(
+                    (ConditionBounceWorkflow wf) => wf.RunAsync(),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+                await AssertHasEventEventuallyAsync(handle, evt => evt.WorkflowTaskCompletedEventAttributes != null);
+                await handle.SignalAsync(wf => wf.DoSignalAsync());
+                await handle.GetResultAsync();
+            });
+    }
+
     internal static Task AssertTaskFailureContainsEventuallyAsync(
         WorkflowHandle handle, string messageContains)
     {


### PR DESCRIPTION
## What was changed

This fixes/reverts an issue caused by #242. Specifically that issue scheduled condition checks as a task and just ran all tasks to completion. The problem is that we don't re-schedule the condition checks after the tasks that the conditions caused to wake up are completed. So we have effectively reverted that issue to return to evaluating conditions inline, but we added a feature to allow `Workflow` access from inside the conditionals.

💥 **WARNING** This is technically a _history_ backwards incompatible change for anyone that has used 1.1.1 and has relied on wait conditions to be woken up after other coroutines set values. After discussion it was determined that short life and limited use of of the 1.1.1 release allows us to fix this 3-week bug. But this can technically cause non-determinism in those upgrading from 1.1.1 in that it can make a condition properly be re-evaluated a second time in a task where it wasn't before. Users before 1.1.1 are not affected.