### PR TITLE
Custom features repo branch in CI until after 1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,4 @@ jobs:
       dotnet-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
+      features-repo-ref: "dotnet-after-1.3.0"


### PR DESCRIPTION
## What was changed

Updated features repo branch to point to new branch with HTTP auth tests. HTTP auth tests at https://github.com/temporalio/features/commit/2376f0dcde96dabe2ffb6dfcd8c9a1c86d72b0a9, closes https://github.com/temporalio/features/issues/521.