### PR TITLE
Use RawValue for built-in query response

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -1145,11 +1145,17 @@ namespace Temporalio.Worker
 
                     if (query.QueryType == "__stack_trace")
                     {
-                        resultObj = GetStackTrace();
+                        // Use raw value built from default converter because we don't want to use
+                        // user-conversion
+                        resultObj = new RawValue(DataConverter.Default.PayloadConverter.ToPayload(
+                            GetStackTrace()));
                     }
                     else if (query.QueryType == "__temporal_workflow_metadata")
                     {
-                        resultObj = GetWorkflowMetadata();
+                        // Use raw value built from default converter because we don't want to use
+                        // user-conversion
+                        resultObj = new RawValue(DataConverter.Default.PayloadConverter.ToPayload(
+                            GetWorkflowMetadata()));
                     }
                     else
                     {


### PR DESCRIPTION
## What was changed

Use RawValue for built-in query response so user's payload converter is not used

## Checklist

1. Closes #414