### PR TITLE
Ready: change readme activity examples from scheduletoclose to starttoclose

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ public class SayHelloWorkflow
             // This is a lambda expression where the instance is typed. If this
             // were static, you wouldn't need a parameter.
             (MyActivities act) => act.SayHello(name),
-            new() { ScheduleToCloseTimeout = TimeSpan.FromMinutes(5) });
+            new() { StartToCloseTimeout = TimeSpan.FromMinutes(5) });
     }
 }
 ```
@@ -401,7 +401,7 @@ public class GreetingWorkflow
                 // This is a static activity method. If it were an instance
                 // method, a typed parameter can be accepted in the lambda call.
                 () => GreetingActivities.CreateGreeting(greetingParams),
-                new() { ScheduleToCloseTimeout = TimeSpan.FromMinutes(5) });
+                new() { StartToCloseTimeout = TimeSpan.FromMinutes(5) });
             Workflow.Logger.LogDebug("Greeting set to {Greeting}", currentGreeting);
 
             // Wait for param update or complete signal. Note, cancellation can


### PR DESCRIPTION
## What was changed
Changed the activity invocation examples from `ScheduleToClose` to `StartToClose` 

## Why?
I have been seeing some examples in the courses that use `ScheduleToClose` where I think we mean `StartToClose` in activities, and I suspect it's a copy-paste thing from here.

In my understanding, `StartToClose` is more common than `ScheduleToClose` for activities, so I just figured I'd switch it.