### PR TITLE
Support for workflow ID conflict policy

### DIFF
--- a/src/Temporalio/Client/Schedules/ScheduleActionStartWorkflow.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleActionStartWorkflow.cs
@@ -122,6 +122,10 @@ namespace Temporalio.Client.Schedules
             {
                 throw new ArgumentException("ID reuse policy cannot change from default for scheduled workflow");
             }
+            if (Options.IdConflictPolicy != Api.Enums.V1.WorkflowIdConflictPolicy.Unspecified)
+            {
+                throw new ArgumentException("ID conflict policy cannot change from default for scheduled workflow");
+            }
             if (Options.CronSchedule != null)
             {
                 throw new ArgumentException("Cron schedule cannot be set on scheduled workflow");

--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -504,6 +504,7 @@ namespace Temporalio.Client
                     Identity = Client.Connection.Options.Identity,
                     RequestId = Guid.NewGuid().ToString(),
                     WorkflowIdReusePolicy = input.Options.IdReusePolicy,
+                    WorkflowIdConflictPolicy = input.Options.IdConflictPolicy,
                     RetryPolicy = input.Options.RetryPolicy?.ToProto(),
                     RequestEagerExecution = input.Options.RequestEagerStart,
                 };

--- a/src/Temporalio/Client/WorkflowOptions.cs
+++ b/src/Temporalio/Client/WorkflowOptions.cs
@@ -63,6 +63,15 @@ namespace Temporalio.Client
         public WorkflowIdReusePolicy IdReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
 
         /// <summary>
+        /// Gets or sets how already-existing workflows of the same ID are treated. Default is
+        /// <see cref="WorkflowIdConflictPolicy.Unspecified" /> which effectively means
+        /// <see cref="WorkflowIdConflictPolicy.Fail"/> on the server. If this value is set, then
+        /// <see cref="IdReusePolicy"/> cannot be set to
+        /// <see cref="WorkflowIdReusePolicy.TerminateIfRunning"/>.
+        /// </summary>
+        public WorkflowIdConflictPolicy IdConflictPolicy { get; set; } = WorkflowIdConflictPolicy.Unspecified;
+
+        /// <summary>
         /// Gets or sets the retry policy for the workflow. If unset, workflow never retries.
         /// </summary>
         public RetryPolicy? RetryPolicy { get; set; }


### PR DESCRIPTION
## What was changed

* Added `WorkflowOptions.IdConflictPolicy` and test

## Checklist

1. Closes #217