### PR TITLE
Properly clear metadata when encoding/decoding payloads

### DIFF
--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Temporalio.Api.Common.V1;
 using Temporalio.Bridge.Api.ActivityResult;
@@ -223,6 +224,7 @@ namespace Temporalio.Worker
             var encodedList = await codec.EncodeAsync(new Payload[] { payload }).ConfigureAwait(false);
             var encoded = encodedList.Single();
             payload.Metadata.Clear();
+            payload.Data = ByteString.Empty;
             payload.MergeFrom(encoded);
         }
 
@@ -324,6 +326,7 @@ namespace Temporalio.Worker
             // We are gonna require a single result here
             var decoded = await codec.DecodeAsync(new Payload[] { payload }).ConfigureAwait(false);
             payload.Metadata.Clear();
+            payload.Data = ByteString.Empty;
             payload.MergeFrom(decoded.Single());
         }
     }

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -5,7 +5,6 @@ namespace Temporalio.Tests.Worker;
 
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
-using System.Text;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Extensions.Logging;
 using Temporalio.Activities;


### PR DESCRIPTION
## What was changed

Properly cleared out `Data` on payload before merging (i.e. replacing) inline.

## Checklist

1. Closes #342