### PR TITLE
Add strongly-typed extension methods for SignalWithStart

### DIFF
--- a/src/Temporalio/Client/ITemporalClientExtensions.cs
+++ b/src/Temporalio/Client/ITemporalClientExtensions.cs
@@ -44,6 +44,49 @@ namespace Temporalio.Client
         }
 
         /// <summary>
+        /// Signal and (optionally) start a workflow via lambda invoking the signalWithStart method.
+        /// </summary>
+        /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
+        /// <param name="client">Client to use.</param>
+        /// <param name="workflowRunCall">Invocation of workflow run method with a result.</param>
+        /// <param name="signalCall">Invocation of signal method without a result.</param>
+        /// <param name="options">Start workflow options. ID and TaskQueue are required.</param>
+        /// <returns>Workflow handle for the started workflow.</returns>
+        /// <exception cref="ArgumentException">Invalid run call or options.</exception>
+        /// <exception cref="Exceptions.RpcException">Server-side error.</exception>
+        public static async Task<WorkflowHandle<TWorkflow>> SignalWorkflowWithStartAsync<TWorkflow>(
+            this ITemporalClient client,
+            Expression<Func<TWorkflow, Task>> workflowRunCall,
+            Expression<Func<TWorkflow, Task>> signalCall,
+            WorkflowOptions options)
+        {
+            options.SignalWithStart(signalCall);
+            return await client.StartWorkflowAsync(workflowRunCall, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Signal and (optionally) start a workflow via lambda invoking the signalWithStart method.
+        /// </summary>
+        /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
+        /// <typeparam name="TResult">Workflow result type.</typeparam>
+        /// <param name="client">Client to use.</param>
+        /// <param name="workflowRunCall">Invocation of workflow run method with a result.</param>
+        /// <param name="signalCall">Invocation of signal method without a result.</param>
+        /// <param name="options">Start workflow options. ID and TaskQueue are required.</param>
+        /// <returns>Workflow handle for the started workflow.</returns>
+        /// <exception cref="ArgumentException">Invalid run call or options.</exception>
+        /// <exception cref="Exceptions.RpcException">Server-side error.</exception>
+        public static async Task<WorkflowHandle<TWorkflow, TResult>> SignalWorkflowWithStartAsync<TWorkflow, TResult>(
+            this ITemporalClient client,
+            Expression<Func<TWorkflow, Task<TResult>>> workflowRunCall,
+            Expression<Func<TWorkflow, Task>> signalCall,
+            WorkflowOptions options)
+        {
+            options.SignalWithStart(signalCall);
+            return await client.StartWorkflowAsync(workflowRunCall, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Shortcut for
         /// <see cref="ITemporalClient.StartWorkflowAsync{T}(Expression{Func{T, Task}}, WorkflowOptions)" />
         /// +


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added extension methods for calling `signalWithStart`.
## Why?
<!-- Tell your future self why have you made these changes -->
Adds support for strong typings when starting a workflow with a signal.

Currently this requires holding a second variable for `WorkflowOptions` and calling
`options.SignalWithStart(x => x.Method())`.

These extension methods give you the ability to short-hand the setup:
```csharp
var handle = await _temporalClient.SignalWorkflowWithStartAsync(
    workflow => workflow.RunAsync(),
    workflow => workflow.SignalMethod(),
    new WorkflowOptions
    {
       //...
    });
```
## Checklist
<!--- add/delete as needed --->

1. Closes 
N/A

2. How was this tested:
I have been using these extension methods in some of my applications for awhile, but I figured they would be useful to others.

3. Any docs updates needed?
N/A
