### PR TITLE
Add `Workflow.Unsafe.WithTracingEventListenerDisabled`

### DIFF
--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -254,6 +254,7 @@ namespace Temporalio.Worker
         /// When false, the default, a <see cref="System.Diagnostics.Tracing.EventListener" /> is
         /// used to catch improper calls from inside the workflow.
         /// </remarks>
+        /// <seealso cref="Workflow.Unsafe.WithTracingEventListenerDisabled{T}(Func{T})"/>
         public bool DisableWorkflowTracingEventListener { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -538,7 +538,7 @@ namespace Temporalio.Worker
                 if (origCmdCount != newCmdCount)
                 {
                     throw new InvalidOperationException(
-                        $"Function during tracing event listener disabling created workflow commands");
+                        "Function during tracing event listener disabling created workflow commands");
                 }
                 return result;
             }

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -228,5 +228,14 @@ namespace Temporalio.Workflows
         /// <param name="options">Options.</param>
         /// <returns>Task for completion.</returns>
         Task<bool> WaitConditionWithOptionsAsync(WaitConditionOptions options);
+
+        /// <summary>
+        /// Backing call for
+        /// <see cref="Workflow.Unsafe.WithTracingEventListenerDisabled{T}(Func{T})"/>.
+        /// </summary>
+        /// <typeparam name="T">Return type.</typeparam>
+        /// <param name="fn">Function.</param>
+        /// <returns>Result.</returns>
+        T WithTracingEventListenerDisabled<T>(Func<T> fn);
     }
 }

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -1353,6 +1353,14 @@ namespace Temporalio.Workflows
             /// before this call, so while nested disablement may work as expected, concurrent
             /// disablement may not.
             /// </remarks>
+            /// <remarks>
+            /// Due to .NET unpredictability for which task scheduler is chosen and the workflow
+            /// using a different task scheduler and no synchronization context, users should NOT
+            /// make this lambda async and should NOT have the lambda return a task that the caller
+            /// awaits. Rather, <c>.GetAwaiter().GetResult()</c> or similar should be used inside
+            /// the lambda or whatever blocking form is needed, keeping in mind deadlock detection
+            /// constraints.
+            /// </remarks>
             /// <typeparam name="T">Return type parameter.</typeparam>
             /// <param name="fn">Function to run.</param>
             /// <returns>Result of the function.</returns>
@@ -1374,6 +1382,14 @@ namespace Temporalio.Workflows
             /// function, an exception is thrown. On complete, the disablement is set to what it was
             /// before this call, so while nested disablement may work as expected, concurrent
             /// disablement may not.
+            /// </remarks>
+            /// <remarks>
+            /// Due to .NET unpredictability for which task scheduler is chosen and the workflow
+            /// using a different task scheduler and no synchronization context, users should NOT
+            /// make this lambda async and should NOT have the lambda return a task that the caller
+            /// awaits. Rather, <c>.GetAwaiter().GetResult()</c> or similar should be used inside
+            /// the lambda or whatever blocking form is needed, keeping in mind deadlock detection
+            /// constraints.
             /// </remarks>
             /// <param name="fn">Function to run.</param>
             /// <seealso cref="Worker.TemporalWorkerOptions.DisableWorkflowTracingEventListener"/>

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -1337,6 +1337,52 @@ namespace Temporalio.Workflows
             /// preventing a log or metric from being recorded on replay.
             /// </remarks>
             public static bool IsReplaying => Context.IsReplaying;
+
+            /// <summary>
+            /// Disables the event listener that catches invalid calls and thread operations in
+            /// workflows. This is the equivalent of
+            /// <see cref="Worker.TemporalWorkerOptions.DisableWorkflowTracingEventListener"/> but
+            /// for a short bit of code.
+            /// </summary>
+            /// <remarks>
+            /// Note, this disablement is set across the workflow instance. This means any other
+            /// concurrent task will also have the tracing event listener disabled while this code
+            /// is running. For this reason, the function passed should not yield/block on the
+            /// workflow's task scheduler and if any workflow commands are created within the passed
+            /// function, an exception is thrown. On complete, the disablement is set to what it was
+            /// before this call, so while nested disablement may work as expected, concurrent
+            /// disablement may not.
+            /// </remarks>
+            /// <typeparam name="T">Return type parameter.</typeparam>
+            /// <param name="fn">Function to run.</param>
+            /// <returns>Result of the function.</returns>
+            /// <seealso cref="Worker.TemporalWorkerOptions.DisableWorkflowTracingEventListener"/>
+            public static T WithTracingEventListenerDisabled<T>(Func<T> fn) =>
+                Context.WithTracingEventListenerDisabled(fn);
+
+            /// <summary>
+            /// Disables the event listener that catches invalid calls and thread operations in
+            /// workflows. This is the equivalent of
+            /// <see cref="Worker.TemporalWorkerOptions.DisableWorkflowTracingEventListener"/> but
+            /// for a short bit of code.
+            /// </summary>
+            /// <remarks>
+            /// Note, this disablement is set across the workflow instance. This means any other
+            /// concurrent task will also have the tracing event listener disabled while this code
+            /// is running. For this reason, the function passed should not yield/block on the
+            /// workflow's task scheduler and if any workflow commands are created within the passed
+            /// function, an exception is thrown. On complete, the disablement is set to what it was
+            /// before this call, so while nested disablement may work as expected, concurrent
+            /// disablement may not.
+            /// </remarks>
+            /// <param name="fn">Function to run.</param>
+            /// <seealso cref="Worker.TemporalWorkerOptions.DisableWorkflowTracingEventListener"/>
+            public static void WithTracingEventListenerDisabled(Action fn) =>
+                WithTracingEventListenerDisabled<ValueTuple>(() =>
+                {
+                    fn();
+                    return default;
+                });
         }
     }
 }

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -225,6 +225,12 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 case Scenario.TaskWhenAnyWithResultThreeParam:
                     return await await Task.WhenAny(
                         Task.FromResult("done"), Task.FromResult("done"), Task.FromResult("done"));
+                case Scenario.ListenerDisabledCreateCommand:
+                    return await Workflow.Unsafe.WithTracingEventListenerDisabled(async () =>
+                    {
+                        await Workflow.DelayAsync(100);
+                        return await Task.Run(async () => "done");
+                    });
 
                 // Good
                 case Scenario.TaskFactoryStartNew:
@@ -254,6 +260,11 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                     var runTaskStart = new Task<string>(() => "done");
                     runTaskStart.Start();
                     return await Workflow.RunTaskAsync(() => runTaskStart);
+                case Scenario.TaskRunListenerDisabled:
+                    return await Workflow.Unsafe.WithTracingEventListenerDisabled(async () =>
+                    {
+                        return await Task.Run(async () => "done");
+                    });
             }
             throw new InvalidOperationException("Unexpected completion");
         }
@@ -270,6 +281,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             DataflowReceiveAsync,
             // https://github.com/dotnet/runtime/issues/87481
             TaskWhenAnyWithResultThreeParam,
+            ListenerDisabledCreateCommand,
 
             // Good
             TaskFactoryStartNew,
@@ -281,6 +293,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             WorkflowWhenAll,
             WorkflowRunTask,
             WorkflowRunTaskAfterTaskStart,
+            TaskRunListenerDisabled,
         }
     }
 
@@ -318,6 +331,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         await AssertScenarioFailsTask(
             StandardLibraryCallsWorkflow.Scenario.TaskWhenAnyWithResultThreeParam,
             "not scheduled on workflow scheduler");
+        await AssertScenarioFailsTask(
+            StandardLibraryCallsWorkflow.Scenario.ListenerDisabledCreateCommand,
+            "Function during tracing event listener disabling created workflow commands");
     }
 
     [Fact]
@@ -343,6 +359,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         await AssertScenarioSucceeds(StandardLibraryCallsWorkflow.Scenario.WorkflowWhenAll);
         await AssertScenarioSucceeds(StandardLibraryCallsWorkflow.Scenario.WorkflowRunTask);
         await AssertScenarioSucceeds(StandardLibraryCallsWorkflow.Scenario.WorkflowRunTaskAfterTaskStart);
+        await AssertScenarioSucceeds(StandardLibraryCallsWorkflow.Scenario.TaskRunListenerDisabled);
     }
 
     [Workflow]

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -261,9 +261,10 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                     runTaskStart.Start();
                     return await Workflow.RunTaskAsync(() => runTaskStart);
                 case Scenario.TaskRunListenerDisabled:
-                    return await Workflow.Unsafe.WithTracingEventListenerDisabled(async () =>
+                    return Workflow.Unsafe.WithTracingEventListenerDisabled(() =>
                     {
-                        return await Task.Run(async () => "done");
+                        var task = Task.Run(async () => "done");
+                        return task.GetAwaiter().GetResult();
                     });
             }
             throw new InvalidOperationException("Unexpected completion");


### PR DESCRIPTION
## What was changed

Add `Workflow.Unsafe.WithTracingEventListenerDisabled` to allow people to disable the event listener for short bits of code

## Checklist

1. Closes #436