### PR TITLE
Add workflow update RPC timeout/canceled exception

### DIFF
--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -348,10 +348,9 @@ namespace Temporalio.Client
         /// <param name="options">Update options. Currently <c>WaitForStage</c> is required.</param>
         /// <returns>Workflow update handle.</returns>
         /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
-        public Task<WorkflowUpdateHandle> StartUpdateAsync(
+        public async Task<WorkflowUpdateHandle> StartUpdateAsync(
             string update, IReadOnlyCollection<object?> args, WorkflowUpdateStartOptions options) =>
-            StartUpdateAsync<ValueTuple>(update, args, options).ContinueWith<WorkflowUpdateHandle>(
-                t => t.Result, TaskScheduler.Current);
+            await StartUpdateAsync<ValueTuple>(update, args, options).ConfigureAwait(false);
 
         /// <summary>
         /// Start a workflow update using its name.

--- a/src/Temporalio/Exceptions/RpcTimeoutOrCanceledException.cs
+++ b/src/Temporalio/Exceptions/RpcTimeoutOrCanceledException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Temporalio.Exceptions
+{
+    /// <summary>
+    /// Exception representing timeout or cancellation on some client calls.
+    /// </summary>
+    public class RpcTimeoutOrCanceledException : TemporalException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RpcTimeoutOrCanceledException"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="inner">Cause of the exception.</param>
+        public RpcTimeoutOrCanceledException(string message, Exception? inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Temporalio/Exceptions/WorkflowUpdateRpcTimeoutOrCanceledException.cs
+++ b/src/Temporalio/Exceptions/WorkflowUpdateRpcTimeoutOrCanceledException.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Temporalio.Exceptions
+{
+    /// <summary>
+    /// Exception representing when an update RPC timeout or cancellation. This is not to be
+    /// confused with an update itself timing out or being canceled, this is just the call.
+    /// </summary>
+    public class WorkflowUpdateRpcTimeoutOrCanceledException : RpcTimeoutOrCanceledException
+    {
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="WorkflowUpdateRpcTimeoutOrCanceledException"/> class.
+        /// </summary>
+        /// <param name="inner">Cause of the exception.</param>
+        public WorkflowUpdateRpcTimeoutOrCanceledException(Exception? inner)
+            : base("Timeout or cancellation waiting for update", inner)
+        {
+        }
+    }
+}

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -3891,25 +3891,6 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    public async Task ExecuteWorkflowAsync_Updates_GetResultCancellation()
-    {
-        await ExecuteWorkerAsync<UpdateWorkflow>(async worker =>
-        {
-            // Start the workflow
-            var handle = await Env.Client.StartWorkflowAsync(
-                (UpdateWorkflow wf) => wf.RunAsync(),
-                new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
-            var updateHandle = await handle.StartUpdateAsync(
-                wf => wf.DoUpdateLongWaitAsync(), new(WorkflowUpdateStage.Accepted));
-            // Ask for the result but only for 1 second
-            using var tokenSource = new CancellationTokenSource();
-            tokenSource.CancelAfter(TimeSpan.FromSeconds(1));
-            await Assert.ThrowsAsync<OperationCanceledException>(() =>
-                updateHandle.GetResultAsync(new() { CancellationToken = tokenSource.Token }));
-        });
-    }
-
-    [Fact]
     public async Task ExecuteWorkflowAsync_Updates_ValidatorCreatesCommands()
     {
         await ExecuteWorkerAsync<UpdateWorkflow>(async worker =>


### PR DESCRIPTION
## What was changed

Added `WorkflowUpdateRpcTimeoutOrCanceledException` and ensured that it was thrown on update RPC calls that are cancelled or timeout

## Checklist

1. Closes #250
