### PR TITLE
Remove "experimental" tag from workflow update

### DIFF
--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -309,7 +309,6 @@ namespace Temporalio.Client
         /// <param name="updateCall">Invocation of workflow update method.</param>
         /// <param name="options">Update options. Currently <c>WaitForStage</c> is required.</param>
         /// <returns>Workflow update handle.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public Task<WorkflowUpdateHandle> StartUpdateAsync<TWorkflow>(
             Expression<Func<TWorkflow, Task>> updateCall, WorkflowUpdateStartOptions options)
         {
@@ -328,7 +327,6 @@ namespace Temporalio.Client
         /// <param name="updateCall">Invocation of workflow update method.</param>
         /// <param name="options">Update options. Currently <c>WaitForStage</c> is required.</param>
         /// <returns>Workflow update handle.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public Task<WorkflowUpdateHandle<TUpdateResult>> StartUpdateAsync<TWorkflow, TUpdateResult>(
             Expression<Func<TWorkflow, Task<TUpdateResult>>> updateCall,
             WorkflowUpdateStartOptions options)
@@ -347,7 +345,6 @@ namespace Temporalio.Client
         /// <param name="args">Arguments for the update.</param>
         /// <param name="options">Update options. Currently <c>WaitForStage</c> is required.</param>
         /// <returns>Workflow update handle.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public async Task<WorkflowUpdateHandle> StartUpdateAsync(
             string update, IReadOnlyCollection<object?> args, WorkflowUpdateStartOptions options) =>
             await StartUpdateAsync<ValueTuple>(update, args, options).ConfigureAwait(false);
@@ -360,7 +357,6 @@ namespace Temporalio.Client
         /// <param name="args">Arguments for the update.</param>
         /// <param name="options">Update options. Currently <c>WaitForStage</c> is required.</param>
         /// <returns>Workflow update handle.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public Task<WorkflowUpdateHandle<TUpdateResult>> StartUpdateAsync<TUpdateResult>(
             string update, IReadOnlyCollection<object?> args, WorkflowUpdateStartOptions options) =>
             Client.OutboundInterceptor.StartWorkflowUpdateAsync<TUpdateResult>(new(
@@ -378,9 +374,6 @@ namespace Temporalio.Client
         /// +
         /// <see cref="WorkflowUpdateHandle.GetResultAsync(RpcOptions?)" />.
         /// </summary>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change. Currently this
-        /// API will timeout on long update requests instead of properly polling for their
-        /// completion.</remarks>
         /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
         /// <param name="updateCall">Invocation of workflow update method.</param>
         /// <param name="options">Extra options.</param>
@@ -401,9 +394,6 @@ namespace Temporalio.Client
         /// +
         /// <see cref="WorkflowUpdateHandle{TResult}.GetResultAsync(RpcOptions?)" />.
         /// </summary>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change. Currently this
-        /// API will timeout on long update requests instead of properly polling for their
-        /// completion.</remarks>
         /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
         /// <typeparam name="TUpdateResult">Update result type.</typeparam>
         /// <param name="updateCall">Invocation of workflow update method.</param>
@@ -424,9 +414,6 @@ namespace Temporalio.Client
         /// +
         /// <see cref="WorkflowUpdateHandle.GetResultAsync(RpcOptions?)" />.
         /// </summary>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change. Currently this
-        /// API will timeout on long update requests instead of properly polling for their
-        /// completion.</remarks>
         /// <param name="update">Update name.</param>
         /// <param name="args">Update args.</param>
         /// <param name="options">Extra options.</param>
@@ -447,9 +434,6 @@ namespace Temporalio.Client
         /// +
         /// <see cref="WorkflowUpdateHandle.GetResultAsync(RpcOptions?)" />.
         /// </summary>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change. Currently this
-        /// API will timeout on long update requests instead of properly polling for their
-        /// completion.</remarks>
         /// <typeparam name="TUpdateResult">Update result type.</typeparam>
         /// <param name="update">Update name.</param>
         /// <param name="args">Update args.</param>
@@ -470,7 +454,6 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="id">ID of the update.</param>
         /// <returns>Workflow update handle.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public WorkflowUpdateHandle GetUpdateHandle(string id) =>
             new(Client: Client, Id: id, WorkflowId: Id, WorkflowRunId: RunId);
 
@@ -480,7 +463,6 @@ namespace Temporalio.Client
         /// <typeparam name="TUpdateResult">Update result type.</typeparam>
         /// <param name="id">ID of the update.</param>
         /// <returns>Workflow update handle.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public WorkflowUpdateHandle<TUpdateResult> GetUpdateHandle<TUpdateResult>(string id) =>
             new(Client: Client, Id: id, WorkflowId: Id, WorkflowRunId: RunId);
 
@@ -679,7 +661,6 @@ namespace Temporalio.Client
         /// <param name="updateCall">Invocation of workflow update method.</param>
         /// <param name="options">Update options. Currently <c>WaitForStage</c> is required.</param>
         /// <returns>Workflow update handle.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public Task<WorkflowUpdateHandle> StartUpdateAsync(
             Expression<Func<TWorkflow, Task>> updateCall, WorkflowUpdateStartOptions options) =>
             StartUpdateAsync<TWorkflow>(updateCall, options);
@@ -691,7 +672,6 @@ namespace Temporalio.Client
         /// <param name="updateCall">Invocation of workflow update method.</param>
         /// <param name="options">Update options. Currently <c>WaitForStage</c> is required.</param>
         /// <returns>Workflow update handle.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public Task<WorkflowUpdateHandle<TUpdateResult>> StartUpdateAsync<TUpdateResult>(
             Expression<Func<TWorkflow, Task<TUpdateResult>>> updateCall,
             WorkflowUpdateStartOptions options) =>
@@ -703,9 +683,6 @@ namespace Temporalio.Client
         /// +
         /// <see cref="WorkflowUpdateHandle.GetResultAsync(RpcOptions?)" />.
         /// </summary>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change. Currently this
-        /// API will timeout on long update requests instead of properly polling for their
-        /// completion.</remarks>
         /// <param name="updateCall">Invocation of workflow update method.</param>
         /// <param name="options">Extra options.</param>
         /// <returns>Completed update task.</returns>
@@ -724,9 +701,6 @@ namespace Temporalio.Client
         /// +
         /// <see cref="WorkflowUpdateHandle{TResult}.GetResultAsync(RpcOptions?)" />.
         /// </summary>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change. Currently this
-        /// API will timeout on long update requests instead of properly polling for their
-        /// completion.</remarks>
         /// <typeparam name="TUpdateResult">Update result type.</typeparam>
         /// <param name="updateCall">Invocation of workflow update method.</param>
         /// <param name="options">Extra options.</param>

--- a/src/Temporalio/Client/WorkflowUpdateHandle.cs
+++ b/src/Temporalio/Client/WorkflowUpdateHandle.cs
@@ -15,7 +15,6 @@ namespace Temporalio.Client
     /// <param name="Id">Update ID.</param>
     /// <param name="WorkflowId">Workflow ID.</param>
     /// <param name="WorkflowRunId">Run ID if any.</param>
-    /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
     public record WorkflowUpdateHandle(
         ITemporalClient Client,
         string Id,
@@ -32,7 +31,6 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="rpcOptions">Extra RPC options.</param>
         /// <returns>Completed update task.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public Task GetResultAsync(RpcOptions? rpcOptions = null) =>
             GetResultAsync<ValueTuple>(rpcOptions);
 
@@ -42,7 +40,6 @@ namespace Temporalio.Client
         /// <typeparam name="TResult">Update result type.</typeparam>
         /// <param name="rpcOptions">Extra RPC options.</param>
         /// <returns>Completed update result.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public virtual async Task<TResult> GetResultAsync<TResult>(RpcOptions? rpcOptions = null)
         {
             await PollUntilOutcomeAsync(rpcOptions).ConfigureAwait(false);
@@ -131,7 +128,6 @@ namespace Temporalio.Client
     /// <param name="Id">Update ID.</param>
     /// <param name="WorkflowId">Workflow ID.</param>
     /// <param name="WorkflowRunId">Run ID if any.</param>
-    /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
     public record WorkflowUpdateHandle<TResult>(
         ITemporalClient Client,
         string Id,
@@ -144,7 +140,6 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="rpcOptions">Extra RPC options.</param>
         /// <returns>Completed update result.</returns>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public new Task<TResult> GetResultAsync(RpcOptions? rpcOptions = null) =>
             GetResultAsync<TResult>(rpcOptions);
     }

--- a/src/Temporalio/Client/WorkflowUpdateOptions.cs
+++ b/src/Temporalio/Client/WorkflowUpdateOptions.cs
@@ -5,7 +5,6 @@ namespace Temporalio.Client
     /// <summary>
     /// Options for executing an update on a <see cref="WorkflowHandle" />.
     /// </summary>
-    /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
     public class WorkflowUpdateOptions : ICloneable
     {
         /// <summary>

--- a/src/Temporalio/Client/WorkflowUpdateStartOptions.cs
+++ b/src/Temporalio/Client/WorkflowUpdateStartOptions.cs
@@ -3,7 +3,6 @@ namespace Temporalio.Client
     /// <summary>
     /// Options for starting an update on a <see cref="WorkflowHandle" />.
     /// </summary>
-    /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
     public class WorkflowUpdateStartOptions : WorkflowUpdateOptions
     {
         /// <summary>

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -96,7 +96,6 @@ namespace Temporalio.Workflows
         /// This set via a <see cref="AsyncLocal{T}" /> and therefore only visible inside the
         /// handler and tasks it creates.
         /// </remarks>
-        /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
         public static WorkflowUpdateInfo? CurrentUpdateInfo => Context.CurrentUpdateInfo;
 
         /// <summary>

--- a/src/Temporalio/Workflows/WorkflowUpdateAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowUpdateAttribute.cs
@@ -15,7 +15,6 @@ namespace Temporalio.Workflows
     /// <see cref="Worker.TemporalWorkerOptions.WorkflowFailureExceptionTypes"/> to change the
     /// default behavior.
     /// </remarks>
-    /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     public sealed class WorkflowUpdateAttribute : Attribute
     {
@@ -45,7 +44,6 @@ namespace Temporalio.Workflows
         /// Gets or sets a short description for this update that may appear in UI/CLI when workflow
         /// is asked for which updates it supports.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public string? Description { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Workflows/WorkflowUpdateInfo.cs
+++ b/src/Temporalio/Workflows/WorkflowUpdateInfo.cs
@@ -9,7 +9,6 @@ namespace Temporalio.Workflows
     /// </summary>
     /// <param name="Id">Current update ID.</param>
     /// <param name="Name">Current update name.</param>
-    /// <remarks>WARNING: Workflow update is experimental and APIs may change.</remarks>
     public record WorkflowUpdateInfo(
         string Id,
         string Name)


### PR DESCRIPTION
## What was changed

No longer consider workflow update experimental in .NET