### PR TITLE
Updated the docs for IdReusePolicy property

### DIFF
--- a/src/Temporalio/Client/WorkflowOptions.cs
+++ b/src/Temporalio/Client/WorkflowOptions.cs
@@ -73,7 +73,7 @@ namespace Temporalio.Client
         public TimeSpan? TaskTimeout { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to allow re-using a workflow id from a previously *closed* workflow.
+        /// Gets or sets whether to allow re-using a workflow ID from a previously *closed* workflow.
         /// Default is <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
         /// </summary>
         public WorkflowIdReusePolicy IdReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;

--- a/src/Temporalio/Client/WorkflowOptions.cs
+++ b/src/Temporalio/Client/WorkflowOptions.cs
@@ -73,8 +73,8 @@ namespace Temporalio.Client
         public TimeSpan? TaskTimeout { get; set; }
 
         /// <summary>
-        /// Gets or sets how already-existing IDs are treated. Default is
-        /// <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
+        /// Gets or sets whether to allow re-using a workflow id from a previously *closed* workflow.
+        /// Default is <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
         /// </summary>
         public WorkflowIdReusePolicy IdReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
 

--- a/src/Temporalio/Workflows/ChildWorkflowOptions.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowOptions.cs
@@ -77,7 +77,7 @@ namespace Temporalio.Workflows
         public TimeSpan? TaskTimeout { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to allow re-using a workflow id from a previously *closed* workflow.
+        /// Gets or sets whether to allow re-using a workflow ID from a previously *closed* workflow.
         /// Default is <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
         /// </summary>
         public WorkflowIdReusePolicy IdReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;

--- a/src/Temporalio/Workflows/ChildWorkflowOptions.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowOptions.cs
@@ -77,8 +77,8 @@ namespace Temporalio.Workflows
         public TimeSpan? TaskTimeout { get; set; }
 
         /// <summary>
-        /// Gets or sets how already-existing IDs are treated. Default is
-        /// <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
+        /// Gets or sets whether to allow re-using a workflow id from a previously *closed* workflow.
+        /// Default is <see cref="WorkflowIdReusePolicy.AllowDuplicate" />.
         /// </summary>
         public WorkflowIdReusePolicy IdReusePolicy { get; set; } = WorkflowIdReusePolicy.AllowDuplicate;
 


### PR DESCRIPTION
## What was changed
Docs for `IdReusePolicy` property in `WorkflowOptions` and `ChildWorkflowOptions`.

## Why?
Previous wording was misleading as it did not explicitly state it applies to "closed" workflows.