### PR TITLE
add protected constructors for metric instrumentation in Temporalio.Common namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1115,6 +1115,7 @@ activity context:
 * `Heartbeater` - Callback invoked each heartbeat.
 * `WorkerShutdownTokenSource` - Token source for issuing worker shutdown.
 * `PayloadConverter` - Defaulted to default payload converter.
+* `MetricMeter` - Defaulted to noop meter.
 
 ### OpenTelemetry Tracing Support
 

--- a/src/Temporalio/Common/MetricCounter.cs
+++ b/src/Temporalio/Common/MetricCounter.cs
@@ -19,6 +19,17 @@ namespace Temporalio.Common
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MetricCounter{T}" /> class.
+        /// </summary>
+        /// <param name="name">The name of the counter.</param>
+        /// <param name="unit">The optional unit of measurement for the values recorded by the counter.</param>
+        /// <param name="description">The optional description of the counter.</param>
+        protected MetricCounter(string name, string? unit = null, string? description = null)
+            : this(new(name, unit, description))
+        {
+        }
+
+        /// <summary>
         /// Add the given value to the counter.
         /// </summary>
         /// <param name="value">Value to add. Currently this can only be a positive integer.</param>

--- a/src/Temporalio/Common/MetricGauge.cs
+++ b/src/Temporalio/Common/MetricGauge.cs
@@ -19,6 +19,17 @@ namespace Temporalio.Common
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MetricGauge{T}" /> class.
+        /// </summary>
+        /// <param name="name">The name of the gauge.</param>
+        /// <param name="unit">The optional unit of measurement for the values recorded by the gauge.</param>
+        /// <param name="description">The optional description of the gauge.</param>
+        protected MetricGauge(string name, string? unit = null, string? description = null)
+            : this(new(name, unit, description))
+        {
+        }
+
+        /// <summary>
         /// Set the given value on the gauge.
         /// </summary>
         /// <param name="value">Value to record. Currently this can only be a positive

--- a/src/Temporalio/Common/MetricHistogram.cs
+++ b/src/Temporalio/Common/MetricHistogram.cs
@@ -19,6 +19,17 @@ namespace Temporalio.Common
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MetricHistogram{T}" /> class.
+        /// </summary>
+        /// <param name="name">The name of the histogram.</param>
+        /// <param name="unit">The optional unit of measurement for the values recorded by the histogram.</param>
+        /// <param name="description">The optional description of the histogram.</param>
+        protected MetricHistogram(string name, string? unit = null, string? description = null)
+            : this(new(name, unit, description))
+        {
+        }
+
+        /// <summary>
         /// Record the given value on the histogram.
         /// </summary>
         /// <param name="value">Value to record. Currently this can only be a positive


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added new `protected` constructors for `MetricCounter`, `MetricGauge`, and `MetricHistogram` in the `Temporalio.Common` namespace. This will allow users to supply their own implementations when passing in a custom `MetricMeter` on the activity environment for tests.

Previously the only constructors for these classes were internal, so they were not instantiable from outside of the `Temporalio` library.
## Why?
<!-- Tell your future self why have you made these changes -->
Users want to be able to test their metric instrumentation within an activity using the `ActivityEnvironment` abstraction, without having to run their activities inside a full `TemporalWorker`.

It's fairly common to use an in-memory exporter to validate metric data points: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.InMemory/README.md, so users want to be able to have the ability to supply a custom metric meter hooked up to an in memory exporter to write tests validating metrics.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-dotnet/issues/430


2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

No logic was added, just an additional constructor. It would be difficult to write a test for this without creating a new test assembly where internals are not visible.

In C#, protected constructors are guaranteed to be accessible by any derived class outside of the assembly: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/accessibility-levels

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

I updated the section on activity testing to inform users of the presence of the `MetricMeter` on the `ActivityEnvironment`, to be consistent with the rest of the public properties.

I can re-order the properties in this list to be alphabetical, but they currently roughly appear to be in the order as the properties appear on the ActivityExecutionContext, so placing the property at the bottom to be roughly consistent
