### PR TITLE
Apply modern event loop algorithm with new SDK flag

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -85,6 +85,8 @@ namespace Temporalio.Worker
         private WorkflowQueryDefinition? dynamicQuery;
         private WorkflowSignalDefinition? dynamicSignal;
         private WorkflowUpdateDefinition? dynamicUpdate;
+        private bool workflowInitialized;
+        private bool applyModernEventLoopLogic;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkflowInstance"/> class.
@@ -529,6 +531,20 @@ namespace Temporalio.Worker
                 IsReplaying = act.IsReplaying;
                 UtcNow = act.Timestamp.ToDateTime();
 
+                // If the workflow has not been initialized, we are in the first activation and we
+                // need to set the modern-event-loop-logic flag
+                if (!workflowInitialized)
+                {
+                    // If we're not replaying or we are replaying and the flag is already set, set
+                    // to true and mark flag. Otherwise we leave false.
+                    if (!IsReplaying ||
+                        act.AvailableInternalFlags.Contains((uint)WorkflowLogicFlag.ApplyModernEventLoopLogic))
+                    {
+                        applyModernEventLoopLogic = true;
+                        completion.Successful.UsedInternalFlags.Add((uint)WorkflowLogicFlag.ApplyModernEventLoopLogic);
+                    }
+                }
+
                 // Starting callback
                 onTaskStarting(this);
 
@@ -541,29 +557,59 @@ namespace Temporalio.Worker
                     {
                         // We must set the sync context to null so work isn't posted there
                         SynchronizationContext.SetSynchronizationContext(null);
-                        // TODO: Temporary workaround in lieu of https://github.com/temporalio/sdk-dotnet/issues/375
-                        var sortedJobs = act.Jobs.OrderBy(j =>
+
+                        // We only sort jobs in legacy event loop logic, modern relies on Core
+                        List<WorkflowActivationJob> jobs;
+                        if (applyModernEventLoopLogic)
                         {
-                            switch (j.VariantCase)
+                            jobs = act.Jobs.ToList();
+                        }
+                        else
+                        {
+                            jobs = act.Jobs.OrderBy(j =>
                             {
-                                case WorkflowActivationJob.VariantOneofCase.NotifyHasPatch:
-                                case WorkflowActivationJob.VariantOneofCase.UpdateRandomSeed:
-                                    return 1;
-                                case WorkflowActivationJob.VariantOneofCase.SignalWorkflow:
-                                case WorkflowActivationJob.VariantOneofCase.DoUpdate:
-                                    return 2;
-                                case WorkflowActivationJob.VariantOneofCase.InitializeWorkflow:
-                                    return 3;
-                                default:
-                                    return 4;
-                            }
-                        }).ToList();
-                        // We can trust jobs are deterministically ordered by core
-                        foreach (var job in sortedJobs)
+                                switch (j.VariantCase)
+                                {
+                                    case WorkflowActivationJob.VariantOneofCase.NotifyHasPatch:
+                                    case WorkflowActivationJob.VariantOneofCase.UpdateRandomSeed:
+                                        return 1;
+                                    case WorkflowActivationJob.VariantOneofCase.SignalWorkflow:
+                                    case WorkflowActivationJob.VariantOneofCase.DoUpdate:
+                                        return 2;
+                                    case WorkflowActivationJob.VariantOneofCase.InitializeWorkflow:
+                                        return 3;
+                                    default:
+                                        return 4;
+                                }
+                            }).ToList();
+                        }
+
+                        // Apply each job
+                        foreach (var job in jobs)
                         {
                             Apply(job);
-                            // Run scheduler once. Do not check conditions when patching or querying.
-                            var checkConditions = job.NotifyHasPatch == null && job.QueryWorkflow == null;
+                            // We only run the scheduler after each job in legacy event loop logic
+                            if (!applyModernEventLoopLogic)
+                            {
+                                // Run scheduler once. Do not check conditions when patching or
+                                // querying with legacy event loop logic.
+                                var checkConditions = job.NotifyHasPatch == null && job.QueryWorkflow == null;
+                                RunOnce(checkConditions);
+                            }
+                        }
+
+                        // For modern event loop logic, we initialize here if not initialized
+                        // already
+                        if (applyModernEventLoopLogic && !workflowInitialized)
+                        {
+                            InitializeWorkflow();
+                        }
+
+                        // For modern event loop logic, we run the event loop only after applying
+                        // everything, and we check conditions if there are any non-query jobs
+                        if (applyModernEventLoopLogic)
+                        {
+                            var checkConditions = jobs.Any(j => j.VariantCase != WorkflowActivationJob.VariantOneofCase.QueryWorkflow);
                             RunOnce(checkConditions);
                         }
                     }
@@ -701,9 +747,20 @@ namespace Temporalio.Worker
                     Workflow.OverrideContext.Value = this;
                     try
                     {
-                        foreach (var source in conditions.Where(t => t.Item1()).Select(t => t.Item2))
+                        foreach (var condition in conditions)
                         {
-                            source.TrySetResult(null);
+                            // Check whether the condition evaluates to true
+                            if (condition.Item1())
+                            {
+                                // Set condition as resolved
+                                condition.Item2.TrySetResult(null);
+                                // When applying modern event loop logic, we want to break after the
+                                // first condition is resolved instead of checking/applying all
+                                if (applyModernEventLoopLogic)
+                                {
+                                    break;
+                                }
+                            }
                         }
                     }
                     finally
@@ -901,7 +958,11 @@ namespace Temporalio.Worker
                     ApplySignalWorkflow(job.SignalWorkflow);
                     break;
                 case WorkflowActivationJob.VariantOneofCase.InitializeWorkflow:
-                    ApplyInitializeWorkflow(job.InitializeWorkflow);
+                    // We only initialize the workflow at job time on legacy event loop logic
+                    if (!applyModernEventLoopLogic)
+                    {
+                        InitializeWorkflow();
+                    }
                     break;
                 case WorkflowActivationJob.VariantOneofCase.UpdateRandomSeed:
                     ApplyUpdateRandomSeed(job.UpdateRandomSeed);
@@ -1327,8 +1388,16 @@ namespace Temporalio.Worker
             }));
         }
 
-        private void ApplyInitializeWorkflow(InitializeWorkflow init)
+        private void ApplyUpdateRandomSeed(UpdateRandomSeed update) =>
+            Random = new(update.RandomnessSeed);
+
+        private void InitializeWorkflow()
         {
+            if (workflowInitialized)
+            {
+                throw new InvalidOperationException("Workflow unexpectedly initialized");
+            }
+            workflowInitialized = true;
             _ = QueueNewTaskAsync(() => RunTopLevelAsync(async () =>
             {
                 var input = new ExecuteWorkflowInput(
@@ -1342,9 +1411,6 @@ namespace Temporalio.Worker
                 AddCommand(new() { CompleteWorkflowExecution = new() { Result = result } });
             }));
         }
-
-        private void ApplyUpdateRandomSeed(UpdateRandomSeed update) =>
-            Random = new(update.RandomnessSeed);
 
         private void OnQueryDefinitionAdded(string name, WorkflowQueryDefinition defn)
         {

--- a/src/Temporalio/Worker/WorkflowLogicFlag.cs
+++ b/src/Temporalio/Worker/WorkflowLogicFlag.cs
@@ -11,5 +11,21 @@ namespace Temporalio.Worker
         /// set.
         /// </summary>
         ReorderWorkflowCompletion = 1,
+
+        /// <summary>
+        /// Before this flag, workflow async logic did the following (in no particular order):
+        /// * Reorder jobs itself.
+        /// * Schedule primary workflow method when the initialize job was seen.
+        /// * Tick the event loop after each job processed.
+        /// * Check all conditions at once and resolve all that are satisfied.
+        /// We have since learned that all of these are wrong. So if this flag is set on the first
+        /// activation/task of a workflow, the following logic now applies respectively:
+        /// * Leave Core's job ordering as is.
+        /// * Do not schedule the primary workflow method until after all jobs have been applied and
+        ///   it's not already present.
+        /// * Tick the event loop only once after everything applied.
+        /// * Only resolve the first condition that is satisfied and re-run the entire event loop.
+        /// </summary>
+        ApplyModernEventLoopLogic = 2,
     }
 }

--- a/tests/Temporalio.Tests/Worker/Histories/multi-signal-order.pre-dotnet-flag.json
+++ b/tests/Temporalio.Tests/Worker/Histories/multi-signal-order.pre-dotnet-flag.json
@@ -1,0 +1,216 @@
+{
+    "events": [
+        {
+            "eventId": "1",
+            "eventTime": "2025-03-18T14:53:30.786565900Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+            "taskId": "1048592",
+            "workflowExecutionStartedEventAttributes": {
+                "workflowType": {
+                    "name": "MultiSignalOrderWorkflow"
+                },
+                "taskQueue": {
+                    "name": "tq-24728a79-4d6c-4b7a-9bd5-f242371aa29b",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "workflowTaskTimeout": "10s",
+                "originalExecutionRunId": "0195a9be-d522-78a2-a9c2-a372d4a13a7d",
+                "identity": "40832@DESKTOP-W0A14BL",
+                "firstExecutionRunId": "0195a9be-d522-78a2-a9c2-a372d4a13a7d",
+                "attempt": 1,
+                "firstWorkflowTaskBackoff": "0s",
+                "workflowId": "workflow-6848becb-84a1-4e25-bf7c-0e653cb4c610"
+            }
+        },
+        {
+            "eventId": "2",
+            "eventTime": "2025-03-18T14:53:30.786565900Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+            "taskId": "1048593",
+            "workflowTaskScheduledEventAttributes": {
+                "taskQueue": {
+                    "name": "tq-24728a79-4d6c-4b7a-9bd5-f242371aa29b",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "startToCloseTimeout": "10s",
+                "attempt": 1
+            }
+        },
+        {
+            "eventId": "3",
+            "eventTime": "2025-03-18T14:53:30.792493700Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+            "taskId": "1048598",
+            "workflowTaskStartedEventAttributes": {
+                "scheduledEventId": "2",
+                "identity": "40832@DESKTOP-W0A14BL",
+                "requestId": "feb456ea-f5d9-4af0-b53e-736676b6de46",
+                "historySizeBytes": "336",
+                "workerVersion": {
+                    "buildId": "b76221fe-6cc7-4d81-b837-7d11bb04315c"
+                }
+            }
+        },
+        {
+            "eventId": "4",
+            "eventTime": "2025-03-18T14:53:31.099838Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+            "taskId": "1048602",
+            "workflowTaskCompletedEventAttributes": {
+                "scheduledEventId": "2",
+                "startedEventId": "3",
+                "identity": "40832@DESKTOP-W0A14BL",
+                "workerVersion": {
+                    "buildId": "b76221fe-6cc7-4d81-b837-7d11bb04315c"
+                },
+                "sdkMetadata": {
+                    "coreUsedFlags": [
+                        1,
+                        2,
+                        3
+                    ],
+                    "sdkName": "temporal-dotnet",
+                    "sdkVersion": "1.5.0.0"
+                },
+                "meteringMetadata": {}
+            }
+        },
+        {
+            "eventId": "5",
+            "eventTime": "2025-03-18T14:53:31.099838Z",
+            "eventType": "EVENT_TYPE_MARKER_RECORDED",
+            "taskId": "1048603",
+            "markerRecordedEventAttributes": {
+                "markerName": "core_local_activity",
+                "details": {
+                    "data": {
+                        "payloads": [
+                            {
+                                "metadata": {
+                                    "encoding": "anNvbi9wbGFpbg=="
+                                },
+                                "data": "eyJzZXEiOjEsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiMSIsImFjdGl2aXR5X3R5cGUiOiJTZW5kVHdvU2lnbmFscyIsImNvbXBsZXRlX3RpbWUiOnsic2Vjb25kcyI6MTc0MjMwOTYxMCwibmFub3MiOjg2Njk1MTMwMH0sImJhY2tvZmYiOm51bGwsIm9yaWdpbmFsX3NjaGVkdWxlX3RpbWUiOnsic2Vjb25kcyI6MTc0MjMwOTYxMSwibmFub3MiOjExNzgzMzAwfX0="
+                            }
+                        ]
+                    },
+                    "result": {
+                        "payloads": [
+                            {
+                                "metadata": {
+                                    "encoding": "anNvbi9wbGFpbg=="
+                                },
+                                "data": "e30="
+                            }
+                        ]
+                    }
+                },
+                "workflowTaskCompletedEventId": "4"
+            }
+        },
+        {
+            "eventId": "6",
+            "eventTime": "2025-03-18T14:53:31.071349300Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+            "taskId": "1048604",
+            "workflowExecutionSignaledEventAttributes": {
+                "signalName": "Signal",
+                "input": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "Im9uZSI="
+                        }
+                    ]
+                },
+                "identity": "40832@DESKTOP-W0A14BL"
+            }
+        },
+        {
+            "eventId": "7",
+            "eventTime": "2025-03-18T14:53:31.074059Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+            "taskId": "1048605",
+            "workflowExecutionSignaledEventAttributes": {
+                "signalName": "Signal",
+                "input": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "InR3byI="
+                        }
+                    ]
+                },
+                "identity": "40832@DESKTOP-W0A14BL"
+            }
+        },
+        {
+            "eventId": "8",
+            "eventTime": "2025-03-18T14:53:31.099838Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+            "taskId": "1048606",
+            "workflowTaskScheduledEventAttributes": {
+                "taskQueue": {
+                    "name": "40832@DESKTOP-W0A14BL-2ab3d8b4b7234e00a900dbc30b57892b",
+                    "kind": "TASK_QUEUE_KIND_STICKY",
+                    "normalName": "tq-24728a79-4d6c-4b7a-9bd5-f242371aa29b"
+                },
+                "startToCloseTimeout": "10s",
+                "attempt": 1
+            }
+        },
+        {
+            "eventId": "9",
+            "eventTime": "2025-03-18T14:53:31.099838Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+            "taskId": "1048607",
+            "workflowTaskStartedEventAttributes": {
+                "scheduledEventId": "8",
+                "identity": "40832@DESKTOP-W0A14BL",
+                "requestId": "request-from-RespondWorkflowTaskCompleted",
+                "historySizeBytes": "469",
+                "workerVersion": {
+                    "buildId": "b76221fe-6cc7-4d81-b837-7d11bb04315c"
+                }
+            }
+        },
+        {
+            "eventId": "10",
+            "eventTime": "2025-03-18T14:53:31.118735600Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+            "taskId": "1048611",
+            "workflowTaskCompletedEventAttributes": {
+                "scheduledEventId": "8",
+                "startedEventId": "9",
+                "identity": "40832@DESKTOP-W0A14BL",
+                "workerVersion": {
+                    "buildId": "b76221fe-6cc7-4d81-b837-7d11bb04315c"
+                },
+                "sdkMetadata": {},
+                "meteringMetadata": {}
+            }
+        },
+        {
+            "eventId": "11",
+            "eventTime": "2025-03-18T14:53:31.118735600Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+            "taskId": "1048612",
+            "workflowExecutionCompletedEventAttributes": {
+                "result": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "WyJvbmUiXQ=="
+                        }
+                    ]
+                },
+                "workflowTaskCompletedEventId": "10"
+            }
+        }
+    ]
+}

--- a/tests/Temporalio.Tests/Worker/Histories/multi-wait-condition.pre-dotnet-flag.json
+++ b/tests/Temporalio.Tests/Worker/Histories/multi-wait-condition.pre-dotnet-flag.json
@@ -1,0 +1,98 @@
+{
+    "events": [
+        {
+            "eventId": "1",
+            "eventTime": "2025-03-18T13:52:26.900552500Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+            "taskId": "1048592",
+            "workflowExecutionStartedEventAttributes": {
+                "workflowType": {
+                    "name": "MultiWaitConditionWorkflow"
+                },
+                "taskQueue": {
+                    "name": "tq-639b5624-d488-4010-9240-c0ac75e67565",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "workflowTaskTimeout": "10s",
+                "originalExecutionRunId": "0195a986-ed14-786e-a2fa-2787d599fc94",
+                "identity": "11120@DESKTOP-W0A14BL",
+                "firstExecutionRunId": "0195a986-ed14-786e-a2fa-2787d599fc94",
+                "attempt": 1,
+                "firstWorkflowTaskBackoff": "0s",
+                "workflowId": "workflow-24a95a27-241d-42ea-8bfe-a0aa4ee99fa4"
+            }
+        },
+        {
+            "eventId": "2",
+            "eventTime": "2025-03-18T13:52:26.900552500Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+            "taskId": "1048593",
+            "workflowTaskScheduledEventAttributes": {
+                "taskQueue": {
+                    "name": "tq-639b5624-d488-4010-9240-c0ac75e67565",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "startToCloseTimeout": "10s",
+                "attempt": 1
+            }
+        },
+        {
+            "eventId": "3",
+            "eventTime": "2025-03-18T13:52:26.900552500Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+            "taskId": "1048598",
+            "workflowTaskStartedEventAttributes": {
+                "scheduledEventId": "2",
+                "identity": "11120@DESKTOP-W0A14BL",
+                "requestId": "125341bf-2a42-4584-832b-529da1f5291e",
+                "historySizeBytes": "338",
+                "workerVersion": {
+                    "buildId": "8571af36-29a5-4fe1-83e1-56d25ae29547"
+                }
+            }
+        },
+        {
+            "eventId": "4",
+            "eventTime": "2025-03-18T13:52:27.128895100Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+            "taskId": "1048602",
+            "workflowTaskCompletedEventAttributes": {
+                "scheduledEventId": "2",
+                "startedEventId": "3",
+                "identity": "11120@DESKTOP-W0A14BL",
+                "workerVersion": {
+                    "buildId": "8571af36-29a5-4fe1-83e1-56d25ae29547"
+                },
+                "sdkMetadata": {
+                    "coreUsedFlags": [
+                        1,
+                        2,
+                        3
+                    ],
+                    "sdkName": "temporal-dotnet",
+                    "sdkVersion": "1.5.0.0"
+                },
+                "meteringMetadata": {}
+            }
+        },
+        {
+            "eventId": "5",
+            "eventTime": "2025-03-18T13:52:27.128895100Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+            "taskId": "1048603",
+            "workflowExecutionCompletedEventAttributes": {
+                "result": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "WyJvbmUiLCJ0d28iLCJmb3VyIiwidGhyZWUiXQ=="
+                        }
+                    ]
+                },
+                "workflowTaskCompletedEventId": "4"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## What was changed

(description as mostly taken from a comment above the SDK flag)

Before this flag, workflow async logic did the following (in no particular order):
* Reorder jobs itself
* Schedule primary workflow method when the initialize job was seen
* Tick the event loop after each job processed
* Check all conditions at once and resolve all that are satisfied

We have since learned that all of these are wrong in one way or another. So if this flag is set on the first activation/task of a workflow, the following logic now applies respectively:
* Leave Core's job ordering as is
* Do not schedule the primary workflow method until after all jobs have been applied and it's not already present.
* Tick the event loop only once after everything applied
* Only resolve the first condition that is satisfied and re-run the entire event loop

We know this solves at least #427 where all-handlers-finished was improperly assumed true too early.

## Checklist

1. Closes #427
2. Closes #375