### PR TITLE
Do not warn about leftover handlers on workflow failure

### DIFF
--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -5505,6 +5505,11 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             bool shouldWarn,
             bool interactionShouldFailWithNotFound = false)
         {
+            // If the finish is a failure, we never warn regardless
+            if (finish == UnfinishedHandlersWorkflow.WorkflowFinish.Fail)
+            {
+                shouldWarn = false;
+            }
             // Setup log capture
             var loggerFactory = new TestUtils.LogCaptureFactory(LoggerFactory);
             // Run the workflow


### PR DESCRIPTION
## What was changed

Only warn if first completion is a non-failure

## Checklist

1. Closes #325