### PR TITLE
Add exceptions to OTel client spans and minor 1.24 server test fixes

### DIFF
--- a/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
+++ b/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
@@ -196,7 +196,15 @@ namespace Temporalio.Extensions.OpenTelemetry
                     {
                         input = input with { Headers = headers };
                     }
-                    return await base.StartWorkflowAsync<TWorkflow, TResult>(input).ConfigureAwait(false);
+                    try
+                    {
+                        return await base.StartWorkflowAsync<TWorkflow, TResult>(input).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        RecordExceptionWithStatus(activity, e);
+                        throw;
+                    }
                 }
             }
 
@@ -212,7 +220,15 @@ namespace Temporalio.Extensions.OpenTelemetry
                     {
                         input = input with { Headers = headers };
                     }
-                    await base.SignalWorkflowAsync(input).ConfigureAwait(false);
+                    try
+                    {
+                        await base.SignalWorkflowAsync(input).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        RecordExceptionWithStatus(activity, e);
+                        throw;
+                    }
                 }
             }
 
@@ -228,7 +244,15 @@ namespace Temporalio.Extensions.OpenTelemetry
                     {
                         input = input with { Headers = headers };
                     }
-                    return await base.QueryWorkflowAsync<TResult>(input).ConfigureAwait(false);
+                    try
+                    {
+                        return await base.QueryWorkflowAsync<TResult>(input).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        RecordExceptionWithStatus(activity, e);
+                        throw;
+                    }
                 }
             }
 
@@ -245,7 +269,15 @@ namespace Temporalio.Extensions.OpenTelemetry
                     {
                         input = input with { Headers = headers };
                     }
-                    return await base.StartWorkflowUpdateAsync<TResult>(input).ConfigureAwait(false);
+                    try
+                    {
+                        return await base.StartWorkflowUpdateAsync<TResult>(input).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        RecordExceptionWithStatus(activity, e);
+                        throw;
+                    }
                 }
             }
 

--- a/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
@@ -323,7 +323,9 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
                 EndAt: now,
                 Overlap: ScheduleOverlapPolicy.AllowAll),
         });
-        Assert.Equal(6, (await handle.DescribeAsync()).Info.NumActions);
+        // Servers < 1.24 this is 6, servers >= 1.24 this is 7
+        var numActions = (await handle.DescribeAsync()).Info.NumActions;
+        Assert.True(numActions == 6 || numActions == 7, $"Invalid num actions: {numActions}");
 
         // Delete when done
         await TestUtils.DeleteAllSchedulesAsync(Client);


### PR DESCRIPTION
## What was changed

* Record exceptions on OTel traces for client calls
* Fix test for server 1.24 since updates now fail on workflow terminate
* Fix test for server 1.24 since schedule backfill count is now different