### PR TITLE
Increase visibility on some client constructs and minor docs updates

### DIFF
--- a/src/Temporalio/Client/ITemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/ITemporalClient.Workflow.cs
@@ -177,6 +177,7 @@ namespace Temporalio.Client
         /// <param name="query">Query to use for filtering.</param>
         /// <param name="options">Options for the list call.</param>
         /// <returns>Async enumerator for the workflows.</returns>
+        /// <seealso href="https://docs.temporal.io/visibility">Visibility docs.</seealso>
         public IAsyncEnumerable<WorkflowExecution> ListWorkflowsAsync(
             string query, WorkflowListOptions? options = null);
 #endif
@@ -187,6 +188,7 @@ namespace Temporalio.Client
         /// <param name="query">Query to use for counting.</param>
         /// <param name="options">Options for the count call.</param>
         /// <returns>Count information for the workflows.</returns>
+        /// <seealso href="https://docs.temporal.io/visibility">Visibility docs.</seealso>
         public Task<WorkflowExecutionCount> CountWorkflowsAsync(
             string query, WorkflowCountOptions? options = null);
     }

--- a/src/Temporalio/Client/Schedules/ScheduleDescription.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleDescription.cs
@@ -17,7 +17,15 @@ namespace Temporalio.Client.Schedules
         private readonly Lazy<IReadOnlyDictionary<string, IEncodedRawValue>> memo;
         private readonly Lazy<SearchAttributeCollection> searchAttributes;
 
-        private ScheduleDescription(
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScheduleDescription"/> class.
+        /// </summary>
+        /// <param name="id">ID for the schedule.</param>
+        /// <param name="schedule">Schedule.</param>
+        /// <param name="rawDescription">Raw protobuf description.</param>
+        /// <param name="dataConverter">Data converter.</param>
+        /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
+        protected internal ScheduleDescription(
             string id, Schedule schedule, DescribeScheduleResponse rawDescription, DataConverter dataConverter)
         {
             Id = id;

--- a/src/Temporalio/Client/Schedules/ScheduleHandle.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleHandle.cs
@@ -20,7 +20,7 @@ namespace Temporalio.Client.Schedules
         /// <param name="backfills">Backfill periods.</param>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Task for completion.</returns>
-        public Task BackfillAsync(
+        public virtual Task BackfillAsync(
             IReadOnlyCollection<ScheduleBackfill> backfills, RpcOptions? rpcOptions = null)
         {
             if (backfills.Count == 0)
@@ -36,7 +36,7 @@ namespace Temporalio.Client.Schedules
         /// </summary>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Task for completion.</returns>
-        public Task DeleteAsync(RpcOptions? rpcOptions = null) =>
+        public virtual Task DeleteAsync(RpcOptions? rpcOptions = null) =>
             Client.OutboundInterceptor.DeleteScheduleAsync(new(Id: Id, RpcOptions: rpcOptions));
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Temporalio.Client.Schedules
         /// </summary>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Schedule description.</returns>
-        public Task<ScheduleDescription> DescribeAsync(RpcOptions? rpcOptions = null) =>
+        public virtual Task<ScheduleDescription> DescribeAsync(RpcOptions? rpcOptions = null) =>
             Client.OutboundInterceptor.DescribeScheduleAsync(new(Id: Id, RpcOptions: rpcOptions));
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Temporalio.Client.Schedules
         /// <param name="note">Note to set when pausing.</param>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Task for completion.</returns>
-        public Task PauseAsync(string? note = null, RpcOptions? rpcOptions = null) =>
+        public virtual Task PauseAsync(string? note = null, RpcOptions? rpcOptions = null) =>
             Client.OutboundInterceptor.PauseScheduleAsync(
                 new(Id: Id, Note: note, RpcOptions: rpcOptions));
 
@@ -62,7 +62,7 @@ namespace Temporalio.Client.Schedules
         /// </summary>
         /// <param name="options">Options for triggering.</param>
         /// <returns>Task for completion.</returns>
-        public Task TriggerAsync(ScheduleTriggerOptions? options = null) =>
+        public virtual Task TriggerAsync(ScheduleTriggerOptions? options = null) =>
             Client.OutboundInterceptor.TriggerScheduleAsync(new(Id: Id, Options: options));
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Temporalio.Client.Schedules
         /// <param name="note">Note to set when unpausing.</param>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Task for completion.</returns>
-        public Task UnpauseAsync(string? note = null, RpcOptions? rpcOptions = null) =>
+        public virtual Task UnpauseAsync(string? note = null, RpcOptions? rpcOptions = null) =>
             Client.OutboundInterceptor.UnpauseScheduleAsync(
                 new(Id: Id, Note: note, RpcOptions: rpcOptions));
 
@@ -98,7 +98,7 @@ namespace Temporalio.Client.Schedules
         /// to perform an update.</param>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Task for completion.</returns>
-        public Task UpdateAsync(
+        public virtual Task UpdateAsync(
             Func<ScheduleUpdateInput, Task<ScheduleUpdate?>> updater,
             RpcOptions? rpcOptions = null) =>
             Client.OutboundInterceptor.UpdateScheduleAsync(

--- a/src/Temporalio/Client/Schedules/ScheduleListDescription.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleListDescription.cs
@@ -20,7 +20,8 @@ namespace Temporalio.Client.Schedules
         /// </summary>
         /// <param name="rawEntry">Raw proto.</param>
         /// <param name="dataConverter">Data converter.</param>
-        internal ScheduleListDescription(
+        /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
+        protected internal ScheduleListDescription(
             Api.Schedule.V1.ScheduleListEntry rawEntry, DataConverter dataConverter)
         {
             RawEntry = rawEntry;

--- a/src/Temporalio/Client/WorkflowExecution.cs
+++ b/src/Temporalio/Client/WorkflowExecution.cs
@@ -22,7 +22,8 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="rawInfo">Raw proto info.</param>
         /// <param name="dataConverter">Data converter used for memos.</param>
-        internal WorkflowExecution(WorkflowExecutionInfo rawInfo, DataConverter dataConverter)
+        /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
+        protected internal WorkflowExecution(WorkflowExecutionInfo rawInfo, DataConverter dataConverter)
         {
             RawInfo = rawInfo;
             // Search attribute conversion is cheap so it doesn't need to lock on publication. But

--- a/src/Temporalio/Client/WorkflowExecutionCount.cs
+++ b/src/Temporalio/Client/WorkflowExecutionCount.cs
@@ -15,7 +15,8 @@ namespace Temporalio.Client
         /// Initializes a new instance of the <see cref="WorkflowExecutionCount" /> class.
         /// </summary>
         /// <param name="raw">Raw proto.</param>
-        internal WorkflowExecutionCount(CountWorkflowExecutionsResponse raw)
+        /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
+        protected internal WorkflowExecutionCount(CountWorkflowExecutionsResponse raw)
         {
             Count = raw.Count;
             Groups = raw.Groups?.Select(
@@ -42,7 +43,8 @@ namespace Temporalio.Client
             /// Initializes a new instance of the <see cref="AggregationGroup"/> class.
             /// </summary>
             /// <param name="raw">Raw proto.</param>
-            internal AggregationGroup(CountWorkflowExecutionsResponse.Types.AggregationGroup raw)
+            /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
+            protected internal AggregationGroup(CountWorkflowExecutionsResponse.Types.AggregationGroup raw)
             {
                 Count = raw.Count;
                 GroupValues = raw.GroupValues?.

--- a/src/Temporalio/Client/WorkflowExecutionDescription.cs
+++ b/src/Temporalio/Client/WorkflowExecutionDescription.cs
@@ -9,7 +9,15 @@ namespace Temporalio.Client
     /// </summary>
     public class WorkflowExecutionDescription : WorkflowExecution
     {
-        private WorkflowExecutionDescription(
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowExecutionDescription"/> class.
+        /// </summary>
+        /// <param name="rawDescription">Raw protobuf description.</param>
+        /// <param name="staticSummary">Static summary.</param>
+        /// <param name="staticDetails">Static details.</param>
+        /// <param name="dataConverter">Data converter.</param>
+        /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
+        protected internal WorkflowExecutionDescription(
             DescribeWorkflowExecutionResponse rawDescription,
             string? staticSummary,
             string? staticDetails,

--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -228,7 +228,7 @@ namespace Temporalio.Client
         /// the workflow yet.
         /// </returns>
         /// <exception cref="RpcException">Server-side error.</exception>
-        public Task SignalAsync(
+        public virtual Task SignalAsync(
             string signal, IReadOnlyCollection<object?> args, WorkflowSignalOptions? options = null) =>
             Client.OutboundInterceptor.SignalWorkflowAsync(new(
                 Id: Id,
@@ -292,7 +292,7 @@ namespace Temporalio.Client
         /// Query rejected by server based on rejection condition.
         /// </exception>
         /// <exception cref="RpcException">Server-side error.</exception>
-        public Task<TQueryResult> QueryAsync<TQueryResult>(
+        public virtual Task<TQueryResult> QueryAsync<TQueryResult>(
             string query, IReadOnlyCollection<object?> args, WorkflowQueryOptions? options = null) =>
             Client.OutboundInterceptor.QueryWorkflowAsync<TQueryResult>(new(
                 Id: Id,
@@ -357,7 +357,7 @@ namespace Temporalio.Client
         /// <param name="args">Arguments for the update.</param>
         /// <param name="options">Update options. Currently <c>WaitForStage</c> is required.</param>
         /// <returns>Workflow update handle.</returns>
-        public Task<WorkflowUpdateHandle<TUpdateResult>> StartUpdateAsync<TUpdateResult>(
+        public virtual Task<WorkflowUpdateHandle<TUpdateResult>> StartUpdateAsync<TUpdateResult>(
             string update, IReadOnlyCollection<object?> args, WorkflowUpdateStartOptions options) =>
             Client.OutboundInterceptor.StartWorkflowUpdateAsync<TUpdateResult>(new(
                 Id: Id,
@@ -471,7 +471,7 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="options">Extra options.</param>
         /// <returns>Description for the workflow.</returns>
-        public Task<WorkflowExecutionDescription> DescribeAsync(
+        public virtual Task<WorkflowExecutionDescription> DescribeAsync(
             WorkflowDescribeOptions? options = null) =>
             Client.OutboundInterceptor.DescribeWorkflowAsync(new(
                 Id: Id,
@@ -484,7 +484,7 @@ namespace Temporalio.Client
         /// <param name="options">Cancellation options.</param>
         /// <returns>Cancel accepted task.</returns>
         /// <exception cref="RpcException">Server-side error.</exception>
-        public Task CancelAsync(WorkflowCancelOptions? options = null) =>
+        public virtual Task CancelAsync(WorkflowCancelOptions? options = null) =>
             Client.OutboundInterceptor.CancelWorkflowAsync(new(
                 Id: Id,
                 RunId: RunId,
@@ -498,7 +498,7 @@ namespace Temporalio.Client
         /// <param name="options">Termination options.</param>
         /// <returns>Terminate completed task.</returns>
         /// <exception cref="RpcException">Server-side error.</exception>
-        public Task TerminateAsync(
+        public virtual Task TerminateAsync(
             string? reason = null, WorkflowTerminateOptions? options = null) =>
             Client.OutboundInterceptor.TerminateWorkflowAsync(new(
                 Id: Id,
@@ -509,11 +509,11 @@ namespace Temporalio.Client
 
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>
-        /// Fetcgh history for the workflow.
+        /// Fetch history for the workflow.
         /// </summary>
         /// <param name="options">Options for history fetching.</param>
         /// <returns>Fetched history.</returns>
-        public async Task<WorkflowHistory> FetchHistoryAsync(
+        public async virtual Task<WorkflowHistory> FetchHistoryAsync(
             WorkflowHistoryEventFetchOptions? options = null)
         {
             WorkflowHistoryEventFetchOptions? eventFetchOptions = null;
@@ -539,7 +539,7 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="options">History event fetch options.</param>
         /// <returns>Async enumerable to iterate events for.</returns>
-        public IAsyncEnumerable<HistoryEvent> FetchHistoryEventsAsync(
+        public virtual IAsyncEnumerable<HistoryEvent> FetchHistoryEventsAsync(
             WorkflowHistoryEventFetchOptions? options = null) =>
             FetchHistoryEventsInternalAsync(options);
 


### PR DESCRIPTION
## What was changed

* Exposed constructors as `protected internal` on multiple currently-internal-constructor-only classes returned from client calls so they can be mocked, but added warning that we may change them in incompatible ways in the future
  * We don't really want to commit to constructor stability here IMO at this time
  * Yes it is a bit annoying that they are internal and therefore you have to extend them to construct them, but we feel `public` encourages using these constructors too much, something we are actually discouraging
* Made final overloads of some client calls `virtual` so they can be overridden in subclasses
* Added docs as needed

## Why?

## Checklist

1. Closes #218
1. Closes #228
1. Closes #419