### PR TITLE
Add limit to list workflows

### DIFF
--- a/src/Temporalio/Client/WorkflowListOptions.cs
+++ b/src/Temporalio/Client/WorkflowListOptions.cs
@@ -14,6 +14,11 @@ namespace Temporalio.Client
         public RpcOptions? Rpc { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number of workflows to return. A zero value means no limit.
+        /// </summary>
+        public int Limit { get; set; }
+
+        /// <summary>
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options and any transitive options fields.</returns>

--- a/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
@@ -272,6 +272,15 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
             actualResults.Add(result);
         }
         Assert.Equal(expectedResults, actualResults);
+
+        // Verify limit option works
+        var limitedResults = 0;
+        await foreach (var wf in Client.ListWorkflowsAsync(
+            $"WorkflowId = '{workflowId}'", new() { Limit = 3 }))
+        {
+            limitedResults++;
+        }
+        Assert.Equal(3, limitedResults);
     }
 
     [Workflow]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Title

## Why?
Convenience functionality since there's no built-in `take` function or similar in .NET for async iterators

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-dotnet/issues/332

2. How was this tested:
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
