### PR TITLE
Doc fixes for cref's so that rider doesn't show red warnings

### DIFF
--- a/src/Temporalio/Activities/ActivityInfo.cs
+++ b/src/Temporalio/Activities/ActivityInfo.cs
@@ -55,7 +55,7 @@ namespace Temporalio.Activities
     {
         /// <summary>
         /// Gets the value that is set on
-        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope" /> before this activity is
+        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope{TState}" /> before this activity is
         /// started.
         /// </summary>
         internal Dictionary<string, object> LoggerScope { get; } = new()

--- a/src/Temporalio/Client/CloudService.cs
+++ b/src/Temporalio/Client/CloudService.cs
@@ -27,7 +27,7 @@ namespace Temporalio.Client
             private readonly TemporalConnection connection;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="Core"/> class.
+            /// Initializes a new instance of the <see cref="CloudService.Core"/> class.
             /// </summary>
             /// <param name="connection">Connection to use.</param>
             public Core(TemporalConnection connection) => this.connection = connection;

--- a/src/Temporalio/Client/Interceptors/QueryWorkflowInput.cs
+++ b/src/Temporalio/Client/Interceptors/QueryWorkflowInput.cs
@@ -4,7 +4,7 @@ using Temporalio.Api.Common.V1;
 namespace Temporalio.Client.Interceptors
 {
     /// <summary>
-    /// Input for <see cref="ClientOutboundInterceptor.QueryWorkflowAsync" />.
+    /// Input for <see cref="ClientOutboundInterceptor.QueryWorkflowAsync{TResult}" />.
     /// </summary>
     /// <param name="Id">Workflow ID.</param>
     /// <param name="RunId">Workflow run ID if any.</param>

--- a/src/Temporalio/Client/Interceptors/StartWorkflowInput.cs
+++ b/src/Temporalio/Client/Interceptors/StartWorkflowInput.cs
@@ -4,7 +4,7 @@ using Temporalio.Api.Common.V1;
 namespace Temporalio.Client.Interceptors
 {
     /// <summary>
-    /// Input for <see cref="ClientOutboundInterceptor.StartWorkflowAsync" />.
+    /// Input for <see cref="ClientOutboundInterceptor.StartWorkflowAsync{TWorkflow,TResult}" />.
     /// </summary>
     /// <param name="Workflow">Workflow type name to start.</param>
     /// <param name="Args">Arguments for the workflow.</param>

--- a/src/Temporalio/Client/Interceptors/StartWorkflowUpdateInput.cs
+++ b/src/Temporalio/Client/Interceptors/StartWorkflowUpdateInput.cs
@@ -4,7 +4,7 @@ using Temporalio.Api.Common.V1;
 namespace Temporalio.Client.Interceptors
 {
     /// <summary>
-    /// Input for <see cref="ClientOutboundInterceptor.StartWorkflowUpdateAsync" />.
+    /// Input for <see cref="ClientOutboundInterceptor.StartWorkflowUpdateAsync{TResult}" />.
     /// </summary>
     /// <param name="Id">Workflow ID.</param>
     /// <param name="RunId">Workflow run ID if any.</param>

--- a/src/Temporalio/Client/OperatorService.cs
+++ b/src/Temporalio/Client/OperatorService.cs
@@ -24,7 +24,7 @@ namespace Temporalio.Client
             private readonly TemporalConnection connection;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="Core"/> class.
+            /// Initializes a new instance of the <see cref="OperatorService.Core"/> class.
             /// </summary>
             /// <param name="connection">Connection to use.</param>
             public Core(TemporalConnection connection) => this.connection = connection;

--- a/src/Temporalio/Client/TemporalClientConnectOptions.cs
+++ b/src/Temporalio/Client/TemporalClientConnectOptions.cs
@@ -68,7 +68,7 @@ namespace Temporalio.Client
 
         /// <summary>
         /// Create client options from a subset of these options for use in
-        /// <see cref="TemporalClient.TemporalClient" />.
+        /// <see cref="TemporalClient" />.
         /// </summary>
         /// <returns>Client options.</returns>
         public TemporalClientOptions ToClientOptions() =>

--- a/src/Temporalio/Client/TestService.cs
+++ b/src/Temporalio/Client/TestService.cs
@@ -24,7 +24,7 @@ namespace Temporalio.Client
             private readonly TemporalConnection connection;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="Core"/> class.
+            /// Initializes a new instance of the <see cref="TestService.Core"/> class.
             /// </summary>
             /// <param name="connection">Connection to use.</param>
             public Core(TemporalConnection connection) => this.connection = connection;

--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -720,7 +720,7 @@ namespace Temporalio.Client
 
         /// <summary>
         /// Start an update and wait for it to complete. This is a shortcut for
-        /// <see cref="StartUpdateAsync{TUpdateResult}(Expression{Func{TWorkflow, Task{TUpdateResult}}}, WorkflowUpdateStartOptions)" />
+        /// <see cref="StartUpdateAsync{TUpdateResult}" />
         /// +
         /// <see cref="WorkflowUpdateHandle{TResult}.GetResultAsync(RpcOptions?)" />.
         /// </summary>

--- a/src/Temporalio/Client/WorkflowService.cs
+++ b/src/Temporalio/Client/WorkflowService.cs
@@ -24,7 +24,7 @@ namespace Temporalio.Client
             private readonly TemporalConnection connection;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="Core"/> class.
+            /// Initializes a new instance of the <see cref="WorkflowService.Core"/> class.
             /// </summary>
             /// <param name="connection">Connection to use.</param>
             public Core(TemporalConnection connection) => this.connection = connection;

--- a/src/Temporalio/Converters/DefaultFailureConverter.cs
+++ b/src/Temporalio/Converters/DefaultFailureConverter.cs
@@ -193,7 +193,7 @@ namespace Temporalio.Converters
         public class WithEncodedCommonAttributes : DefaultFailureConverter
         {
             /// <summary>
-            /// Initializes a new instance of the <see cref="WithEncodedCommonAttributes"/> class.
+            /// Initializes a new instance of the <see cref="DefaultFailureConverter.WithEncodedCommonAttributes"/> class.
             /// </summary>
             public WithEncodedCommonAttributes()
                 : base(new() { EncodeCommonAttributes = true })

--- a/src/Temporalio/Testing/WorkflowEnvironment.cs
+++ b/src/Temporalio/Testing/WorkflowEnvironment.cs
@@ -253,7 +253,7 @@ namespace Temporalio.Testing
             private bool autoTimeSkipping = true;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="EphemeralServerBased"/> class.
+            /// Initializes a new instance of the <see cref="WorkflowEnvironment.EphemeralServerBased"/> class.
             /// </summary>
             /// <param name="client">Client for the server.</param>
             /// <param name="server">The underlying bridge server.</param>

--- a/src/Temporalio/Worker/Interceptors/ScheduleActivityInput.cs
+++ b/src/Temporalio/Worker/Interceptors/ScheduleActivityInput.cs
@@ -5,7 +5,7 @@ using Temporalio.Workflows;
 namespace Temporalio.Worker.Interceptors
 {
     /// <summary>
-    /// Input for <see cref="WorkflowOutboundInterceptor.ScheduleActivityAsync" />.
+    /// Input for <see cref="WorkflowOutboundInterceptor.ScheduleActivityAsync{TResult}" />.
     /// </summary>
     /// <param name="Activity">Activity type name.</param>
     /// <param name="Args">Activity args.</param>

--- a/src/Temporalio/Worker/Interceptors/ScheduleLocalActivityInput.cs
+++ b/src/Temporalio/Worker/Interceptors/ScheduleLocalActivityInput.cs
@@ -5,7 +5,7 @@ using Temporalio.Workflows;
 namespace Temporalio.Worker.Interceptors
 {
     /// <summary>
-    /// Input for <see cref="WorkflowOutboundInterceptor.ScheduleLocalActivityAsync" />.
+    /// Input for <see cref="WorkflowOutboundInterceptor.ScheduleLocalActivityAsync{TResult}" />.
     /// </summary>
     /// <param name="Activity">Activity type name.</param>
     /// <param name="Args">Activity args.</param>

--- a/src/Temporalio/Worker/Interceptors/StartChildWorkflowInput.cs
+++ b/src/Temporalio/Worker/Interceptors/StartChildWorkflowInput.cs
@@ -5,7 +5,7 @@ using Temporalio.Workflows;
 namespace Temporalio.Worker.Interceptors
 {
     /// <summary>
-    /// Input for <see cref="WorkflowOutboundInterceptor.StartChildWorkflowAsync" />.
+    /// Input for <see cref="WorkflowOutboundInterceptor.StartChildWorkflowAsync{TWorkflow,TResult}" />.
     /// </summary>
     /// <param name="Workflow">Workflow type name.</param>
     /// <param name="Args">Workflow args.</param>

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -135,7 +135,7 @@ namespace Temporalio.Workflows
             string workflow, IReadOnlyCollection<object?> args, ContinueAsNewOptions? options);
 
         /// <summary>
-        /// Backing call for <see cref="Workflow.DelayAsync(TimeSpan, CancellationToken?)" /> and
+        /// Backing call for <see cref="Workflow.DelayAsync(TimeSpan, System.Threading.CancellationToken?)" /> and
         /// overloads.
         /// </summary>
         /// <param name="delay">Delay duration.</param>
@@ -213,7 +213,7 @@ namespace Temporalio.Workflows
         void UpsertTypedSearchAttributes(IReadOnlyCollection<SearchAttributeUpdate> updates);
 
         /// <summary>
-        /// Backing call for <see cref="Workflow.WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" />
+        /// Backing call for <see cref="Workflow.WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" />
         /// and overloads.
         /// </summary>
         /// <param name="conditionCheck">Function to call.</param>

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -285,15 +285,15 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Sleep in a workflow for the given time. See documentation of
-        /// <see cref="DelayAsync(TimeSpan, CancellationToken?)" /> for details.
+        /// <see cref="DelayAsync(TimeSpan, System.Threading.CancellationToken?)" /> for details.
         /// </summary>
         /// <param name="millisecondsDelay">Delay amount. See documentation of
-        /// <see cref="DelayAsync(TimeSpan, CancellationToken?)" /> for details.</param>
+        /// <see cref="DelayAsync(TimeSpan, System.Threading.CancellationToken?)" /> for details.</param>
         /// <param name="cancellationToken">Cancellation token. See documentation of
-        /// <see cref="DelayAsync(TimeSpan, CancellationToken?)" /> for details.</param>
+        /// <see cref="DelayAsync(TimeSpan, System.Threading.CancellationToken?)" /> for details.</param>
         /// <returns>Task for completion. See documentation of
-        /// <see cref="DelayAsync(TimeSpan, CancellationToken?)" /> for details.</returns>
-        /// <seealso cref="DelayAsync(TimeSpan, CancellationToken?)" />
+        /// <see cref="DelayAsync(TimeSpan, System.Threading.CancellationToken?)" /> for details.</returns>
+        /// <seealso cref="DelayAsync(TimeSpan, System.Threading.CancellationToken?)" />
         public static Task DelayAsync(int millisecondsDelay, CancellationToken? cancellationToken = null) =>
             DelayAsync(TimeSpan.FromMilliseconds(millisecondsDelay), cancellationToken);
 
@@ -1113,41 +1113,41 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Wait for the given function to return true. See documentation of
-        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.
         /// </summary>
         /// <param name="conditionCheck">Condition function. See documentation of
-        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.</param>
         /// <param name="cancellationToken">Cancellation token. See documentation of
-        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.</param>
         /// <returns>Task when condition becomes true. See documentation
-        /// of <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// of <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.</returns>
-        /// <seealso cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" />.
+        /// <seealso cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" />.
         public static Task WaitConditionAsync(
             Func<bool> conditionCheck, CancellationToken? cancellationToken = null) =>
                 Context.WaitConditionAsync(conditionCheck, null, cancellationToken);
 
         /// <summary>
         /// Wait for the given function to return true or a timeout. See documentation of
-        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.
         /// </summary>
         /// <param name="conditionCheck">Condition function. See documentation of
-        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.</param>
         /// <param name="timeoutMilliseconds">Timeout milliseconds. See documentation of
-        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.</param>
         /// <param name="cancellationToken">Cancellation token. See documentation of
-        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.</param>
         /// <returns>Task when condition becomes true or a timeout has occurred. See documentation
-        /// of <see cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" /> for more
+        /// of <see cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" /> for more
         /// details.</returns>
-        /// <seealso cref="WaitConditionAsync(Func{bool}, TimeSpan, CancellationToken?)" />.
+        /// <seealso cref="WaitConditionAsync(Func{bool}, TimeSpan, System.Threading.CancellationToken?)" />.
         public static Task<bool> WaitConditionAsync(
             Func<bool> conditionCheck,
             int timeoutMilliseconds,

--- a/src/Temporalio/Workflows/WorkflowDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowDefinition.cs
@@ -120,7 +120,7 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Create a workflow with a custom creator. The result is not cached. Most users will use
-        /// <see cref="Create(Type)" /> instead.
+        /// <see cref="Create(System.Type)" /> instead.
         /// </summary>
         /// <param name="type">Type to get definition for.</param>
         /// <param name="nameOverride">The name to use instead of what may be on the attribute.</param>

--- a/src/Temporalio/Workflows/WorkflowInfo.cs
+++ b/src/Temporalio/Workflows/WorkflowInfo.cs
@@ -50,7 +50,7 @@ namespace Temporalio.Workflows
     {
         /// <summary>
         /// Gets the value that is set on
-        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope" /> before this workflow is
+        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope{TState}" /> before this workflow is
         /// started.
         /// </summary>
         internal Dictionary<string, object> LoggerScope { get; } = new()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

In Rider, when you open the solutions there's a bunch of red warning showing up for cref docs so I've updated them.

## Why?
<!-- Tell your future self why have you made these changes -->

This fixes the solution wide analysis that Rider runs

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
