### PR TITLE
Fix BasicAuth bug in HttpConnectProxyOptions.ToInteropOptions()

### DIFF
--- a/src/Temporalio/Bridge/EphemeralServer.cs
+++ b/src/Temporalio/Bridge/EphemeralServer.cs
@@ -30,7 +30,7 @@ namespace Temporalio.Bridge
         public override unsafe bool IsInvalid => ptr == null;
 
         /// <summary>
-        /// Gets the target host:port of the server.
+        /// Gets the target <c>host:port</c> of the server.
         /// </summary>
         public string Target { get; private init; }
 

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -334,7 +334,7 @@ namespace Temporalio.Bridge
             {
                 target_host = scope.ByteArray(options.TargetHost),
                 username = scope.ByteArray(options.BasicAuth?.Username),
-                password = scope.ByteArray(options.BasicAuth?.Username),
+                password = scope.ByteArray(options.BasicAuth?.Password),
             };
         }
 

--- a/src/Temporalio/Client/HttpConnectProxyOptions.cs
+++ b/src/Temporalio/Client/HttpConnectProxyOptions.cs
@@ -20,11 +20,11 @@ namespace Temporalio.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpConnectProxyOptions"/> class.
         /// </summary>
-        /// <param name="targetHost">A 'host:port' string representing the target to proxy through.</param>
+        /// <param name="targetHost">A <c>host:port</c> string representing the target to proxy through.</param>
         public HttpConnectProxyOptions(string targetHost) => TargetHost = targetHost;
 
         /// <summary>
-        /// Gets or sets the target host to proxy through as a host:port string.
+        /// Gets or sets the target host to proxy through as a <c>host:port</c> string.
         /// </summary>
         /// <remarks>
         /// This is required for all proxy options.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed a typo where `ClientHttpConnectProxyOptions.password` was being incorrectly set to `HttpConnectProxyOptions.BasicAuth.Username`