### PR TITLE
Disallow open generics on activity methods

### DIFF
--- a/src/Temporalio/Activities/ActivityDefinition.cs
+++ b/src/Temporalio/Activities/ActivityDefinition.cs
@@ -126,6 +126,10 @@ namespace Temporalio.Activities
         {
             var attr = method.GetCustomAttribute<ActivityAttribute>(false) ??
                 throw new ArgumentException($"{method} missing Activity attribute");
+            if (method.ContainsGenericParameters)
+            {
+                throw new ArgumentException($"{method} contains generic parameters");
+            }
             var parms = method.GetParameters();
             return Create(
                 NameFromAttributed(method, attr),


### PR DESCRIPTION
## What was changed

We can't invoke open generic activity methods, so disallow them at definition creation time

(features CI will fail until #352 merged)

## Checklist

1. Closes #350