### PR TITLE
Allow unaltered payload response from codec

### DIFF
--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -275,11 +275,16 @@ namespace Temporalio.Worker
         {
             // We are gonna require a single result here. It is important that we do Single() call
             // before clearing out payload to merge with since underlying enumerable may be lazy.
+            // If the returned payload is literally the same object as the one sent to the codec,
+            // we leave it alone.
             var encodedList = await codec.EncodeAsync(new Payload[] { payload }).ConfigureAwait(false);
             var encoded = encodedList.Single();
-            payload.Metadata.Clear();
-            payload.Data = ByteString.Empty;
-            payload.MergeFrom(encoded);
+            if (!ReferenceEquals(encoded, payload))
+            {
+                payload.Metadata.Clear();
+                payload.Data = ByteString.Empty;
+                payload.MergeFrom(encoded);
+            }
         }
 
         private static async Task DecodeAsync(IPayloadCodec codec, ActivityResolution res)
@@ -379,9 +384,13 @@ namespace Temporalio.Worker
         {
             // We are gonna require a single result here
             var decoded = await codec.DecodeAsync(new Payload[] { payload }).ConfigureAwait(false);
-            payload.Metadata.Clear();
-            payload.Data = ByteString.Empty;
-            payload.MergeFrom(decoded.Single());
+            var decodedPayload = decoded.Single();
+            if (!ReferenceEquals(decodedPayload, payload))
+            {
+                payload.Metadata.Clear();
+                payload.Data = ByteString.Empty;
+                payload.MergeFrom(decodedPayload);
+            }
         }
     }
 }

--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -382,7 +382,8 @@ namespace Temporalio.Worker
 
         private static async Task DecodeAsync(IPayloadCodec codec, Payload payload)
         {
-            // We are gonna require a single result here
+            // We are gonna require a single result here.
+            // Similarly with encode, we leave the payload alone if it's exactly the same object as the original.
             var decoded = await codec.DecodeAsync(new Payload[] { payload }).ConfigureAwait(false);
             var decodedPayload = decoded.Single();
             if (!ReferenceEquals(decodedPayload, payload))


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This change allows for codecs to return unaltered payloads, without the need to explicitly
clone them first.

## Why?
It's a bit unintuitive that one can't simply return the unaltered payload, and there are a
handful of sample code snippets that do exactly this.

## Checklist
<!--- add/delete as needed --->

1. Closes #417 

2. How was this tested:
A new codec was added to the unit tests to exercise the code with a codec that simply
returns the unaltered payload. The new unit testing will fail with existing code, but pass
with the new changes.

3. Any docs updates needed?
Probably not required, but if desired, the codec section could be updated to explicitly
state that it's possible to return an unaltered payload: https://docs.temporal.io/develop/dotnet/converters-and-encryption#custom-payload-codec
