### PR TITLE
Expose instance to workflows/activities and client to activities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
           - os: ubuntu-latest
             docsTarget: true
             cloudTestTarget: true
+            # This is here alongside docsTarget because newer docfx doesn't work
+            # with .NET 6.
+            dotNetVersionOverride: |
+              6.x
+              8.x
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-intel

--- a/src/Temporalio.Extensions.Hosting/ActivityScope.cs
+++ b/src/Temporalio.Extensions.Hosting/ActivityScope.cs
@@ -1,0 +1,68 @@
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Information and ability to control the activity DI scope.
+    /// </summary>
+    public static class ActivityScope
+    {
+        private static readonly AsyncLocal<IServiceScope?> ServiceScopeLocal = new();
+        private static readonly AsyncLocal<object?> ScopedInstanceLocal = new();
+
+        /// <summary>
+        /// Gets or sets the current scope for this activity.
+        /// </summary>
+        /// <remarks>
+        /// This is backed by an async local. By default, when the activity invocation starts
+        /// (meaning inside the interceptor, not before), a new service scope is created and set on
+        /// this value. This means it will not be present in the primary execute-activity
+        /// interceptor
+        /// (<see cref="Worker.Interceptors.ActivityInboundInterceptor.ExecuteActivityAsync"/>) call
+        /// but will be available everywhere else the ActivityExecutionContext is. When set by the
+        /// internal code, it is also disposed by the internal code. See the next remark for how to
+        /// control the scope.
+        /// </remarks>
+        /// <remarks>
+        /// In situations where a user wants to control the service scope from the primary
+        /// execute-activity interceptor, this can be set to the result of <c>CreateScope</c> or
+        /// <c>CreateAsyncScope</c> of a service provider. The internal code will then use this
+        /// instead of creating its own, and will therefore not dispose it. This should never be set
+        /// anywhere but inside the primary execute-activity interceptor, and it no matter the value
+        /// it will be set to null before the <c>base</c> call returns from the primary
+        /// execute-activity interceptor.
+        /// </remarks>
+        public static IServiceScope? ServiceScope
+        {
+            get => ServiceScopeLocal.Value;
+            set => ServiceScopeLocal.Value = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the scoped instance for non-static activity methods.
+        /// </summary>
+        /// <remarks>
+        /// This is backed by an async local. By default, when the activity invocation starts
+        /// (meaning inside the interceptor, not before) for a non-static method, an instance is
+        /// obtained from the service provider and set on this value. This means it will not be
+        /// present in the primary execute-activity interceptor
+        /// (<see cref="Worker.Interceptors.ActivityInboundInterceptor.ExecuteActivityAsync"/>) call
+        /// but will be available everywhere else the ActivityExecutionContext is. See the next
+        /// remark for how to control the instance.
+        /// </remarks>
+        /// <remarks>
+        /// In situations where a user wants to control the instance from the primary
+        /// execute-activity interceptor, this can be set to the result of <c>GetRequiredService</c>
+        /// of a service provider. The internal code will then use this instead of creating its own.
+        /// This should never be set anywhere but inside the primary execute-activity interceptor,
+        /// and it no matter the value it will be set to null before the <c>base</c> call returns
+        /// from the primary execute-activity interceptor.
+        /// </remarks>
+        public static object? ScopedInstance
+        {
+            get => ScopedInstanceLocal.Value;
+            set => ScopedInstanceLocal.Value = value;
+        }
+    }
+}

--- a/src/Temporalio/Testing/ActivityEnvironment.cs
+++ b/src/Temporalio/Testing/ActivityEnvironment.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Temporalio.Activities;
 using Temporalio.Api.Common.V1;
+using Temporalio.Client;
 using Temporalio.Common;
 using Temporalio.Converters;
 
@@ -59,6 +60,12 @@ namespace Temporalio.Testing
         /// Gets or inits the metric meter for this activity. If unset, a noop meter is used.
         /// </summary>
         public MetricMeter? MetricMeter { get; init; }
+
+        /// <summary>
+        /// Gets or inits the Temporal client accessible from the activity context. If unset, an
+        /// exception is thrown when the client is accessed.
+        /// </summary>
+        public ITemporalClient? TemporalClient { get; init; }
 
         /// <summary>
         /// Gets or sets the cancel reason. Callers may prefer <see cref="Cancel" /> instead.
@@ -134,7 +141,8 @@ namespace Temporalio.Testing
                     taskToken: ByteString.Empty,
                     logger: Logger,
                     payloadConverter: PayloadConverter,
-                    runtimeMetricMeter: new(() => MetricMeter ?? MetricMeterNoop.Instance))
+                    runtimeMetricMeter: new(() => MetricMeter ?? MetricMeterNoop.Instance),
+                    temporalClient: TemporalClient)
                 {
                     Heartbeater = Heartbeater,
                     CancelReasonRef = CancelReasonRef,

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -10,6 +10,7 @@ using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 using Temporalio.Activities;
+using Temporalio.Client;
 using Temporalio.Converters;
 using Temporalio.Exceptions;
 using Temporalio.Worker.Interceptors;
@@ -191,7 +192,8 @@ namespace Temporalio.Worker
                 taskToken: tsk.TaskToken,
                 logger: worker.LoggerFactory.CreateLogger($"Temporalio.Activity:{info.ActivityType}"),
                 payloadConverter: worker.Client.Options.DataConverter.PayloadConverter,
-                runtimeMetricMeter: worker.MetricMeter);
+                runtimeMetricMeter: worker.MetricMeter,
+                temporalClient: worker.Client as ITemporalClient);
 
             // Start task
             using (context.Logger.BeginScope(info.LoggerScope))

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -285,6 +285,19 @@ namespace Temporalio.Worker
         public WorkflowInfo Info { get; private init; }
 
         /// <inheritdoc />
+        ///
+        /// This is lazily created and should never be called outside of the scheduler
+        public object Instance
+        {
+            get
+            {
+                // We create this lazily because we want the constructor in a workflow context
+                instance ??= Definition.CreateWorkflowInstance(startArgs!.Value);
+                return instance;
+            }
+        }
+
+        /// <inheritdoc />
         public bool IsReplaying { get; private set; }
 
         /// <inheritdoc />
@@ -321,20 +334,6 @@ namespace Temporalio.Worker
         /// Gets the workflow definition.
         /// </summary>
         internal WorkflowDefinition Definition { get; private init; }
-
-        /// <summary>
-        /// Gets the instance, lazily creating if needed. This should never be called outside this
-        /// scheduler.
-        /// </summary>
-        private object Instance
-        {
-            get
-            {
-                // We create this lazily because we want the constructor in a workflow context
-                instance ??= Definition.CreateWorkflowInstance(startArgs!.Value);
-                return instance;
-            }
-        }
 
         /// <inheritdoc/>
         public ContinueAsNewException CreateContinueAsNewException(

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -74,6 +74,11 @@ namespace Temporalio.Workflows
         WorkflowInfo Info { get; }
 
         /// <summary>
+        /// Gets value for <see cref="Workflow.Instance" />.
+        /// </summary>
+        object Instance { get; }
+
+        /// <summary>
         /// Gets a value indicating whether <see cref="Workflow.Unsafe.IsReplaying" /> is true.
         /// </summary>
         bool IsReplaying { get; }

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -135,6 +135,11 @@ namespace Temporalio.Workflows
         public static WorkflowInfo Info => Context.Info;
 
         /// <summary>
+        /// Gets the instance of the current workflow class.
+        /// </summary>
+        public static object Instance => Context.Instance;
+
+        /// <summary>
         /// Gets a value indicating whether this code is currently running in a workflow.
         /// </summary>
         public static bool InWorkflow => TaskScheduler.Current is IWorkflowContext;

--- a/tests/Temporalio.Tests/Extensions/Hosting/ActivityScopeTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/ActivityScopeTests.cs
@@ -1,0 +1,139 @@
+#pragma warning disable SA1201, SA1204 // We want to have classes near their tests
+namespace Temporalio.Tests.Extensions.Hosting;
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Temporalio.Activities;
+using Temporalio.Client;
+using Temporalio.Exceptions;
+using Temporalio.Extensions.Hosting;
+using Temporalio.Worker.Interceptors;
+using Temporalio.Workflows;
+using Xunit;
+using Xunit.Abstractions;
+
+public class ActivityScopeTests : WorkflowEnvironmentTestBase
+{
+    public ActivityScopeTests(ITestOutputHelper output, WorkflowEnvironment env)
+        : base(output, env)
+    {
+    }
+
+    // Custom interceptor that fails when bad state is seen
+    public class FailOnBadStateInterceptor : IWorkerInterceptor
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        public FailOnBadStateInterceptor(IServiceProvider serviceProvider) =>
+            this.serviceProvider = serviceProvider;
+
+        public ActivityInboundInterceptor InterceptActivity(ActivityInboundInterceptor nextInterceptor) =>
+            new ActivityInbound(serviceProvider, nextInterceptor);
+
+        private class ActivityInbound : ActivityInboundInterceptor
+        {
+            private readonly IServiceProvider serviceProvider;
+
+            public ActivityInbound(IServiceProvider serviceProvider, ActivityInboundInterceptor next)
+                : base(next) => this.serviceProvider = serviceProvider;
+
+            public override async Task<object?> ExecuteActivityAsync(ExecuteActivityInput input)
+            {
+                // Make sure it's the expected activity
+                if (input.Activity.Name != "SetSomeState")
+                {
+                    throw new InvalidOperationException("Unexpected activity");
+                }
+
+                // We want to control the instance so we have access to SomeState
+                await using var scope = serviceProvider.CreateAsyncScope();
+                ActivityScope.ServiceScope = scope;
+                var instance = scope.ServiceProvider.GetRequiredService<MyActivities>();
+                ActivityScope.ScopedInstance = instance;
+
+                // Run the activity, but if SomeState is "should-fail", then raise
+                var result = await base.ExecuteActivityAsync(input);
+                if (instance.SomeState == "should-fail")
+                {
+                    throw new ApplicationFailureException("Intentional failure", nonRetryable: true);
+                }
+                return result;
+            }
+        }
+    }
+
+    public class MyActivities
+    {
+        public string SomeState { get; set; } = "<unset>";
+
+        [Activity]
+        public void SetSomeState(string someState)
+        {
+            Assert.NotNull(ActivityScope.ServiceScope);
+            Assert.Same(ActivityScope.ScopedInstance, this);
+            SomeState = someState;
+        }
+    }
+
+    [Workflow]
+    public class MyWorkflow
+    {
+        [WorkflowRun]
+        public Task RunAsync(string someState) =>
+            Workflow.ExecuteActivityAsync(
+                (MyActivities acts) => acts.SetSomeState(someState),
+                new() { StartToCloseTimeout = TimeSpan.FromMinutes(5) });
+    }
+
+    [Fact]
+    public async Task ActivityScope_CustomInstance_IsAccessible()
+    {
+        // Create the host
+        using var loggerFactory = new TestUtils.LogCaptureFactory(NullLoggerFactory.Instance);
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var host = Host.CreateDefaultBuilder().ConfigureServices(services =>
+        {
+            // Configure a client
+            services.AddTemporalClient(
+                clientTargetHost: Client.Connection.Options.TargetHost,
+                clientNamespace: Client.Options.Namespace);
+
+            // Add the rest of the services
+            services.
+                AddSingleton<ILoggerFactory>(loggerFactory).
+                AddHostedTemporalWorker(taskQueue).
+                AddScopedActivities<MyActivities>().
+                AddWorkflow<MyWorkflow>().
+                // Add the interceptor and give it the service provider
+                ConfigureOptions().PostConfigure<IServiceProvider>((options, serviceProvider) =>
+                    options.Interceptors = new List<IWorkerInterceptor>
+                        { new FailOnBadStateInterceptor(serviceProvider) });
+        }).Build();
+
+        // Start the host
+        using var tokenSource = new CancellationTokenSource();
+        var hostTask = Task.Run(() => host.RunAsync(tokenSource.Token));
+
+        // Execute the workflow successfully. confirming no scope leak
+        Assert.Null(ActivityScope.ServiceScope);
+        Assert.Null(ActivityScope.ScopedInstance);
+        await Client.ExecuteWorkflowAsync(
+            (MyWorkflow wf) => wf.RunAsync("should-succeed"),
+            new($"wf-{Guid.NewGuid()}", taskQueue));
+        Assert.Null(ActivityScope.ServiceScope);
+        Assert.Null(ActivityScope.ScopedInstance);
+
+        // Now execute a workflow with state that the interceptor will see set on the activity and
+        // fail
+        var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
+            Client.ExecuteWorkflowAsync(
+                (MyWorkflow wf) => wf.RunAsync("should-fail"),
+                new($"wf-{Guid.NewGuid()}", taskQueue)));
+        var exc2 = Assert.IsType<ActivityFailureException>(exc.InnerException);
+        var exc3 = Assert.IsType<ApplicationFailureException>(exc2.InnerException);
+        Assert.Equal("Intentional failure", exc3.Message);
+    }
+}

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -5512,7 +5512,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             Func<WorkflowHandle<UnfinishedHandlersWorkflow>, Task> interaction,
             bool waitAllHandlersFinished,
             bool shouldWarn,
-            bool interactionShouldFailWithNotFound = false)
+            bool interactionShouldFailWithWorkflowAlreadyCompleted = false)
         {
             // If the finish is a failure, we never warn regardless
             if (finish == UnfinishedHandlersWorkflow.WorkflowFinish.Fail)
@@ -5534,11 +5534,12 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                     try
                     {
                         await interaction(handle);
-                        Assert.False(interactionShouldFailWithNotFound);
+                        Assert.False(interactionShouldFailWithWorkflowAlreadyCompleted);
                     }
-                    catch (RpcException e) when (e.Code == RpcException.StatusCode.NotFound)
+                    catch (WorkflowUpdateFailedException e) when (
+                        e.InnerException is ApplicationFailureException { ErrorType: "AcceptedUpdateCompletedWorkflow" })
                     {
-                        Assert.True(interactionShouldFailWithNotFound);
+                        Assert.True(interactionShouldFailWithWorkflowAlreadyCompleted);
                     }
                     // Wait for workflow completion
                     try
@@ -5576,7 +5577,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             interaction: h => h.ExecuteUpdateAsync(wf => wf.MyUpdateAsync()),
             waitAllHandlersFinished: false,
             shouldWarn: true,
-            interactionShouldFailWithNotFound: true);
+            interactionShouldFailWithWorkflowAlreadyCompleted: true);
         await AssertWarnings(
             interaction: h => h.ExecuteUpdateAsync(wf => wf.MyUpdateAsync()),
             waitAllHandlersFinished: true,
@@ -5585,7 +5586,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             interaction: h => h.ExecuteUpdateAsync(wf => wf.MyUpdateAbandonAsync()),
             waitAllHandlersFinished: false,
             shouldWarn: false,
-            interactionShouldFailWithNotFound: true);
+            interactionShouldFailWithWorkflowAlreadyCompleted: true);
         await AssertWarnings(
             interaction: h => h.ExecuteUpdateAsync(wf => wf.MyUpdateAbandonAsync()),
             waitAllHandlersFinished: true,
@@ -5594,7 +5595,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             interaction: h => h.ExecuteUpdateAsync("MyUpdateManual", Array.Empty<object?>()),
             waitAllHandlersFinished: false,
             shouldWarn: true,
-            interactionShouldFailWithNotFound: true);
+            interactionShouldFailWithWorkflowAlreadyCompleted: true);
         await AssertWarnings(
             interaction: h => h.ExecuteUpdateAsync("MyUpdateManual", Array.Empty<object?>()),
             waitAllHandlersFinished: true,
@@ -5603,7 +5604,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             interaction: h => h.ExecuteUpdateAsync("MyUpdateManualAbandon", Array.Empty<object?>()),
             waitAllHandlersFinished: false,
             shouldWarn: false,
-            interactionShouldFailWithNotFound: true);
+            interactionShouldFailWithWorkflowAlreadyCompleted: true);
         await AssertWarnings(
             interaction: h => h.ExecuteUpdateAsync("MyUpdateManualAbandon", Array.Empty<object?>()),
             waitAllHandlersFinished: true,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

* Add `Temporalio.Workflows.Workflow.Instance` to give access to the literal instance of the workflow class
* Add `Temporalio.Extensions.Hosting.ActivityScope` for activity scope information
  * This DI extension the only place .NET creates the user's instance for them
  * Provides both the `ServiceScope` and the `ScopedInstance` used by DI
  * Has advanced used for primary-execute-activity interceptor users to make their own scope or instance if needed since the instance is not available until inside the root call of the interceptor
* Add `Temporalio.Activities.ActivityExecutionContext.TemporalClient` to give access to Temporal client
  * Users can make test instances without this, which will throw on access
  * Users can _technically_ make workers with a more generic `IWorkerClient` interface that is not the full client, which will throw on access
* Minor test refactoring and fix for tests since new dev server release

## Checklist

1. Closes #388
2. Closes #389