### PR TITLE
Fix HTTP CONNECT proxy options not passing to core

### DIFF
--- a/src/Temporalio/Bridge/src/client.rs
+++ b/src/Temporalio/Bridge/src/client.rs
@@ -525,7 +525,8 @@ impl TryFrom<&ClientOptions> for CoreClientOptions {
             } else {
                 Some(opts.metadata.to_string_map_on_newlines())
             })
-            .api_key(opts.api_key.to_option_string());
+            .api_key(opts.api_key.to_option_string())
+            .http_connect_proxy(unsafe { opts.http_connect_proxy_options.as_ref() }.map(Into::into));
         if let Some(tls_config) = unsafe { opts.tls_options.as_ref() } {
             opts_builder.tls_cfg(tls_config.try_into()?);
         }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
Follow-up fix to #318.

The proxy settings were not being pushed down to core. Although the ClientHttpConnectProxyOptions were properly translated to core's HttpConnectProxyOptions, the TryFrom trait on the CoreClientOptions was not updated to include the new ClientHttpConnectProxyOptions.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unfortunately, there still is no viable path for automated test coverage as-is. However, I validated this change by configuring a temporal app to point to an invalid proxy location and verified that a connection was not successful. Previously, no error would occur since the connection was not being routed to the proxy target.


```csharp
var client = await TemporalClient.ConnectAsync(new TemporalClientConnectOptions()
{
    TargetHost = "<valid_host>",
    HttpConnectProxy = new HttpConnectProxyOptions("localhost:9392"), // Arbitrary invalid location
});
```

```
Unhandled exception. System.InvalidOperationException: Connection failed: Server connection error: tonic::transport::Error(Transport, ConnectError(client error (Connect)

Caused by:
    Connection refused (os error 61)))
   at Temporalio.Bridge.Client.ConnectAsync(Runtime runtime, TemporalConnectionOptions options)
   at Temporalio.Client.TemporalConnection.GetBridgeClientAsync()
   at Temporalio.Client.TemporalConnection.ConnectAsync(TemporalConnectionOptions options)
   at Temporalio.Client.TemporalClient.ConnectAsync(TemporalClientConnectOptions options)
   at Program.<Main>$(String[] args) in /Users/adeal/src/samples-dotnet/src/ActivitySimple/Program.cs:line 15
   at Program.<Main>(String[] args)

```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
