### PR TITLE
Download cURL in older Linux containers on binary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-lint-test:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-arm, macos-intel, macos-arm, windows-latest]
         include:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-bridge-libraries:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-arm, macos-intel, macos-arm, windows-latest]
         include:
@@ -18,6 +18,7 @@ jobs:
             # We use the Python manylinux image for glibc compatibility
             container: quay.io/pypa/manylinux2014_x86_64
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
+            curl-download: https://github.com/stunnel/static-curl/releases/download/8.8.0/curl-linux-x86_64-8.8.0.tar.xz
           - os: ubuntu-arm
             out-file: libtemporal_sdk_bridge.so
             out-prefix: linux-arm64
@@ -25,6 +26,7 @@ jobs:
             # We use the Python manylinux image for glibc compatibility
             container: quay.io/pypa/manylinux2014_aarch64
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
+            curl-download: https://github.com/stunnel/static-curl/releases/download/8.8.0/curl-linux-aarch64-8.8.0.tar.xz
           - os: macos-intel
             out-file: libtemporal_sdk_bridge.dylib
             out-prefix: osx-x64
@@ -50,6 +52,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      # Need to update cURL on Linux for the Rust install step
+      - name: Update cURL
+        if: ${{ matrix.curl-download }}
+        run: |
+          curl --fail -L "${{ matrix.curl-download }}" -o curl.tar.xz
+          tar -xJvf curl.tar.xz -C /usr/local/bin
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What was changed

Newer GH actions fail on older Linux containers due to older cURL so we update with a statically linked one (tested while this PR was in draft)