### PR TITLE
Fix issue where null timer summary breaks codec

### DIFF
--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -193,7 +193,10 @@ namespace Temporalio.Worker
                     }
                     break;
                 case WorkflowCommand.VariantOneofCase.StartTimer:
-                    await EncodeAsync(codec, cmd.StartTimer.Summary).ConfigureAwait(false);
+                    if (cmd.StartTimer.Summary != null)
+                    {
+                        await EncodeAsync(codec, cmd.StartTimer.Summary).ConfigureAwait(false);
+                    }
                     break;
                 case WorkflowCommand.VariantOneofCase.UpdateResponse:
                     if (cmd.UpdateResponse.Completed is { } updateCompleted)

--- a/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
@@ -78,6 +78,26 @@ public class WorkflowCodecHelperTests : TestBase
         });
     }
 
+    [Fact]
+    public async Task EncodeAsync_AllPayloads_WorksWithNull()
+    {
+        // For every singular Payload field, we are going to set it to null and ensure it can still
+        // encode. This is to prevent regression since we missed that sometimes we are not checking
+        // for null in WorkflowCodecHelper.
+        var comp = new WorkflowActivationCompletion();
+        var codec = new MarkerPayloadCodec();
+        await CreateAndVisitPayload(new(), comp, async (ctx, payload) =>
+        {
+            var (msg, prop) = ctx.PropertyPath.Last();
+            var propInfo = msg.GetType().GetProperty(prop);
+            if (propInfo?.PropertyType == typeof(Payload))
+            {
+                propInfo.SetValue(msg, null);
+                await WorkflowCodecHelper.EncodeAsync(codec, comp);
+            }
+        });
+    }
+
     // Creates payloads as needed, null context if already seen
     private static async Task CreateAndVisitPayload(
         PayloadVisitContext ctx, IMessage current, Func<PayloadVisitContext, Func<Payload>, Task> visitor)


### PR DESCRIPTION
## What was changed

* Properly check for null summary before trying codec
* Add test that makes sure that any singular payload can be null

## Checklist

1. Closes #400