### PR TITLE
Fix child workflow already exists and minor README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ CLI:
 
     dotnet add package Temporalio
 
-If you are using .NET Framework or a non-standard target platform, see the
+The .NET SDK supports .NET Framework >= 4.6.2, .NET Core >= 3.1 (so includes .NET 5+), and .NET Standard >= 2.0. If you
+are using .NET Framework or a non-standard target platform, see the
 [Built-in Native Shared Library](#built-in-native-shared-library) section later for additional information.
 
 **NOTE: This README is for the current branch and not necessarily what's released on NuGet.**

--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -106,8 +106,9 @@ namespace Temporalio.Client
                         {
                             throw new WorkflowAlreadyStartedException(
                                 e.Message,
-                                input.Options.Id!,
-                                failure.RunId);
+                                workflowId: input.Options.Id!,
+                                workflowType: input.Workflow,
+                                runId: failure.RunId);
                         }
                     }
                     throw;

--- a/src/Temporalio/Exceptions/WorkflowAlreadyStartedException.cs
+++ b/src/Temporalio/Exceptions/WorkflowAlreadyStartedException.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Temporalio.Exceptions
 {
     /// <summary>
@@ -9,12 +11,27 @@ namespace Temporalio.Exceptions
         /// Initializes a new instance of the <see cref="WorkflowAlreadyStartedException"/> class.
         /// </summary>
         /// <param name="message">Error message.</param>
-        /// <param name="workflowId">Already started workflow ID.</param>
-        /// <param name="runId">Already started run ID.</param>
+        /// <param name="workflowId">See <see cref="WorkflowId"/>.</param>
+        /// <param name="runId">See <see cref="RunId"/>.</param>
+        [Obsolete("Use other constructor")]
         public WorkflowAlreadyStartedException(string message, string workflowId, string runId)
+            : this(message, workflowId, "<unknown>", runId)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowAlreadyStartedException"/> class.
+        /// </summary>
+        /// <param name="message">Error message.</param>
+        /// <param name="workflowId">See <see cref="WorkflowId"/>.</param>
+        /// <param name="workflowType">See <see cref="WorkflowType"/>.</param>
+        /// <param name="runId">See <see cref="RunId"/>.</param>
+        public WorkflowAlreadyStartedException(
+            string message, string workflowId, string workflowType, string runId)
             : base(message)
         {
             WorkflowId = workflowId;
+            WorkflowType = workflowType;
             RunId = runId;
         }
 
@@ -24,7 +41,13 @@ namespace Temporalio.Exceptions
         public string WorkflowId { get; private init; }
 
         /// <summary>
-        /// Gets the run ID that was already started.
+        /// Gets the workflow type that was attempted to start.
+        /// </summary>
+        public string WorkflowType { get; private init; }
+
+        /// <summary>
+        /// Gets the run ID that was already started. This may be <c>&lt;unknown&gt;</c> when this
+        /// error is thrown for a child workflow from inside a workflow.
         /// </summary>
         public string RunId { get; private init; }
     }

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -2003,8 +2003,10 @@ namespace Temporalio.Worker
                                         handleSource.SetException(
                                             new WorkflowAlreadyStartedException(
                                                 "Child workflow already started",
-                                                startRes.Failed.WorkflowId,
-                                                startRes.Failed.WorkflowType));
+                                                workflowId: startRes.Failed.WorkflowId,
+                                                workflowType: startRes.Failed.WorkflowType,
+                                                // Pending https://github.com/temporalio/temporal/issues/6961
+                                                runId: "<unknown>"));
                                         return;
                                     default:
                                         handleSource.SetException(new InvalidOperationException(

--- a/src/Temporalio/Worker/WorkflowWorker.cs
+++ b/src/Temporalio/Worker/WorkflowWorker.cs
@@ -49,7 +49,9 @@ namespace Temporalio.Worker
             {
                 if (!defn.Instantiable)
                 {
-                    throw new ArgumentException($"Workflow named {defn.Name} is not instantiable");
+                    throw new ArgumentException($"Workflow named {defn.Name} is not instantiable. " +
+                        "Note, dependency injection is not supported in workflows. " +
+                        "Workflows must be deterministic and self-contained with a lifetime controlled by Temporal.");
                 }
                 if (defn.Name == null)
                 {

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -6011,6 +6011,53 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             new TemporalWorkerOptions().AddAllActivities(activities));
     }
 
+    [Workflow]
+    public class ChildWorkflowAlreadyExists1Workflow
+    {
+        [WorkflowRun]
+        public Task RunAsync() => Workflow.WaitConditionAsync(() => false);
+    }
+
+    [Workflow]
+    public class ChildWorkflowAlreadyExists2Workflow
+    {
+        [WorkflowRun]
+        public async Task<string> RunAsync(string workflowId)
+        {
+            try
+            {
+                await Workflow.StartChildWorkflowAsync(
+                    (ChildWorkflowAlreadyExists2Workflow wf) => wf.RunAsync("ignored"),
+                    new() { Id = workflowId });
+                throw new ApplicationFailureException("Should not be reached");
+            }
+            catch (WorkflowAlreadyStartedException e)
+            {
+                return $"already started, type: {e.WorkflowType}, run ID: {e.RunId}";
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_ChildWorkflowAlreadyExists_ErrorsProperly()
+    {
+        await ExecuteWorkerAsync<ChildWorkflowAlreadyExists1Workflow>(
+            async worker =>
+            {
+                // Start workflow
+                var handle = await Client.StartWorkflowAsync(
+                    (ChildWorkflowAlreadyExists1Workflow wf) => wf.RunAsync(),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+
+                // Try to run other one
+                var result = await Client.ExecuteWorkflowAsync(
+                    (ChildWorkflowAlreadyExists2Workflow wf) => wf.RunAsync(handle.Id),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+                Assert.Equal("already started, type: ChildWorkflowAlreadyExists2Workflow, run ID: <unknown>", result);
+            },
+            new TemporalWorkerOptions().AddWorkflow<ChildWorkflowAlreadyExists2Workflow>());
+    }
+
     internal static Task AssertTaskFailureContainsEventuallyAsync(
         WorkflowHandle handle, string messageContains)
     {


### PR DESCRIPTION
## What was changed

* Fixed mistakenly setting child workflow type as run ID on already-exists
  * Also opened https://github.com/temporalio/temporal/issues/6961 to get actual run ID here
* Added .NET version info to README
* Clarified workflow-not-instantiable error to mention DI not supported

## Checklist

1. Closes #371
1. Closes #368
1. Closes #361