### PR TITLE
HTTP CONNECT proxy support

### DIFF
--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -561,7 +561,7 @@ namespace Temporalio.Bridge.Interop
     {
         public SlotSupplier_Tag tag;
 
-        [NativeTypeName("__AnonymousRecord_temporal-sdk-bridge_L380_C3")]
+        [NativeTypeName("__AnonymousRecord_temporal-sdk-bridge_L387_C3")]
         public _Anonymous_e__Union Anonymous;
 
         internal ref FixedSizeSlotSupplier fixed_size
@@ -590,11 +590,11 @@ namespace Temporalio.Bridge.Interop
         internal unsafe partial struct _Anonymous_e__Union
         {
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-bridge_L381_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-bridge_L388_C5")]
             public _Anonymous1_e__Struct Anonymous1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-bridge_L384_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-bridge_L391_C5")]
             public _Anonymous2_e__Struct Anonymous2;
 
             internal partial struct _Anonymous1_e__Struct

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -141,6 +141,18 @@ namespace Temporalio.Bridge.Interop
         public ulong timeout_millis;
     }
 
+    internal partial struct ClientHttpConnectProxyConfig
+    {
+        [NativeTypeName("struct ByteArrayRef")]
+        public ByteArrayRef target_addr;
+
+        [NativeTypeName("struct ByteArrayRef")]
+        public ByteArrayRef username;
+
+        [NativeTypeName("struct ByteArrayRef")]
+        public ByteArrayRef password;
+    }
+
     internal unsafe partial struct ClientOptions
     {
         [NativeTypeName("struct ByteArrayRef")]
@@ -169,6 +181,9 @@ namespace Temporalio.Bridge.Interop
 
         [NativeTypeName("const struct ClientKeepAliveOptions *")]
         public ClientKeepAliveOptions* keep_alive_options;
+
+        [NativeTypeName("const struct ClientHttpConnectProxyConfig *")]
+        public ClientHttpConnectProxyConfig* http_connect_proxy_options;
     }
 
     internal unsafe partial struct ByteArray

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -144,7 +144,7 @@ namespace Temporalio.Bridge.Interop
     internal partial struct ClientHttpConnectProxyOptions
     {
         [NativeTypeName("struct ByteArrayRef")]
-        public ByteArrayRef target_addr;
+        public ByteArrayRef target_host;
 
         [NativeTypeName("struct ByteArrayRef")]
         public ByteArrayRef username;

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -141,7 +141,7 @@ namespace Temporalio.Bridge.Interop
         public ulong timeout_millis;
     }
 
-    internal partial struct ClientHttpConnectProxyConfig
+    internal partial struct ClientHttpConnectProxyOptions
     {
         [NativeTypeName("struct ByteArrayRef")]
         public ByteArrayRef target_addr;
@@ -182,8 +182,8 @@ namespace Temporalio.Bridge.Interop
         [NativeTypeName("const struct ClientKeepAliveOptions *")]
         public ClientKeepAliveOptions* keep_alive_options;
 
-        [NativeTypeName("const struct ClientHttpConnectProxyConfig *")]
-        public ClientHttpConnectProxyConfig* http_connect_proxy_options;
+        [NativeTypeName("const struct ClientHttpConnectProxyOptions *")]
+        public ClientHttpConnectProxyOptions* http_connect_proxy_options;
     }
 
     internal unsafe partial struct ByteArray

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -321,7 +321,7 @@ namespace Temporalio.Bridge
         /// <param name="options">Options to convert.</param>
         /// <param name="scope">Scope to use.</param>
         /// <returns>Converted options.</returns>
-        public static Interop.ClientHttpConnectProxyConfig ToInteropOptions(
+        public static Interop.ClientHttpConnectProxyOptions ToInteropOptions(
             this Temporalio.Client.HttpConnectProxyOptions options,
             Scope scope)
         {
@@ -330,7 +330,7 @@ namespace Temporalio.Bridge
                 throw new ArgumentException("TargetHost is required");
             }
 
-            return new ClientHttpConnectProxyConfig
+            return new ClientHttpConnectProxyOptions
             {
                 target_addr = scope.ByteArray(options.TargetHost),
                 username = scope.ByteArray(options.BasicAuth?.Username),

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -318,18 +318,25 @@ namespace Temporalio.Bridge
         /// <summary>
         /// Convert http connect proxy options.
         /// </summary>
-        /// <param name="config">Options to convert.</param>
+        /// <param name="options">Options to convert.</param>
         /// <param name="scope">Scope to use.</param>
         /// <returns>Converted options.</returns>
         public static Interop.ClientHttpConnectProxyConfig ToInteropOptions(
-            this Temporalio.Client.HttpConnectProxyConfig config,
-            Scope scope) =>
-            new()
+            this Temporalio.Client.HttpConnectProxyOptions options,
+            Scope scope)
+        {
+            if (string.IsNullOrEmpty(options.TargetHost))
             {
-                target_addr = scope.ByteArray(config.TargetHost),
-                username = scope.ByteArray(config.BasicAuth?.Username),
-                password = scope.ByteArray(config.BasicAuth?.Username),
+                throw new ArgumentException("TargetHost is required");
+            }
+
+            return new ClientHttpConnectProxyConfig
+            {
+                target_addr = scope.ByteArray(options.TargetHost),
+                username = scope.ByteArray(options.BasicAuth?.Username),
+                password = scope.ByteArray(options.BasicAuth?.Username),
             };
+        }
 
         /// <summary>
         /// Convert start local options options.

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -332,7 +332,7 @@ namespace Temporalio.Bridge
 
             return new ClientHttpConnectProxyOptions
             {
-                target_addr = scope.ByteArray(options.TargetHost),
+                target_host = scope.ByteArray(options.TargetHost),
                 username = scope.ByteArray(options.BasicAuth?.Username),
                 password = scope.ByteArray(options.BasicAuth?.Username),
             };

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Temporalio.Bridge.Interop;
 using Temporalio.Exceptions;
 
 namespace Temporalio.Bridge
@@ -245,6 +246,10 @@ namespace Temporalio.Bridge
                     options.KeepAlive == null
                         ? null
                         : scope.Pointer(options.KeepAlive.ToInteropOptions()),
+                http_connect_proxy_options =
+                    options.HttpConnectProxy == null
+                        ? null
+                        : scope.Pointer(options.HttpConnectProxy.ToInteropOptions(scope)),
             };
         }
 
@@ -308,6 +313,22 @@ namespace Temporalio.Bridge
             {
                 interval_millis = (ulong)options.Interval.TotalMilliseconds,
                 timeout_millis = (ulong)options.Timeout.TotalMilliseconds,
+            };
+
+        /// <summary>
+        /// Convert http connect proxy options.
+        /// </summary>
+        /// <param name="config">Options to convert.</param>
+        /// <param name="scope">Scope to use.</param>
+        /// <returns>Converted options.</returns>
+        public static Interop.ClientHttpConnectProxyConfig ToInteropOptions(
+            this Temporalio.Client.HttpConnectProxyConfig config,
+            Scope scope) =>
+            new()
+            {
+                target_addr = scope.ByteArray(config.TargetHost),
+                username = scope.ByteArray(config.BasicAuth?.Username),
+                password = scope.ByteArray(config.BasicAuth?.Username),
             };
 
         /// <summary>

--- a/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
+++ b/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
@@ -96,6 +96,12 @@ typedef struct ClientKeepAliveOptions {
   uint64_t timeout_millis;
 } ClientKeepAliveOptions;
 
+typedef struct ClientHttpConnectProxyOptions {
+  struct ByteArrayRef target_host;
+  struct ByteArrayRef username;
+  struct ByteArrayRef password;
+} ClientHttpConnectProxyOptions;
+
 typedef struct ClientOptions {
   struct ByteArrayRef target_url;
   struct ByteArrayRef client_name;
@@ -106,7 +112,7 @@ typedef struct ClientOptions {
   const struct ClientTlsOptions *tls_options;
   const struct ClientRetryOptions *retry_options;
   const struct ClientKeepAliveOptions *keep_alive_options;
-  const HttpConnectProxyOptions *http_connect_proxy_options;
+  const struct ClientHttpConnectProxyOptions *http_connect_proxy_options;
 } ClientOptions;
 
 typedef struct ByteArray {

--- a/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
+++ b/src/Temporalio/Bridge/include/temporal-sdk-bridge.h
@@ -106,6 +106,7 @@ typedef struct ClientOptions {
   const struct ClientTlsOptions *tls_options;
   const struct ClientRetryOptions *retry_options;
   const struct ClientKeepAliveOptions *keep_alive_options;
+  const HttpConnectProxyOptions *http_connect_proxy_options;
 } ClientOptions;
 
 typedef struct ByteArray {

--- a/src/Temporalio/Bridge/src/client.rs
+++ b/src/Temporalio/Bridge/src/client.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use temporal_client::{
     ClientKeepAliveConfig, ClientOptions as CoreClientOptions, ClientOptionsBuilder,
-    ClientTlsConfig, CloudService, ConfiguredClient, HealthService, OperatorService, RetryClient,
+    ClientTlsConfig, CloudService, ConfiguredClient, HealthService, HttpConnectProxyOptions, OperatorService, RetryClient,
     RetryConfig, TemporalServiceClientWithMetrics, TestService, TlsConfig, WorkflowService,
 };
 use tonic::metadata::MetadataKey;
@@ -26,6 +26,7 @@ pub struct ClientOptions {
     tls_options: *const ClientTlsOptions,
     retry_options: *const ClientRetryOptions,
     keep_alive_options: *const ClientKeepAliveOptions,
+    http_connect_proxy_options: *const HttpConnectProxyOptions,
 }
 
 #[repr(C)]
@@ -50,6 +51,13 @@ pub struct ClientRetryOptions {
 pub struct ClientKeepAliveOptions {
     pub interval_millis: u64,
     pub timeout_millis: u64,
+}
+
+#[repr(C)]
+pub struct ClientHttpConnectProxyConfig {
+    pub target_host: ByteArrayRef,
+    pub username: ByteArrayRef,
+    pub password: ByteArrayRef,
 }
 
 type CoreClient = RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>;
@@ -573,6 +581,19 @@ impl From<&ClientKeepAliveOptions> for ClientKeepAliveConfig {
         ClientKeepAliveConfig {
             interval: Duration::from_millis(opts.interval_millis),
             timeout: Duration::from_millis(opts.timeout_millis),
+        }
+    }
+}
+
+impl From<&ClientHttpConnectProxyConfig> for HttpConnectProxyOptions {
+    fn from(opts: &ClientHttpConnectProxyConfig) -> Self {
+        HttpConnectProxyOptions {
+            target_addr: opts.target_host.to_string(),
+            basic_auth: if opts.username.size != 0 && opts.password.size != 0 {
+                Some((opts.username.to_string(), opts.password.to_string()))
+            } else {
+                None
+            },
         }
     }
 }

--- a/src/Temporalio/Bridge/src/client.rs
+++ b/src/Temporalio/Bridge/src/client.rs
@@ -54,7 +54,7 @@ pub struct ClientKeepAliveOptions {
 }
 
 #[repr(C)]
-pub struct ClientHttpConnectProxyConfig {
+pub struct ClientHttpConnectProxyOptions {
     pub target_host: ByteArrayRef,
     pub username: ByteArrayRef,
     pub password: ByteArrayRef,
@@ -585,8 +585,8 @@ impl From<&ClientKeepAliveOptions> for ClientKeepAliveConfig {
     }
 }
 
-impl From<&ClientHttpConnectProxyConfig> for HttpConnectProxyOptions {
-    fn from(opts: &ClientHttpConnectProxyConfig) -> Self {
+impl From<&ClientHttpConnectProxyOptions> for HttpConnectProxyOptions {
+    fn from(opts: &ClientHttpConnectProxyOptions) -> Self {
         HttpConnectProxyOptions {
             target_addr: opts.target_host.to_string(),
             basic_auth: if opts.username.size != 0 && opts.password.size != 0 {

--- a/src/Temporalio/Bridge/src/client.rs
+++ b/src/Temporalio/Bridge/src/client.rs
@@ -26,7 +26,7 @@ pub struct ClientOptions {
     tls_options: *const ClientTlsOptions,
     retry_options: *const ClientRetryOptions,
     keep_alive_options: *const ClientKeepAliveOptions,
-    http_connect_proxy_options: *const HttpConnectProxyOptions,
+    http_connect_proxy_options: *const ClientHttpConnectProxyOptions,
 }
 
 #[repr(C)]

--- a/src/Temporalio/Client/HttpConnectProxyConfig.cs
+++ b/src/Temporalio/Client/HttpConnectProxyConfig.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Temporalio.Client
+{
+    /// <summary>
+    /// HTTP connect proxy options for Temporal connections.
+    /// </summary>
+    public class HttpConnectProxyConfig : ICloneable
+    {
+        /// <summary>
+        /// Gets or sets the target host to proxy through as a host:port string.
+        /// </summary>
+        public string? TargetHost { get; set; }
+
+        /// <summary>
+        /// Gets or sets HTTP basic auth for the proxy.
+        /// </summary>
+        public (string Username, string Password)? BasicAuth { get; set; }
+
+        /// <summary>
+        /// Create a shallow copy of these options.
+        /// </summary>
+        /// <returns>A shallow copy of these options.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio/Client/HttpConnectProxyOptions.cs
+++ b/src/Temporalio/Client/HttpConnectProxyOptions.cs
@@ -5,8 +5,14 @@ namespace Temporalio.Client
     /// <summary>
     /// HTTP connect proxy options for Temporal connections.
     /// </summary>
-    public class HttpConnectProxyConfig : ICloneable
+    public class HttpConnectProxyOptions : ICloneable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpConnectProxyOptions"/> class.
+        /// </summary>
+        /// <param name="targetHost">A 'host:port' string representing the target to proxy through.</param>
+        public HttpConnectProxyOptions(string targetHost) => TargetHost = targetHost;
+
         /// <summary>
         /// Gets or sets the target host to proxy through as a host:port string.
         /// </summary>

--- a/src/Temporalio/Client/HttpConnectProxyOptions.cs
+++ b/src/Temporalio/Client/HttpConnectProxyOptions.cs
@@ -10,12 +10,25 @@ namespace Temporalio.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpConnectProxyOptions"/> class.
         /// </summary>
+        /// <remarks>
+        /// <see cref="TargetHost"/> must be set.
+        /// </remarks>
+        public HttpConnectProxyOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpConnectProxyOptions"/> class.
+        /// </summary>
         /// <param name="targetHost">A 'host:port' string representing the target to proxy through.</param>
         public HttpConnectProxyOptions(string targetHost) => TargetHost = targetHost;
 
         /// <summary>
         /// Gets or sets the target host to proxy through as a host:port string.
         /// </summary>
+        /// <remarks>
+        /// This is required for all proxy options.
+        /// </remarks>
         public string? TargetHost { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Temporalio.Bridge.Interop;
 using Temporalio.Runtime;
 
 namespace Temporalio.Client
@@ -63,10 +62,7 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets or sets HTTP connect proxy options for this connection.
         /// </summary>
-        /// <remarks>
-        /// Default enabled, set to null to disable.
-        /// </remarks>
-        public HttpConnectProxyConfig? HttpConnectProxy { get; set; } = new();
+        public HttpConnectProxyConfig? HttpConnectProxy { get; set; }
 
         /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Temporalio.Bridge.Interop;
 using Temporalio.Runtime;
 
 namespace Temporalio.Client
@@ -58,6 +59,14 @@ namespace Temporalio.Client
         /// Default enabled, set to null to disable.
         /// </remarks>
         public KeepAliveOptions? KeepAlive { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets HTTP connect proxy options for this connection.
+        /// </summary>
+        /// <remarks>
+        /// Default enabled, set to null to disable.
+        /// </remarks>
+        public HttpConnectProxyConfig? HttpConnectProxy { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -62,7 +62,7 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets or sets HTTP connect proxy options for this connection.
         /// </summary>
-        public HttpConnectProxyConfig? HttpConnectProxy { get; set; }
+        public HttpConnectProxyOptions? HttpConnectProxy { get; set; }
 
         /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This change adds HTTP CONNECT proxy support.

- No need to update core submodule
- Added `Temporalio.Client.HttpConnectProxyConfig`
- Updated client to accept that config

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes #215 

2. How was this tested:
  This is challenging to test w/o a local proxy setup, but I'm open to recommendations. If I'm able, I'll publish a local release and see if I can test this against an environment where proxy resources exist.


4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
