### PR TITLE
Workflow completion command reordering

### DIFF
--- a/src/Temporalio/Bridge/Cargo.lock
+++ b/src/Temporalio/Bridge/Cargo.lock
@@ -312,12 +312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,15 +620,6 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "enum-iterator"
@@ -1108,20 +1093,24 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http 0.2.12",
- "hyper 0.14.29",
- "rustls 0.21.12",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1143,12 +1132,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "hyper 1.3.1",
  "pin-project-lite",
+ "socket2",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1397,18 +1391,6 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
 
 [[package]]
 name = "no-std-compat"
@@ -2022,20 +2004,20 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.29",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
  "hyper-rustls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2043,15 +2025,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -2140,18 +2122,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -2159,7 +2129,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2171,19 +2141,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2201,16 +2162,6 @@ name = "rustls-pki-types"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -2249,16 +2200,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -2484,27 +2425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,7 +2526,6 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "mockall",
- "nix",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2808,21 +2727,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -2880,10 +2789,10 @@ dependencies = [
  "pin-project",
  "prost",
  "rustls-native-certs",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -3206,9 +3115,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -3401,9 +3313,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -89,7 +89,8 @@ namespace Temporalio.Worker
                     OnTaskStarting: options.OnTaskStarting,
                     OnTaskCompleted: options.OnTaskCompleted,
                     RuntimeMetricMeter: MetricMeter,
-                    WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes));
+                    WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
+                    DisableCompletionCommandReordering: options.DisableWorkflowCompletionCommandReordering));
             }
         }
 

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -287,6 +287,15 @@ namespace Temporalio.Worker
             DefaultWorkflowInstanceFactory;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the workflow completion command reordering will
+        /// apply.
+        /// </summary>
+        /// <remarks>
+        /// This is visible for testing only.
+        /// </remarks>
+        internal bool DisableWorkflowCompletionCommandReordering { get; set; }
+
+        /// <summary>
         /// Add the given delegate with <see cref="ActivityAttribute" /> as an activity. This is
         /// usually a method reference.
         /// </summary>

--- a/src/Temporalio/Worker/WorkflowInstanceDetails.cs
+++ b/src/Temporalio/Worker/WorkflowInstanceDetails.cs
@@ -26,6 +26,9 @@ namespace Temporalio.Worker
     /// <param name="OnTaskCompleted">Callback for every instance task complete.</param>
     /// <param name="RuntimeMetricMeter">Lazy runtime-level metric meter.</param>
     /// <param name="WorkerLevelFailureExceptionTypes">Failure exception types at worker level.</param>
+    /// <param name="DisableCompletionCommandReordering">
+    /// Whether to disable completion command reordering.
+    /// </param>
     internal record WorkflowInstanceDetails(
         string Namespace,
         string TaskQueue,
@@ -41,5 +44,6 @@ namespace Temporalio.Worker
         Action<WorkflowInstance> OnTaskStarting,
         Action<WorkflowInstance, Exception?> OnTaskCompleted,
         Lazy<MetricMeter> RuntimeMetricMeter,
-        IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes);
+        IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
+        bool DisableCompletionCommandReordering);
 }

--- a/src/Temporalio/Worker/WorkflowLogicFlag.cs
+++ b/src/Temporalio/Worker/WorkflowLogicFlag.cs
@@ -1,0 +1,15 @@
+namespace Temporalio.Worker
+{
+    /// <summary>
+    /// Flags that may be set on task/activation completion to differentiate new from old workflow
+    /// behavior.
+    /// </summary>
+    internal enum WorkflowLogicFlag : uint
+    {
+        /// <summary>
+        /// When set, this makes sure that workflow completion is moved to the end of the command
+        /// set.
+        /// </summary>
+        ReorderWorkflowCompletion = 1,
+    }
+}

--- a/src/Temporalio/Worker/WorkflowReplayer.cs
+++ b/src/Temporalio/Worker/WorkflowReplayer.cs
@@ -173,7 +173,8 @@ namespace Temporalio.Worker
                             OnTaskStarting: options.OnTaskStarting,
                             OnTaskCompleted: options.OnTaskCompleted,
                             RuntimeMetricMeter: new(() => runtime.MetricMeter),
-                            WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes),
+                            WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
+                            DisableCompletionCommandReordering: options.DisableWorkflowCompletionCommandReordering),
                         (runId, removeFromCache) => SetResult(removeFromCache));
                 }
                 catch

--- a/src/Temporalio/Worker/WorkflowReplayerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowReplayerOptions.cs
@@ -129,6 +129,15 @@ namespace Temporalio.Worker
             TemporalWorkerOptions.DefaultWorkflowInstanceFactory;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the workflow completion command reordering will
+        /// apply.
+        /// </summary>
+        /// <remarks>
+        /// This is visible for testing only.
+        /// </remarks>
+        internal bool DisableWorkflowCompletionCommandReordering { get; set; }
+
+        /// <summary>
         /// Add the given type as a workflow.
         /// </summary>
         /// <typeparam name="T">Type to add.</typeparam>

--- a/src/Temporalio/Worker/WorkflowWorker.cs
+++ b/src/Temporalio/Worker/WorkflowWorker.cs
@@ -283,7 +283,8 @@ namespace Temporalio.Worker
                     OnTaskStarting: options.OnTaskStarting,
                     OnTaskCompleted: options.OnTaskCompleted,
                     RuntimeMetricMeter: options.RuntimeMetricMeter,
-                    WorkerLevelFailureExceptionTypes: options.WorkerLevelFailureExceptionTypes));
+                    WorkerLevelFailureExceptionTypes: options.WorkerLevelFailureExceptionTypes,
+                    DisableCompletionCommandReordering: options.DisableCompletionCommandReordering));
         }
     }
 }

--- a/src/Temporalio/Worker/WorkflowWorkerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowWorkerOptions.cs
@@ -21,5 +21,6 @@ namespace Temporalio.Worker
         Action<WorkflowInstance> OnTaskStarting,
         Action<WorkflowInstance, Exception?> OnTaskCompleted,
         Lazy<MetricMeter> RuntimeMetricMeter,
-        IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes);
+        IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
+        bool DisableCompletionCommandReordering);
 }


### PR DESCRIPTION
## What was changed

See https://github.com/temporalio/features/issues/481. Like other core-based SDKs, .NET put the workflow complete command on the command list immediately when it occurred from workflow return. And then it truncated anything else after that. So coroutines that completed in the same task but after workflow method return were dropped.

This issue changes that behavior to enure same-task-post-complete coroutine commands are preserved. The approach that is taken now is that, if we are not replaying (or replaying w/ SDK flag set) and there are commands after return, move the return to the end and set an SDK flag. Otherwise do as done today. This not only ensures that workflow completion comes last, but the checking for whether any post-complete commands even exist allow us to not set this flag.

(there is also a somewhat unrelated fix to a flaky user-client-replacement test)

## Checklist

1. Closes #249