### PR TITLE
Set Rust callbacks to complete tasks asynchronously

### DIFF
--- a/src/Temporalio/Bridge/Client.cs
+++ b/src/Temporalio/Bridge/Client.cs
@@ -43,7 +43,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<Client>();
+                var completion = new TaskCompletionSource<Client>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.client_connect(
@@ -125,7 +126,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<ByteArray>();
+                var completion = new TaskCompletionSource<ByteArray>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.client_rpc_call(

--- a/src/Temporalio/Bridge/EphemeralServer.cs
+++ b/src/Temporalio/Bridge/EphemeralServer.cs
@@ -51,7 +51,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<EphemeralServer>();
+                var completion = new TaskCompletionSource<EphemeralServer>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.ephemeral_server_start_dev_server(
@@ -76,7 +77,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<EphemeralServer>();
+                var completion = new TaskCompletionSource<EphemeralServer>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.ephemeral_server_start_test_server(
@@ -97,7 +99,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<bool>();
+                var completion = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.ephemeral_server_shutdown(

--- a/src/Temporalio/Bridge/Worker.cs
+++ b/src/Temporalio/Bridge/Worker.cs
@@ -96,7 +96,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<bool>();
+                var completion = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.worker_validate(
@@ -141,7 +142,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<ByteArray?>();
+                var completion = new TaskCompletionSource<ByteArray?>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.worker_poll_workflow_activation(
@@ -179,7 +181,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<ByteArray?>();
+                var completion = new TaskCompletionSource<ByteArray?>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.worker_poll_activity_task(
@@ -218,7 +221,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<bool>();
+                var completion = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.worker_complete_workflow_activation(
@@ -252,7 +256,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<bool>();
+                var completion = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.worker_complete_activity_task(
@@ -338,7 +343,8 @@ namespace Temporalio.Bridge
         {
             using (var scope = new Scope())
             {
-                var completion = new TaskCompletionSource<bool>();
+                var completion = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 unsafe
                 {
                     Interop.Methods.worker_finalize_shutdown(


### PR DESCRIPTION
## What was changed

We use `TaskCompletionSource` for callbacks from Rust threads, but resolving a task completion source in a non-.NET thread and await/continue-with in the same thread it was started in can have deadlock issues in certain situations. Setting `TaskCreationOptions.RunContinuationsAsynchronously` forces the task to schedule its continuation instead of running inline in same blocking thread. We now set this on every completion source callback used by Rust.

The test suite cannot easily replicate this because it is top level, but this was tested against the replication in #248.

## Checklist

1. Closes #248
