### PR TITLE
Store `MethodInfo` when creating an `ActivityDefinition`

### DIFF
--- a/src/Temporalio/Activities/ActivityDefinition.cs
+++ b/src/Temporalio/Activities/ActivityDefinition.cs
@@ -19,13 +19,15 @@ namespace Temporalio.Activities
             Type returnType,
             IReadOnlyCollection<Type> parameterTypes,
             int requiredParameterCount,
-            Func<object?[], object?> invoker)
+            Func<object?[], object?> invoker,
+            MethodInfo? methodInfo)
         {
             Name = name;
             ReturnType = returnType;
             ParameterTypes = parameterTypes;
             RequiredParameterCount = requiredParameterCount;
             this.invoker = invoker;
+            MethodInfo = methodInfo;
         }
 
         /// <summary>
@@ -55,6 +57,11 @@ namespace Temporalio.Activities
         /// Gets a value indicating whether the activity is dynamic.
         /// </summary>
         public bool Dynamic => Name == null;
+
+        /// <summary>
+        /// Gets the <see cref="MethodInfo"/>. Will only have a value if one was used to create this <see cref="ActivityDefinition"/>.
+        /// </summary>
+        public MethodInfo? MethodInfo { get; private init; }
 
         /// <summary>
         /// Create an activity definition from a delegate. <see cref="Delegate.DynamicInvoke" /> is
@@ -89,31 +96,7 @@ namespace Temporalio.Activities
             int requiredParameterCount,
             Func<object?[], object?> invoker)
         {
-            // If there is a null name, which means dynamic, there must only be one parameter type
-            // and it must be varargs IRawValue
-            if (name == null && (
-                requiredParameterCount != 1 ||
-                parameterTypes.SingleOrDefault() != typeof(Converters.IRawValue[])))
-            {
-                throw new ArgumentException(
-                    $"Dynamic activity must accept a required array of IRawValue");
-            }
-
-            if (requiredParameterCount > parameterTypes.Count)
-            {
-                throw new ArgumentException(
-                    $"Activity {name} has more required parameters than parameters",
-                    nameof(requiredParameterCount));
-            }
-            foreach (var parameterType in parameterTypes)
-            {
-                if (parameterType.IsByRef)
-                {
-                    throw new ArgumentException(
-                        $"Activity {name} has disallowed ref/out parameter");
-                }
-            }
-            return new(name, returnType, parameterTypes, requiredParameterCount, invoker);
+            return Create(name, returnType, parameterTypes, requiredParameterCount, invoker, methodInfo: null);
         }
 
         /// <summary>
@@ -136,7 +119,8 @@ namespace Temporalio.Activities
                 method.ReturnType,
                 parms.Select(p => p.ParameterType).ToArray(),
                 parms.Count(p => !p.HasDefaultValue),
-                parameters => invoker.Invoke(ParametersWithDefaults(parms, parameters)));
+                parameters => invoker.Invoke(ParametersWithDefaults(parms, parameters)),
+                method);
         }
 
         /// <summary>
@@ -299,6 +283,41 @@ namespace Temporalio.Activities
                 name = name.Substring(0, name.Length - 5);
             }
             return name;
+        }
+
+        private static ActivityDefinition Create(
+            string? name,
+            Type returnType,
+            IReadOnlyCollection<Type> parameterTypes,
+            int requiredParameterCount,
+            Func<object?[], object?> invoker,
+            MethodInfo? methodInfo)
+        {
+            // If there is a null name, which means dynamic, there must only be one parameter type
+            // and it must be varargs IRawValue
+            if (name == null && (
+                requiredParameterCount != 1 ||
+                parameterTypes.SingleOrDefault() != typeof(Converters.IRawValue[])))
+            {
+                throw new ArgumentException(
+                    $"Dynamic activity must accept a required array of IRawValue");
+            }
+
+            if (requiredParameterCount > parameterTypes.Count)
+            {
+                throw new ArgumentException(
+                    $"Activity {name} has more required parameters than parameters",
+                    nameof(requiredParameterCount));
+            }
+            foreach (var parameterType in parameterTypes)
+            {
+                if (parameterType.IsByRef)
+                {
+                    throw new ArgumentException(
+                        $"Activity {name} has disallowed ref/out parameter");
+                }
+            }
+            return new(name, returnType, parameterTypes, requiredParameterCount, invoker, methodInfo);
         }
     }
 }

--- a/tests/Temporalio.Tests/Activities/ActivityDefinitionTests.cs
+++ b/tests/Temporalio.Tests/Activities/ActivityDefinitionTests.cs
@@ -1,7 +1,6 @@
-using System.Reflection;
-
 namespace Temporalio.Tests.Activities;
 
+using System.Reflection;
 using System.Threading.Tasks;
 using Temporalio.Activities;
 using Temporalio.Converters;

--- a/tests/Temporalio.Tests/Activities/ActivityDefinitionTests.cs
+++ b/tests/Temporalio.Tests/Activities/ActivityDefinitionTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace Temporalio.Tests.Activities;
 
 using System.Threading.Tasks;
@@ -171,6 +173,40 @@ public class ActivityDefinitionTests
             typeof(GoodActivityGeneric<string>),
             new GoodActivityGeneric<string>("some-val")).Single();
         Assert.Equal("some-val", await defn.InvokeAsync(Array.Empty<object?>()));
+    }
+
+    [Fact]
+    public async Task Create_WithMethodInfo_HasValidMethodInfo()
+    {
+        var methodInfo = typeof(ActivityDefinitionTests)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(mi => mi.Name.Equals(nameof(GoodAct1Async), StringComparison.Ordinal));
+
+        var defn = ActivityDefinition.Create(methodInfo, objects => methodInfo!.Invoke(this, objects));
+        Assert.Equal(methodInfo, defn.MethodInfo);
+    }
+
+    [Fact]
+    public async Task Create_WithDelegate_HasValidMethodInfo()
+    {
+        var methodInfo = typeof(ActivityDefinitionTests)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(mi => mi.Name.Equals(nameof(GoodAct1Async), StringComparison.Ordinal));
+
+        var defn = ActivityDefinition.Create(GoodAct1Async);
+        Assert.Equal(methodInfo, defn.MethodInfo);
+    }
+
+    [Fact]
+    public async Task Create_WithLambda_DoesNotHaveValidMethodInfo()
+    {
+        var defn = ActivityDefinition.Create(
+            "some-name",
+            typeof(int),
+            new Type[] { typeof(int) },
+            1,
+            parameters => ((int)parameters[0]!) + 5);
+        Assert.Null(defn.MethodInfo);
     }
 
     protected static void BadAct1()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
In order to access other attributes for a given activity, the MethodInfo used to create the activity is needed. There are only certain situations where a MethodInfo is used so the new property is added but made nullable.

## Why?
The main reason is to allow activity interceptors to get reflection information about the method that is being called so it can use things like Attributes to make decisions, if needed.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-dotnet/issues/367

2. How was this tested:

New tests are added to verify each public Create method properly sets or does not set the MethodInfo.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
