### PR TITLE
Added namespace name to workflow/activity tags

### DIFF
--- a/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
+++ b/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
@@ -163,6 +163,10 @@ namespace Temporalio.Extensions.OpenTelemetry
             {
                 ret.Add(new(runName, info.RunId));
             }
+            if (Options.TagNameNamespace is string namespaceName)
+            {
+                ret.Add(new(namespaceName, info.Namespace));
+            }
             return ret;
         }
 
@@ -186,6 +190,10 @@ namespace Temporalio.Extensions.OpenTelemetry
             if (Options.TagNameActivityId is string actName)
             {
                 ret.Add(new(actName, info.ActivityId));
+            }
+            if (Options.TagNameNamespace is string namespaceName)
+            {
+                ret.Add(new(namespaceName, info.WorkflowNamespace));
             }
             return ret;
         }

--- a/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptorOptions.cs
+++ b/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptorOptions.cs
@@ -39,6 +39,11 @@ namespace Temporalio.Extensions.OpenTelemetry
         public string? TagNameUpdateId { get; set; } = "temporalUpdateID";
 
         /// <summary>
+        /// Gets or sets the tag name for namespace. If null, no tag is created.
+        /// </summary>
+        public string? TagNameNamespace { get; set; } = "temporalNamespace";
+
+        /// <summary>
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options.</returns>


### PR DESCRIPTION
## What was changed
OpenTelemetry tags were extended with a namespace name.

## Why?
Motivation is to get a namespace name as part of OTel data so we can do some grouping based on that in our observability tool.