### PR TITLE
Added exception notation to ConnectAsync method

### DIFF
--- a/src/Temporalio/Client/TemporalConnection.cs
+++ b/src/Temporalio/Client/TemporalConnection.cs
@@ -145,6 +145,7 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="options">Options for connecting.</param>
         /// <returns>The established connection.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when cannot successfully connect.</exception>
         public static async Task<TemporalConnection> ConnectAsync(TemporalConnectionOptions options)
         {
             var conn = new TemporalConnection(options, lazy: false);


### PR DESCRIPTION
## What was changed
Added a `exception` notation.

## Why?
To make it obvious to callers what kinds of exception might be thrown.

## Checklist
1. Closes 290

2. How was this tested:
N/A

3. Any docs updates needed?
No
