### PR TITLE
Support failed completion building for activity

### DIFF
--- a/src/Temporalio/Converters/DefaultFailureConverter.cs
+++ b/src/Temporalio/Converters/DefaultFailureConverter.cs
@@ -41,7 +41,7 @@ namespace Temporalio.Converters
         public DefaultFailureConverterOptions Options { get; private init; }
 
         /// <inheritdoc />
-        public Failure ToFailure(Exception exception, IPayloadConverter payloadConverter)
+        public virtual Failure ToFailure(Exception exception, IPayloadConverter payloadConverter)
         {
             // If the exception is not already a failure exception, make it an application exception
             var failureEx =
@@ -76,7 +76,7 @@ namespace Temporalio.Converters
         }
 
         /// <inheritdoc />
-        public Exception ToException(Failure failure, IPayloadConverter payloadConverter)
+        public virtual Exception ToException(Failure failure, IPayloadConverter payloadConverter)
         {
             // If encoded attributes are present and we can decode the attributes, set them as
             // expected

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -223,11 +223,16 @@ namespace Temporalio.Worker
             {
                 completion = new()
                 {
+                    TaskToken = tsk.TaskToken,
                     Result = new()
                     {
                         Failed = new()
                         {
-                            Failure_ = new() { Message = $"Failed building completion: {e}" },
+                            Failure_ = new()
+                            {
+                                Message = $"Failed building completion: {e}",
+                                ApplicationFailureInfo = new() { Type = e.GetType().Name },
+                            },
                         },
                     },
                 };


### PR DESCRIPTION
## What was changed

When failing to build completion, that outer failure was not setting the proper things. This is a rare code path and was not tested properly.

(features CI will fail until #352 merged)

## Checklist

1. Closes #349