### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,12 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -80,7 +78,7 @@ jobs:
 
       - name: Upload test failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-fail-${{ matrix.os }}
           path: tests/Temporalio.Tests/TestResults

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -57,6 +57,7 @@ jobs:
           toolchain: stable
 
       - name: Setup Rust cache
+        # FIXME: v2.7.2+ requires Node 20
         # Fixed version due to https://github.com/Swatinem/rust-cache/issues/183#issuecomment-1893979126
         uses: Swatinem/rust-cache@v2.7.1
         with:
@@ -92,7 +93,7 @@ jobs:
 
       - name: Download bridge libraries
         # Need v3 here to stay compatible with the compile-native-binaries job.
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3-node20
         with:
           path: bridge-libraries
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,43 +38,43 @@ jobs:
             out-prefix: win-x64
     runs-on: ${{ matrix.runsOn || matrix.os }}
     container: ${{ matrix.container }}
+    env:
+      # This is required to allow continuing usage of Node 16 for actions,
+      # as Node 20 won't run on the docker image we use for linux builds
+      # (Node 20 require glibc 2.28+, but container image has glibc 2.17).
+      # https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        # FIXME: v4+ requires Node 20
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
       - name: Setup Rust cache
         # Fixed version due to https://github.com/Swatinem/rust-cache/issues/183#issuecomment-1893979126
-        uses: Swatinem/rust-cache@v2.7.0
+        uses: Swatinem/rust-cache@v2.7.1
         with:
           workspaces: src/Temporalio/Bridge
           key: ${{ matrix.os }}
 
-      - name: Install protoc (non-Linux)
-        if: ${{ matrix.os != 'ubuntu-latest' && matrix.os != 'ubuntu-arm' }}
-        uses: arduino/setup-protoc@v3
+      - name: Install protoc
+        # FIXME: v3+ requires Node 20
+        uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install protoc (Linux)
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-arm' }}
-        run: |
-          curl --location -o protobuf-compiler.zip ${{ matrix.protobuf-url }}
-          mkdir protobuf-compiler
-          unzip protobuf-compiler.zip -d protobuf-compiler
-          echo $(realpath .)/protobuf-compiler/bin >> $GITHUB_PATH
 
       - name: Build
         run: cargo build --manifest-path src/Temporalio/Bridge/Cargo.toml --release
 
       - name: Upload bridge library
+        # FIXME: v4+ requires Node 20
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.out-prefix }}-bridge
@@ -86,11 +86,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Download bridge libraries
+        # Need v3 here to stay compatible with the compile-native-binaries job.
         uses: actions/download-artifact@v3
         with:
           path: bridge-libraries
@@ -102,7 +103,7 @@ jobs:
         run: dotnet pack -c Release /p:BridgeLibraryRoot=${{ github.workspace }}/bridge-libraries
 
       - name: Upload NuGet artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nuget-package
           path: |
@@ -132,12 +133,12 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nuget-package
           path: nuget-package
@@ -156,7 +157,7 @@ jobs:
 
       - name: Setup msbuild (Windows only)
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Run .NET framework smoke test (Windows only)
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -8,14 +8,12 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -23,13 +21,12 @@ jobs:
           workspaces: src/Temporalio/Bridge
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # TODO(cretz): Upgrade when https://github.com/arduino/setup-protoc/issues/33 fixed
-          version: '3.x'
+        uses: arduino/setup-protoc@v3
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build


### PR DESCRIPTION
## What was changed

- Updated all GHA actions to latest.

## Why?

- GitHub is pulling the plug on `download-artifact@v2` and `upload-artifact@v2` on June 30th;
- `actions-rs/toolchain@v1` is no longer maintained;
- All GHA official actions based on Node 16 are deprecated.
