### PR TITLE
Implementation of Temporalio.Workflows.Semaphore

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,10 @@ with .NET tasks inside of workflows:
   * Use `Workflow.WhenAnyAsync` instead.
   * Technically this only applies to an enumerable set of tasks with results or more than 2 tasks with results. Other
     uses are safe. See [this issue](https://github.com/dotnet/runtime/issues/87481).
+* Do not use `System.Threading.Semaphore` or `System.Threading.SemaphoreSlim`.
+  * Use `Temporalio.Workflows.Semaphore` instead.
+  * _Technically_ `SemaphoreSlim` does work if only the async form of `WaitAsync` is used without no timeouts and
+    `Release` is used. But anything else can deadlock the workflow and its use is cumbersome since it must be disposed.
 * Be wary of additional libraries' implicit use of the default scheduler.
   * For example, while there are articles for `Dataflow` about
     [using a specific scheduler](https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-specify-a-task-scheduler-in-a-dataflow-block),

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -366,13 +366,14 @@ namespace Temporalio.Worker
                     Headers: tsk.Start.HeaderFields)).ConfigureAwait(false);
 
                 completion.Result.Completed = new();
-                // As a special case, ValueTuple is considered "void"
-                if (result?.GetType() != typeof(ValueTuple))
+                // As a special case, ValueTuple is considered "void" which is null
+                if (result?.GetType() == typeof(ValueTuple))
                 {
-                    completion.Result.Completed.Result =
-                        await worker.Client.Options.DataConverter.ToPayloadAsync(
-                            result).ConfigureAwait(false);
+                    result = null;
                 }
+                completion.Result.Completed.Result =
+                    await worker.Client.Options.DataConverter.ToPayloadAsync(
+                        result).ConfigureAwait(false);
             }
             catch (CompleteAsyncException)
             {

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -1004,6 +1004,14 @@ namespace Temporalio.Worker
                             // If workflow failure exception, it's an update failure. If it's some
                             // other exception, it's a task failure. Otherwise it's a success.
                             var exc = task.Exception?.InnerExceptions?.SingleOrDefault();
+                            // There are .NET cases where cancellation occurs but is not considered
+                            // an exception. We are going to make it an exception. Unfortunately
+                            // there is no easy way to make it include the outer stack trace at this
+                            // time.
+                            if (exc == null && task.IsCanceled)
+                            {
+                                exc = new TaskCanceledException();
+                            }
                             if (exc != null && IsWorkflowFailureException(exc))
                             {
                                 AddCommand(new()

--- a/src/Temporalio/Workflows/Semaphore.cs
+++ b/src/Temporalio/Workflows/Semaphore.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Temporalio.Workflows
+{
+    /// <summary>
+    /// Semaphore is an alternative to <see cref="System.Threading.Semaphore"/> and
+    /// <see cref="SemaphoreSlim"/> built to be deterministic and lightweight. Many of the concepts
+    /// are similar to <see cref="SemaphoreSlim"/>.
+    /// </summary>
+    public class Semaphore
+    {
+        private static readonly object SemaphoreUnit = new();
+
+        private readonly LinkedList<object> waiters = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Semaphore"/> class.
+        /// </summary>
+        /// <param name="initialCount">
+        /// The initial number of permits that will be available for requests.
+        /// </param>
+        public Semaphore(int initialCount)
+        {
+            if (!Workflow.InWorkflow)
+            {
+                throw new InvalidOperationException("Cannot use workflow semaphore outside of workflow");
+            }
+            Max = initialCount;
+            CurrentCount = initialCount;
+        }
+
+        /// <summary>
+        /// Gets the fixed maximum number of permits that can be granted concurrently. This is
+        /// always the <c>initialCount</c> value from the constructor.
+        /// </summary>
+        public int Max { get; init; }
+
+        /// <summary>
+        /// Gets the current number of available permits that can be granted concurrently. This is
+        /// decremented on each successful <c>WaitAsync</c> call and incremented on each
+        /// <c>Release</c> call.
+        /// </summary>
+        public int CurrentCount { get; private set; }
+
+        /// <summary>
+        /// Wait for a permit to become available. If the task succeeds, users must call
+        /// <see cref="Release"/> to properly give the permit back when done.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// Cancellation token that can interrupt this wait. If unset, this defaults to
+        /// <see cref="Workflow.CancellationToken"/>. Upon cancel, awaiting the resulting task will
+        /// throw a <see cref="TaskCanceledException"/> exception.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the result of the asynchronous operation. This task is
+        /// canceled if the cancellation token is.
+        /// </returns>
+        public Task WaitAsync(CancellationToken? cancellationToken = null) =>
+            WaitInternalAsync(null, cancellationToken);
+
+        /// <summary>
+        /// Wait for a permit to become available or timeout to be reached. If the task returns
+        /// true, users must call <see cref="Release"/> to properly give the permit back when done.
+        /// </summary>
+        /// <param name="millisecondsTimeout">
+        /// Milliseconds until timeout. If this is 0, this is a non-blocking task that will return
+        /// immediately. If this value is -1 (i.e. <see cref="Timeout.Infinite"/>), there is no
+        /// timeout and the result will always be true on success (at which point you might as well
+        /// use <see cref="WaitAsync(CancellationToken?)"/>). Otherwise a timer is started for the
+        /// timeout and canceled if the wait succeeds.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Cancellation token that can interrupt this wait. If unset, this defaults to
+        /// <see cref="Workflow.CancellationToken"/>. Upon cancel, awaiting the resulting task will
+        /// throw a <see cref="TaskCanceledException"/> exception.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the result of the asynchronous operation. The task is
+        /// true if the wait succeeded and false if it timed out. This task is canceled if the
+        /// cancellation token is.
+        /// </returns>
+        public Task<bool> WaitAsync(
+            int millisecondsTimeout,
+            CancellationToken? cancellationToken = null) =>
+            WaitInternalAsync(TimeSpan.FromMilliseconds(millisecondsTimeout), cancellationToken);
+
+        /// <summary>
+        /// Wait for a permit to become available or timeout to be reached. If the task returns
+        /// true, users must call <see cref="Release"/> to properly give the permit back when done.
+        /// </summary>
+        /// <param name="timeout">
+        /// TimeSpan until timeout. If this is <see cref="TimeSpan.Zero"/>, this is a non-blocking
+        /// task that will return immediately. If this value is -1ms (i.e.
+        /// <see cref="Timeout.InfiniteTimeSpan"/>), there is no timeout and the result will always
+        /// be true on success (at which point you might as well use
+        /// <see cref="WaitAsync(CancellationToken?)"/>). Otherwise a timer is started for the
+        /// timeout and canceled if the wait succeeds.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Cancellation token that can interrupt this wait. If unset, this defaults to
+        /// <see cref="Workflow.CancellationToken"/>. Upon cancel, awaiting the resulting task will
+        /// throw a <see cref="TaskCanceledException"/> exception.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the result of the asynchronous operation. The task is
+        /// true if the wait succeeded and false if it timed out. This task is canceled if the
+        /// cancellation token is.
+        /// </returns>
+        public Task<bool> WaitAsync(
+            TimeSpan timeout,
+            CancellationToken? cancellationToken = null) =>
+            WaitInternalAsync(timeout, cancellationToken);
+
+        /// <summary>
+        /// Release a permit for use by another waiter.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this release call would extend the <see cref="CurrentCount"/> beyond
+        /// <see cref="Max"/> which means more <c>Release</c> calls were made than successful
+        /// <c>WaitAsync</c> calls.
+        /// </exception>
+        public void Release()
+        {
+            if (CurrentCount >= Max)
+            {
+                throw new InvalidOperationException("More released than successfully waited");
+            }
+            CurrentCount++;
+        }
+
+        private Task<bool> WaitInternalAsync(
+            TimeSpan? timeout = null,
+            CancellationToken? cancellationToken = null)
+        {
+            // Infinite means no timeout
+            if (timeout == Timeout.InfiniteTimeSpan)
+            {
+                timeout = null;
+            }
+            else if ((timeout ?? TimeSpan.Zero) < TimeSpan.Zero)
+            {
+                throw new ArgumentException("Timeout cannot be less than zero (except -1ms for infinite)");
+            }
+
+            // Attempt non-blocking acquire. Since we don't yield within here, we don't have to
+            // lock. We accept that this is an unfair semaphore in that non-blocking wait requests
+            // could always win.
+            if (CurrentCount > 0)
+            {
+                CurrentCount--;
+                return Task.FromResult(true);
+            }
+
+            // If there is 0 timeout and no cancellation, this is non-blocking
+            if (timeout == TimeSpan.Zero && cancellationToken == null)
+            {
+                return Task.FromResult(false);
+            }
+
+            // Now we know we need to wait, so add ourselves as waiter and wait until it's our
+            // waiter's turn.
+            var me = waiters.AddLast(SemaphoreUnit);
+
+            // We don't expose an overload for a nullable timeout on wait condition, so we have to
+            // differentiate
+            var task = timeout is { } timeoutNonNull ?
+                Workflow.WaitConditionAsync(
+                    () => CurrentCount > 0 && waiters.Count > 0 && waiters.First == me,
+                    timeoutNonNull,
+                    cancellationToken) :
+                Workflow.WaitConditionAsync(
+                    () => CurrentCount > 0 && waiters.Count > 0 && waiters.First == me,
+                    cancellationToken);
+
+            // Have a continue with that only runs on success that decrements current count on
+            // success. Then have a continue with that runs always that removes the waiter. Both
+            // must run synchronously.
+            return task.
+                ContinueWith(
+                    task =>
+                    {
+                        if (task is not Task<bool> timeoutTask || timeoutTask.Result)
+                        {
+                            CurrentCount--;
+                            return true;
+                        }
+                        return false;
+                    },
+                    default,
+                    TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Current).
+                ContinueWith(
+                    task =>
+                    {
+                        waiters.Remove(me);
+#pragma warning disable VSTHRD003 // This is safe to reuse tasks for our case
+                        return task;
+#pragma warning restore VSTHRD003
+                    },
+                    default,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Current).
+                Unwrap();
+        }
+    }
+}

--- a/tests/Temporalio.Tests/.editorconfig
+++ b/tests/Temporalio.Tests/.editorconfig
@@ -4,6 +4,9 @@
 
 # Please keep in alphabetical order by field.
 
+# We use generic lists for queries, it's ok.
+dotnet_diagnostic.CA1002.severity = none
+
 # We use getters for queries, they cannot be properties
 dotnet_diagnostic.CA1024.severity = none
 


### PR DESCRIPTION
## What was changed

* Added `Temporalio.Workflows.Semaphore` deterministic semaphore implementation
* Added tests for that implementation
* Added tests to confirm when existing standard library semaphore does/doesn't work
* Updated README with guidance

Opening as draft due to a bug that is occurring when cancelling the workflow while waiting on this semaphore (see TODO in test).

## Checklist

1. Relates to #281