### PR TITLE
Upgrade dependency and add .NET 8 in one CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         include:
           - os: windows-latest
             checkTarget: true
+            # We want to use one version for most things and this latest for
+            # others. This is an ok way to test both without requiring a
+            # separate matrix permutation.
+            dotNetVersionOverride: 8.x
           - os: ubuntu-latest
             docsTarget: true
             cloudTestTarget: true
@@ -44,7 +48,7 @@ jobs:
         with:
           # Specific .NET version required because GitHub macos ARM image has
           # bad pre-installed .NET version
-          dotnet-version: 6.x
+          dotnet-version: ${{ matrix.dotNetVersionOverride || 6 }}
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           # Specific .NET version required because GitHub macos ARM image has
           # bad pre-installed .NET version
-          dotnet-version: ${{ matrix.dotNetVersionOverride || 6 }}
+          dotnet-version: ${{ matrix.dotNetVersionOverride || '6.x' }}
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3

--- a/src/Temporalio/Temporalio.csproj
+++ b/src/Temporalio/Temporalio.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <!-- Allow tests to use internals -->


### PR DESCRIPTION
## What was changed

* Update `System.Text.Json` minimum version to account for vuln at https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
  * Note, we do not always blindly upgrade transitive dependencies on our users for every vuln, but this is a semver patch-level upgrade which is a no brainer
* Use .NET 8 during compile on one of the matrix targets to ensure we catch this in the future
  * Only recently have .NET warnings been added for dependencies with vulns

## Checklist

1. Closes #347