### PR TITLE
Serialization context for converters and codecs

### DIFF
--- a/src/Temporalio/Client/Interceptors/CompleteAsyncActivityInput.cs
+++ b/src/Temporalio/Client/Interceptors/CompleteAsyncActivityInput.cs
@@ -1,3 +1,5 @@
+using Temporalio.Converters;
+
 namespace Temporalio.Client.Interceptors
 {
     /// <summary>
@@ -6,6 +8,7 @@ namespace Temporalio.Client.Interceptors
     /// <param name="Activity">Activity to complete.</param>
     /// <param name="Result">Result.</param>
     /// <param name="Options">Options passed in to complete.</param>
+    /// <param name="DataConverterOverride">Data converter to use instead of client one.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
@@ -13,5 +16,6 @@ namespace Temporalio.Client.Interceptors
     public record CompleteAsyncActivityInput(
         AsyncActivityHandle.Reference Activity,
         object? Result,
-        AsyncActivityCompleteOptions? Options);
+        AsyncActivityCompleteOptions? Options,
+        DataConverter? DataConverterOverride = null);
 }

--- a/src/Temporalio/Client/Interceptors/FailAsyncActivityInput.cs
+++ b/src/Temporalio/Client/Interceptors/FailAsyncActivityInput.cs
@@ -1,4 +1,5 @@
 using System;
+using Temporalio.Converters;
 
 namespace Temporalio.Client.Interceptors
 {
@@ -8,6 +9,7 @@ namespace Temporalio.Client.Interceptors
     /// <param name="Activity">Activity to fail.</param>
     /// <param name="Exception">Exception.</param>
     /// <param name="Options">Options passed in to fail.</param>
+    /// <param name="DataConverterOverride">Data converter to use instead of client one.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
@@ -15,5 +17,6 @@ namespace Temporalio.Client.Interceptors
     public record FailAsyncActivityInput(
         AsyncActivityHandle.Reference Activity,
         Exception Exception,
-        AsyncActivityFailOptions? Options);
+        AsyncActivityFailOptions? Options,
+        DataConverter? DataConverterOverride = null);
 }

--- a/src/Temporalio/Client/Interceptors/HeartbeatAsyncActivityInput.cs
+++ b/src/Temporalio/Client/Interceptors/HeartbeatAsyncActivityInput.cs
@@ -1,3 +1,5 @@
+using Temporalio.Converters;
+
 namespace Temporalio.Client.Interceptors
 {
     /// <summary>
@@ -5,11 +7,13 @@ namespace Temporalio.Client.Interceptors
     /// </summary>
     /// <param name="Activity">Activity to heartbeat.</param>
     /// <param name="Options">Options passed in to heartbeat.</param>
+    /// <param name="DataConverterOverride">Data converter to use instead of client one.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record HeartbeatAsyncActivityInput(
         AsyncActivityHandle.Reference Activity,
-        AsyncActivityHeartbeatOptions? Options);
+        AsyncActivityHeartbeatOptions? Options,
+        DataConverter? DataConverterOverride = null);
 }

--- a/src/Temporalio/Client/Interceptors/ReportCancellationAsyncActivityInput.cs
+++ b/src/Temporalio/Client/Interceptors/ReportCancellationAsyncActivityInput.cs
@@ -1,3 +1,5 @@
+using Temporalio.Converters;
+
 namespace Temporalio.Client.Interceptors
 {
     /// <summary>
@@ -5,11 +7,13 @@ namespace Temporalio.Client.Interceptors
     /// </summary>
     /// <param name="Activity">Activity to report cancellation.</param>
     /// <param name="Options">Options passed in to report cancellation.</param>
+    /// <param name="DataConverterOverride">Data converter to use instead of client one.</param>
     /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
     public record ReportCancellationAsyncActivityInput(
         AsyncActivityHandle.Reference Activity,
-        AsyncActivityReportCancellationOptions? Options);
+        AsyncActivityReportCancellationOptions? Options,
+        DataConverter? DataConverterOverride = null);
 }

--- a/src/Temporalio/Client/Schedules/Schedule.cs
+++ b/src/Temporalio/Client/Schedules/Schedule.cs
@@ -28,12 +28,13 @@ namespace Temporalio.Client.Schedules
         /// Convert from proto.
         /// </summary>
         /// <param name="proto">Proto.</param>
+        /// <param name="clientNamespace">Client namespace.</param>
         /// <param name="dataConverter">Data converter.</param>
         /// <returns>Converted value.</returns>
         internal static async Task<Schedule> FromProtoAsync(
-            Api.Schedule.V1.Schedule proto, DataConverter dataConverter) =>
+            Api.Schedule.V1.Schedule proto, string clientNamespace, DataConverter dataConverter) =>
             new(
-                Action: await ScheduleAction.FromProtoAsync(proto.Action, dataConverter).ConfigureAwait(false),
+                Action: await ScheduleAction.FromProtoAsync(proto.Action, clientNamespace, dataConverter).ConfigureAwait(false),
                 Spec: ScheduleSpec.FromProto(proto.Spec))
             {
                 Policy = SchedulePolicy.FromProto(proto.Policies),
@@ -43,12 +44,14 @@ namespace Temporalio.Client.Schedules
         /// <summary>
         /// Convert to proto.
         /// </summary>
+        /// <param name="clientNamespace">Client namespace.</param>
         /// <param name="dataConverter">Data converter.</param>
         /// <returns>Proto.</returns>
-        internal async Task<Api.Schedule.V1.Schedule> ToProtoAsync(DataConverter dataConverter) => new()
+        internal async Task<Api.Schedule.V1.Schedule> ToProtoAsync(
+            string clientNamespace, DataConverter dataConverter) => new()
         {
             Spec = Spec.ToProto(),
-            Action = await Action.ToProtoAsync(dataConverter).ConfigureAwait(false),
+            Action = await Action.ToProtoAsync(clientNamespace, dataConverter).ConfigureAwait(false),
             Policies = Policy.ToProto(),
             State = State.ToProto(),
         };

--- a/src/Temporalio/Client/Schedules/Schedule.cs
+++ b/src/Temporalio/Client/Schedules/Schedule.cs
@@ -49,11 +49,11 @@ namespace Temporalio.Client.Schedules
         /// <returns>Proto.</returns>
         internal async Task<Api.Schedule.V1.Schedule> ToProtoAsync(
             string clientNamespace, DataConverter dataConverter) => new()
-        {
-            Spec = Spec.ToProto(),
-            Action = await Action.ToProtoAsync(clientNamespace, dataConverter).ConfigureAwait(false),
-            Policies = Policy.ToProto(),
-            State = State.ToProto(),
-        };
+            {
+                Spec = Spec.ToProto(),
+                Action = await Action.ToProtoAsync(clientNamespace, dataConverter).ConfigureAwait(false),
+                Policies = Policy.ToProto(),
+                State = State.ToProto(),
+            };
     }
 }

--- a/src/Temporalio/Client/Schedules/ScheduleAction.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleAction.cs
@@ -14,15 +14,16 @@ namespace Temporalio.Client.Schedules
         /// Convert from proto.
         /// </summary>
         /// <param name="proto">Proto.</param>
+        /// <param name="clientNamespace">Client namespace.</param>
         /// <param name="dataConverter">Data converter.</param>
         /// <returns>Converted value.</returns>
         internal static async Task<ScheduleAction> FromProtoAsync(
-            Api.Schedule.V1.ScheduleAction proto, DataConverter dataConverter)
+            Api.Schedule.V1.ScheduleAction proto, string clientNamespace, DataConverter dataConverter)
         {
             if (proto.StartWorkflow != null)
             {
                 return await ScheduleActionStartWorkflow.FromProtoAsync(
-                    proto.StartWorkflow, dataConverter).ConfigureAwait(false);
+                    proto.StartWorkflow, clientNamespace, dataConverter).ConfigureAwait(false);
             }
             else
             {
@@ -33,8 +34,10 @@ namespace Temporalio.Client.Schedules
         /// <summary>
         /// Convert to proto.
         /// </summary>
+        /// <param name="clientNamespace">Client namespace.</param>
         /// <param name="dataConverter">Data converter.</param>
         /// <returns>Proto.</returns>
-        internal abstract Task<Api.Schedule.V1.ScheduleAction> ToProtoAsync(DataConverter dataConverter);
+        internal abstract Task<Api.Schedule.V1.ScheduleAction> ToProtoAsync(
+            string clientNamespace, DataConverter dataConverter);
     }
 }

--- a/src/Temporalio/Client/Schedules/ScheduleDescription.cs
+++ b/src/Temporalio/Client/Schedules/ScheduleDescription.cs
@@ -78,13 +78,17 @@ namespace Temporalio.Client.Schedules
         /// </summary>
         /// <param name="id">ID.</param>
         /// <param name="rawDescription">Proto.</param>
+        /// <param name="clientNamespace">Client namespace.</param>
         /// <param name="dataConverter">Converter.</param>
         /// <returns>Converted value.</returns>
         internal static async Task<ScheduleDescription> FromProtoAsync(
-            string id, DescribeScheduleResponse rawDescription, DataConverter dataConverter) =>
+            string id,
+            DescribeScheduleResponse rawDescription,
+            string clientNamespace,
+            DataConverter dataConverter) =>
             new(
                 id,
-                await Schedule.FromProtoAsync(rawDescription.Schedule, dataConverter).ConfigureAwait(false),
+                await Schedule.FromProtoAsync(rawDescription.Schedule, clientNamespace, dataConverter).ConfigureAwait(false),
                 rawDescription,
                 dataConverter);
     }

--- a/src/Temporalio/Client/TemporalClient.AsyncActivity.cs
+++ b/src/Temporalio/Client/TemporalClient.AsyncActivity.cs
@@ -25,6 +25,7 @@ namespace Temporalio.Client
             /// <inheritdoc />
             public override async Task HeartbeatAsyncActivityAsync(HeartbeatAsyncActivityInput input)
             {
+                var converter = input.DataConverterOverride ?? Client.Options.DataConverter;
                 Payloads? details = null;
                 if (input.Options?.Details != null && input.Options.Details.Count > 0)
                 {
@@ -32,8 +33,7 @@ namespace Temporalio.Client
                     {
                         Payloads_ =
                         {
-                            await Client.Options.DataConverter.ToPayloadsAsync(
-                                input.Options.Details).ConfigureAwait(false),
+                            await converter.ToPayloadsAsync(input.Options.Details).ConfigureAwait(false),
                         },
                     };
                 }
@@ -80,8 +80,8 @@ namespace Temporalio.Client
             /// <inheritdoc />
             public override async Task CompleteAsyncActivityAsync(CompleteAsyncActivityInput input)
             {
-                var result = await Client.Options.DataConverter.ToPayloadAsync(
-                    input.Result).ConfigureAwait(false);
+                var converter = input.DataConverterOverride ?? Client.Options.DataConverter;
+                var result = await converter.ToPayloadAsync(input.Result).ConfigureAwait(false);
                 if (input.Activity is AsyncActivityHandle.IdReference idRef)
                 {
                     await Client.Connection.WorkflowService.RespondActivityTaskCompletedByIdAsync(
@@ -117,8 +117,8 @@ namespace Temporalio.Client
             /// <inheritdoc />
             public override async Task FailAsyncActivityAsync(FailAsyncActivityInput input)
             {
-                var failure = await Client.Options.DataConverter.ToFailureAsync(
-                    input.Exception).ConfigureAwait(false);
+                var converter = input.DataConverterOverride ?? Client.Options.DataConverter;
+                var failure = await converter.ToFailureAsync(input.Exception).ConfigureAwait(false);
                 Payloads? lastHeartbeatDetails = null;
                 if (input.Options?.LastHeartbeatDetails != null &&
                     input.Options.LastHeartbeatDetails.Count > 0)
@@ -127,7 +127,7 @@ namespace Temporalio.Client
                     {
                         Payloads_ =
                         {
-                            await Client.Options.DataConverter.ToPayloadsAsync(
+                            await converter.ToPayloadsAsync(
                                 input.Options.LastHeartbeatDetails).ConfigureAwait(false),
                         },
                     };
@@ -170,6 +170,7 @@ namespace Temporalio.Client
             public override async Task ReportCancellationAsyncActivityAsync(
                 ReportCancellationAsyncActivityInput input)
             {
+                var converter = input.DataConverterOverride ?? Client.Options.DataConverter;
                 Payloads? details = null;
                 if (input.Options?.Details != null && input.Options.Details.Count > 0)
                 {
@@ -177,8 +178,7 @@ namespace Temporalio.Client
                     {
                         Payloads_ =
                         {
-                            await Client.Options.DataConverter.ToPayloadsAsync(
-                                input.Options.Details).ConfigureAwait(false),
+                            await converter.ToPayloadsAsync(input.Options.Details).ConfigureAwait(false),
                         },
                     };
                 }

--- a/src/Temporalio/Client/TemporalClient.Schedules.cs
+++ b/src/Temporalio/Client/TemporalClient.Schedules.cs
@@ -45,7 +45,8 @@ namespace Temporalio.Client
                 {
                     Namespace = Client.Options.Namespace,
                     ScheduleId = input.Id,
-                    Schedule = await input.Schedule.ToProtoAsync(Client.Options.DataConverter).ConfigureAwait(false),
+                    Schedule = await input.Schedule.ToProtoAsync(
+                        Client.Options.Namespace, Client.Options.DataConverter).ConfigureAwait(false),
                     Identity = Client.Connection.Options.Identity,
                     RequestId = Guid.NewGuid().ToString(),
                 };
@@ -137,7 +138,7 @@ namespace Temporalio.Client
                     },
                     DefaultRetryOptions(input.RpcOptions)).ConfigureAwait(false);
                 return await ScheduleDescription.FromProtoAsync(
-                    input.Id, desc, Client.Options.DataConverter).ConfigureAwait(false);
+                    input.Id, desc, Client.Options.Namespace, Client.Options.DataConverter).ConfigureAwait(false);
             }
 
             /// <inheritdoc />
@@ -201,7 +202,8 @@ namespace Temporalio.Client
                     {
                         Namespace = Client.Options.Namespace,
                         ScheduleId = input.Id,
-                        Schedule = await update.Schedule.ToProtoAsync(Client.Options.DataConverter).ConfigureAwait(false),
+                        Schedule = await update.Schedule.ToProtoAsync(
+                            Client.Options.Namespace, Client.Options.DataConverter).ConfigureAwait(false),
                         Identity = Client.Connection.Options.Identity,
                         RequestId = Guid.NewGuid().ToString(),
                         SearchAttributes = update.TypedSearchAttributes?.ToProto(),

--- a/src/Temporalio/Client/WorkflowExecution.cs
+++ b/src/Temporalio/Client/WorkflowExecution.cs
@@ -22,16 +22,34 @@ namespace Temporalio.Client
         /// </summary>
         /// <param name="rawInfo">Raw proto info.</param>
         /// <param name="dataConverter">Data converter used for memos.</param>
-        internal WorkflowExecution(WorkflowExecutionInfo rawInfo, DataConverter dataConverter)
+        /// <param name="clientNamespaceForDataConverterWithContext">Namespace to make the data
+        /// converter specific to the workflow context. If null, assumes the data converter is
+        /// already context specific.</param>
+        internal WorkflowExecution(
+            WorkflowExecutionInfo rawInfo,
+            DataConverter dataConverter,
+            string? clientNamespaceForDataConverterWithContext)
         {
             RawInfo = rawInfo;
             // Search attribute conversion is cheap so it doesn't need to lock on publication. But
             // memo conversion may use remote codec so it should only ever be created once lazily.
-            memo = new(
-                () => rawInfo.Memo == null ? new Dictionary<string, IEncodedRawValue>(0) :
-                    rawInfo.Memo.Fields.ToDictionary(
+            memo = new(() =>
+            {
+                if (rawInfo.Memo == null)
+                {
+                    return new Dictionary<string, IEncodedRawValue>(0);
+                }
+                var specificDataConverter = dataConverter;
+                if (clientNamespaceForDataConverterWithContext is { } ns)
+                {
+                    specificDataConverter = dataConverter.WithSerializationContext(
+                        new ISerializationContext.Workflow(
+                            Namespace: ns, WorkflowId: rawInfo.Execution.WorkflowId));
+                }
+                return rawInfo.Memo.Fields.ToDictionary(
                         kvp => kvp.Key,
-                        kvp => (IEncodedRawValue)new EncodedRawValue(dataConverter, kvp.Value)));
+                        kvp => (IEncodedRawValue)new EncodedRawValue(specificDataConverter, kvp.Value));
+            });
             searchAttributes = new(
                 () => rawInfo.SearchAttributes == null ?
                     SearchAttributeCollection.Empty :

--- a/src/Temporalio/Client/WorkflowExecutionDescription.cs
+++ b/src/Temporalio/Client/WorkflowExecutionDescription.cs
@@ -14,7 +14,7 @@ namespace Temporalio.Client
             string? staticSummary,
             string? staticDetails,
             DataConverter dataConverter)
-            : base(rawDescription.WorkflowExecutionInfo, dataConverter)
+            : base(rawDescription.WorkflowExecutionInfo, dataConverter, null)
         {
             RawDescription = rawDescription;
             StaticSummary = staticSummary;

--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -80,6 +80,12 @@ namespace Temporalio.Client
         public virtual async Task<TResult> GetResultAsync<TResult>(
             bool followRuns = true, RpcOptions? rpcOptions = null)
         {
+            // Workflow-specific data converter
+            var dataConverter = Client.Options.DataConverter.WithSerializationContext(
+                new ISerializationContext.Workflow(
+                    Namespace: Client.Options.Namespace,
+                    WorkflowId: Id));
+
             // Continually get pages
             var histRunId = ResultRunId;
             while (true)
@@ -119,7 +125,7 @@ namespace Temporalio.Client
                             {
                                 throw new InvalidOperationException("No result present");
                             }
-                            return await Client.Options.DataConverter.ToSingleValueAsync<TResult>(
+                            return await dataConverter.ToSingleValueAsync<TResult>(
                                 compAttr.Result.Payloads_).ConfigureAwait(false);
                         case HistoryEvent.AttributesOneofCase.WorkflowExecutionFailedEventAttributes:
                             var failAttr = evt.WorkflowExecutionFailedEventAttributes;
@@ -129,8 +135,7 @@ namespace Temporalio.Client
                                 break;
                             }
                             throw new WorkflowFailedException(
-                                await Client.Options.DataConverter.ToExceptionAsync(
-                                    failAttr.Failure).ConfigureAwait(false));
+                                await dataConverter.ToExceptionAsync(failAttr.Failure).ConfigureAwait(false));
                         case HistoryEvent.AttributesOneofCase.WorkflowExecutionCanceledEventAttributes:
                             var cancelAttr = evt.WorkflowExecutionCanceledEventAttributes;
                             throw new WorkflowFailedException(new CanceledFailureException(
@@ -140,7 +145,7 @@ namespace Temporalio.Client
                                     CanceledFailureInfo = new() { Details = cancelAttr.Details },
                                 },
                                 null,
-                                Client.Options.DataConverter.PayloadConverter));
+                                dataConverter.PayloadConverter));
                         case HistoryEvent.AttributesOneofCase.WorkflowExecutionTerminatedEventAttributes:
                             var termAttr = evt.WorkflowExecutionTerminatedEventAttributes;
                             var message = string.IsNullOrEmpty(termAttr.Reason) ?
@@ -148,9 +153,7 @@ namespace Temporalio.Client
                             InboundFailureDetails? details = null;
                             if (termAttr.Details != null && termAttr.Details.Payloads_.Count > 0)
                             {
-                                details = new(
-                                    Client.Options.DataConverter.PayloadConverter,
-                                    termAttr.Details.Payloads_);
+                                details = new(dataConverter.PayloadConverter, termAttr.Details.Payloads_);
                             }
                             throw new WorkflowFailedException(new TerminatedFailureException(
                                 new() { Message = message, TerminatedFailureInfo = new() },
@@ -173,7 +176,7 @@ namespace Temporalio.Client
                                     },
                                 },
                                 null,
-                                Client.Options.DataConverter.PayloadConverter));
+                                dataConverter.PayloadConverter));
                         case HistoryEvent.AttributesOneofCase.WorkflowExecutionContinuedAsNewEventAttributes:
                             var contAttr = evt.WorkflowExecutionContinuedAsNewEventAttributes;
                             if (string.IsNullOrEmpty(contAttr.NewExecutionRunId))

--- a/src/Temporalio/Client/WorkflowUpdateHandle.cs
+++ b/src/Temporalio/Client/WorkflowUpdateHandle.cs
@@ -44,11 +44,16 @@ namespace Temporalio.Client
         {
             await PollUntilOutcomeAsync(rpcOptions).ConfigureAwait(false);
 
+            // Workflow-specific data converter
+            var dataConverter = Client.Options.DataConverter.WithSerializationContext(
+                new ISerializationContext.Workflow(
+                    Namespace: Client.Options.Namespace,
+                    WorkflowId: WorkflowId));
             // Convert outcome to result
             if (KnownOutcome!.Failure is { } failure)
             {
                 throw new WorkflowUpdateFailedException(
-                    await Client.Options.DataConverter.ToExceptionAsync(failure).ConfigureAwait(false));
+                    await dataConverter.ToExceptionAsync(failure).ConfigureAwait(false));
             }
             else if (KnownOutcome.Success is { } success)
             {
@@ -57,7 +62,7 @@ namespace Temporalio.Client
                 {
                     return default!;
                 }
-                return await Client.Options.DataConverter.ToSingleValueAsync<TResult>(
+                return await dataConverter.ToSingleValueAsync<TResult>(
                     success.Payloads_).ConfigureAwait(false);
             }
             throw new InvalidOperationException($"Unrecognized outcome case: {KnownOutcome.ValueCase}");

--- a/src/Temporalio/Converters/DataConverter.cs
+++ b/src/Temporalio/Converters/DataConverter.cs
@@ -10,11 +10,37 @@ namespace Temporalio.Converters
         IPayloadConverter PayloadConverter,
         IFailureConverter FailureConverter,
         IPayloadCodec? PayloadCodec = null)
+    : IWithSerializationContext<DataConverter>
     {
         /// <summary>
         /// Gets default data converter instance.
         /// </summary>
         public static DataConverter Default { get; } =
             new(new DefaultPayloadConverter(), new DefaultFailureConverter());
+
+        /// <inheritdoc/>
+        public virtual DataConverter WithSerializationContext(ISerializationContext context)
+        {
+            var payloadConverter = PayloadConverter is IWithSerializationContext<IPayloadConverter> p ?
+                p.WithSerializationContext(context) : PayloadConverter;
+            var failureConverter = FailureConverter is IWithSerializationContext<IFailureConverter> f ?
+                f.WithSerializationContext(context) : FailureConverter;
+            var payloadCodec = PayloadCodec is IWithSerializationContext<IPayloadCodec> pc ?
+                pc.WithSerializationContext(context) : PayloadCodec;
+
+            // Only create if the objects weren't the same as before. There is no benefit to using
+            // whether the interface is implemented as the check since the default payload converter
+            // implements the interface but returns "this" in most cases. The benefit of preventing
+            // the instantiation is probably negligible, but harmless and actually helps in
+            // AsyncActivityHandle.
+            if (ReferenceEquals(payloadConverter, PayloadConverter) &&
+                ReferenceEquals(failureConverter, FailureConverter) &&
+                ReferenceEquals(payloadCodec, PayloadCodec))
+            {
+                return this;
+            }
+
+            return new(payloadConverter, failureConverter, payloadCodec);
+        }
     }
 }

--- a/src/Temporalio/Converters/IEncodingConverter.cs
+++ b/src/Temporalio/Converters/IEncodingConverter.cs
@@ -6,6 +6,11 @@ namespace Temporalio.Converters
     /// <summary>
     /// Representation of a payload converter for a specific encoding.
     /// </summary>
+    /// <remarks>
+    /// Implementations of this interface can also implement
+    /// <see cref="IWithSerializationContext{TResult}"/> for <c>IEncodingConverter</c> to customize
+    /// the converter based on context.
+    /// </remarks>
     public interface IEncodingConverter
     {
         /// <summary>

--- a/src/Temporalio/Converters/IFailureConverter.cs
+++ b/src/Temporalio/Converters/IFailureConverter.cs
@@ -12,6 +12,11 @@ namespace Temporalio.Converters
     /// this converter should be immediate and avoid any network calls or any asynchronous/slow code
     /// paths.
     /// </remarks>
+    /// <remarks>
+    /// Implementations of this interface can also implement
+    /// <see cref="IWithSerializationContext{TResult}"/> for <c>IFailureConverter</c> to customize
+    /// the converter based on context.
+    /// </remarks>
     /// <seealso cref="DefaultFailureConverter" />
     public interface IFailureConverter
     {

--- a/src/Temporalio/Converters/IPayloadCodec.cs
+++ b/src/Temporalio/Converters/IPayloadCodec.cs
@@ -10,6 +10,11 @@ namespace Temporalio.Converters
     /// <remarks>
     /// This is often useful for encryption and/or compression.
     /// </remarks>
+    /// <remarks>
+    /// Implementations of this interface can also implement
+    /// <see cref="IWithSerializationContext{TResult}"/> for <c>IPayloadCodec</c> to customize the
+    /// converter based on context.
+    /// </remarks>
     public interface IPayloadCodec
     {
         /// <summary>

--- a/src/Temporalio/Converters/IPayloadConverter.cs
+++ b/src/Temporalio/Converters/IPayloadConverter.cs
@@ -11,6 +11,11 @@ namespace Temporalio.Converters
     /// this converter should be immediate and avoid any network calls or any asynchronous/slow code
     /// paths.
     /// </remarks>
+    /// <remarks>
+    /// Implementations of this interface can also implement
+    /// <see cref="IWithSerializationContext{TResult}"/> for <c>IPayloadConverter</c> to customize
+    /// the converter based on context.
+    /// </remarks>
     /// <seealso cref="DefaultPayloadConverter" />
     public interface IPayloadConverter
     {

--- a/src/Temporalio/Converters/ISerializationContext.cs
+++ b/src/Temporalio/Converters/ISerializationContext.cs
@@ -1,0 +1,84 @@
+#pragma warning disable CA1724 // We don't care that Workflow/Activity clash with API namespace
+
+namespace Temporalio.Converters
+{
+    /// <summary>
+    /// Base interface for all serialization contexts that can be passed in to
+    /// <see cref="IWithSerializationContext{TResult}.WithSerializationContext(ISerializationContext)"/>.
+    /// The two implementations used by the SDK are <see cref="Activity"/> and <see cref="Workflow"/>.
+    /// </summary>
+    public interface ISerializationContext
+    {
+        /// <summary>
+        /// Base interface for serialization contexts that have workflow information.
+        /// </summary>
+        public interface IHasWorkflow : ISerializationContext
+        {
+            /// <summary>
+            /// Gets the namespace for the workflow.
+            /// </summary>
+#pragma warning disable CA1716 // We're ok with Namespace identifier here
+            string Namespace { get; }
+#pragma warning restore CA1716
+
+            /// <summary>
+            /// Gets the ID for the workflow.
+            /// </summary>
+            string WorkflowId { get; }
+        }
+
+        /// <summary>
+        /// Serialization context for activities. See
+        /// <see cref="IWithSerializationContext{TResult}.WithSerializationContext(ISerializationContext)"/>
+        /// for information on when this is made available to converters and codecs.
+        /// </summary>
+        /// <remarks>
+        /// WARNING: This constructor may have required properties added and is not guaranteed to
+        /// remain compatible from one version to the next.
+        /// </remarks>
+        /// <param name="Namespace">Workflow/activity namespace.</param>
+        /// <param name="WorkflowId">Workflow ID.</param>
+        /// <param name="WorkflowType">Workflow Type.</param>
+        /// <param name="ActivityType">Activity Type.</param>
+        /// <param name="ActivityTaskQueue">ActivityTaskQueue.</param>
+        /// <param name="IsLocal">Whether the activity is a local activity.</param>
+        public sealed record Activity(
+            string Namespace,
+            string WorkflowId,
+            string WorkflowType,
+            string ActivityType,
+            string ActivityTaskQueue,
+            bool IsLocal) : IHasWorkflow
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Activity"/> class using info.
+            /// </summary>
+            /// <param name="info">Info available within an activity.</param>
+            public Activity(Activities.ActivityInfo info)
+                : this(
+                    Namespace: info.WorkflowNamespace,
+                    WorkflowId: info.WorkflowId,
+                    WorkflowType: info.WorkflowType,
+                    ActivityType: info.ActivityType,
+                    ActivityTaskQueue: info.TaskQueue,
+                    IsLocal: info.IsLocal)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Serialization context for workflows. See
+        /// <see cref="IWithSerializationContext{TResult}.WithSerializationContext(ISerializationContext)"/>
+        /// for information on when this is made available to converters and codecs.
+        /// </summary>
+        /// <remarks>
+        /// WARNING: This constructor may have required properties added and is not guaranteed to
+        /// remain compatible from one version to the next.
+        /// </remarks>
+        /// <param name="Namespace">Workflow namespace.</param>
+        /// <param name="WorkflowId">Workflow ID.</param>
+        public sealed record Workflow(
+            string Namespace,
+            string WorkflowId) : IHasWorkflow;
+    }
+}

--- a/src/Temporalio/Converters/IWithSerializationContext.cs
+++ b/src/Temporalio/Converters/IWithSerializationContext.cs
@@ -1,0 +1,54 @@
+namespace Temporalio.Converters
+{
+    /// <summary>
+    /// Interface implemented by converters and codecs that want to be able to create
+    /// context-specific implementations of themselves for certain workflows or activities.
+    /// </summary>
+    /// <remarks>
+    /// The only supported implementations by the SDK are <see cref="DataConverter"/> implementing
+    /// <see cref="IWithSerializationContext{T}"/> of <c>DataConverter</c>,
+    /// <see cref="IPayloadConverter"/> implementing
+    /// <see cref="IWithSerializationContext{T}"/> of <c>IPayloadConverter</c>,
+    /// <see cref="IEncodingConverter"/> implementing
+    /// <see cref="IWithSerializationContext{T}"/> of <c>IEncodingConverter</c>,
+    /// <see cref="IFailureConverter"/> implementing
+    /// <see cref="IWithSerializationContext{T}"/> of <c>IFailureConverter</c>, and
+    /// <see cref="IPayloadCodec"/> implementing
+    /// <see cref="IWithSerializationContext{T}"/> of <c>IPayloadCodec</c>. See
+    /// <see cref="WithSerializationContext(ISerializationContext)"/> for details on when this is
+    /// called.
+    /// </remarks>
+    /// <typeparam name="T">The converter or codec type that will be returned.</typeparam>
+    public interface IWithSerializationContext<T>
+    {
+        /// <summary>
+        /// Create a new instance of this converter or codec with the given serialization context.
+        /// </summary>
+        /// <remarks>
+        /// This will be called with an instance of <see cref="ISerializationContext.Activity"/>
+        /// on converters and codecs when an activity is invoked from workflow, when an activity
+        /// attempt is run on an activity worker, or manually via
+        /// <see cref="Client.AsyncActivityHandle.WithSerializationContext(ISerializationContext)"/>
+        /// when using async activity completion.
+        /// </remarks>
+        /// <remarks>
+        /// This will be called with an instance of <see cref="ISerializationContext.Workflow"/>
+        /// on converters and codecs when a workflow is used from a client, a schedule is created
+        /// or described with a workflow, a child or external workflow is used from another
+        /// workflow, or when the workflow task is run in the workflow worker.
+        /// </remarks>
+        /// <remarks>
+        /// Note, this may be called many times for the same activity/workflow, sometimes in
+        /// succession when using. Do not expect a specific instance returned converter/codec to be
+        /// the one always used in those workflow/activity cases, this may be called again to
+        /// re-obtain the converter/codec. Also make sure this is very inexpensive to call as it
+        /// may be called frequently. Users can return <c>this</c> to effectively bypass
+        /// context-specific converter/codec.
+        /// </remarks>
+        /// <param name="context">Context to use to return a context-specific instance of a
+        /// converter or codec.</param>
+        /// <returns>Context-specific instance of a converter/codec to use. This may return
+        /// <c>this</c> to effectively bypass the context-specific nature.</returns>
+        T WithSerializationContext(ISerializationContext context);
+    }
+}

--- a/src/Temporalio/Converters/JsonPlainConverter.cs
+++ b/src/Temporalio/Converters/JsonPlainConverter.cs
@@ -21,7 +21,7 @@ namespace Temporalio.Converters
             SerializerOptions = serializerOptions;
 
         /// <inheritdoc />
-        public string Encoding => "json/plain";
+        public virtual string Encoding => "json/plain";
 
         /// <summary>
         /// Gets the serializer options used during conversion.
@@ -29,7 +29,7 @@ namespace Temporalio.Converters
         protected JsonSerializerOptions SerializerOptions { get; private init; }
 
         /// <inheritdoc />
-        public bool TryToPayload(object? value, out Payload? payload)
+        public virtual bool TryToPayload(object? value, out Payload? payload)
         {
             payload = new();
             payload.Metadata["encoding"] = EncodingByteString;
@@ -40,7 +40,7 @@ namespace Temporalio.Converters
         }
 
         /// <inheritdoc />
-        public object? ToValue(Payload payload, Type type) =>
+        public virtual object? ToValue(Payload payload, Type type) =>
             JsonSerializer.Deserialize(payload.Data.ToByteArray(), type, SerializerOptions);
     }
 }

--- a/src/Temporalio/Worker/IWorkflowCodecHelperInstance.cs
+++ b/src/Temporalio/Worker/IWorkflowCodecHelperInstance.cs
@@ -1,0 +1,44 @@
+using Temporalio.Converters;
+using Temporalio.Workflows;
+
+namespace Temporalio.Worker
+{
+    /// <summary>
+    /// Implemented by instances that can provide workflow codec helper contextual information.
+    /// </summary>
+    internal interface IWorkflowCodecHelperInstance
+    {
+        /// <summary>
+        /// Gets the workflow info.
+        /// </summary>
+        WorkflowInfo Info { get; }
+
+        /// <summary>
+        /// Gets the pending activity serialization context for the given sequence.
+        /// </summary>
+        /// <param name="seq">Sequence.</param>
+        /// <returns>Context.</returns>
+        ISerializationContext.Activity? GetPendingActivitySerializationContext(uint seq);
+
+        /// <summary>
+        /// Gets the pending child serialization context for the given sequence.
+        /// </summary>
+        /// <param name="seq">Sequence.</param>
+        /// <returns>Context.</returns>
+        ISerializationContext.Workflow? GetPendingChildSerializationContext(uint seq);
+
+        /// <summary>
+        /// Gets the pending external cancel serialization context for the given sequence.
+        /// </summary>
+        /// <param name="seq">Sequence.</param>
+        /// <returns>Context.</returns>
+        ISerializationContext.Workflow? GetPendingExternalCancelSerializationContext(uint seq);
+
+        /// <summary>
+        /// Gets the pending external signal serialization context for the given sequence.
+        /// </summary>
+        /// <param name="seq">Sequence.</param>
+        /// <returns>Context.</returns>
+        ISerializationContext.Workflow? GetPendingExternalSignalSerializationContext(uint seq);
+    }
+}

--- a/src/Temporalio/Worker/IWorkflowInstance.cs
+++ b/src/Temporalio/Worker/IWorkflowInstance.cs
@@ -6,7 +6,7 @@ namespace Temporalio.Worker
     /// <summary>
     /// Representation of a workflow instance that can be sent activations.
     /// </summary>
-    internal interface IWorkflowInstance
+    internal interface IWorkflowInstance : IWorkflowCodecHelperInstance
     {
         /// <summary>
         /// Send activation and get completion.

--- a/src/Temporalio/Worker/WorkflowWorker.cs
+++ b/src/Temporalio/Worker/WorkflowWorker.cs
@@ -87,7 +87,6 @@ namespace Temporalio.Worker
             }))
             {
                 var tasks = new ConcurrentDictionary<Task, bool?>();
-                var codec = options.DataConverter.PayloadCodec;
                 while (true)
                 {
                     var act = await options.BridgeWorker.PollWorkflowActivationAsync().ConfigureAwait(false);
@@ -98,7 +97,7 @@ namespace Temporalio.Worker
                     }
                     // Otherwise handle and put on task set
                     // TODO(cretz): Any reason for users to need to customize factory here?
-                    var task = Task.Run(() => HandleActivationAsync(codec, act));
+                    var task = Task.Run(() => HandleActivationAsync(act));
                     tasks[task] = null;
                     _ = task.ContinueWith(
                         task => { tasks.TryRemove(task, out _); }, TaskScheduler.Current);
@@ -115,71 +114,102 @@ namespace Temporalio.Worker
             }
         }
 
-        private async Task HandleActivationAsync(IPayloadCodec? codec, WorkflowActivation act)
+        private async Task HandleActivationAsync(WorkflowActivation act)
         {
+            // Do eviction if requested and exit early
+            if (act.Jobs.Select(job => job.RemoveFromCache).FirstOrDefault(job => job != null) is { } removeJob)
+            {
+                if (act.Jobs.Count != 1)
+                {
+                    logger.LogWarning("Unexpected job alongside remove job");
+                }
+                await HandleCacheEvictionAsync(act, removeJob).ConfigureAwait(false);
+                return;
+            }
+
             WorkflowActivationCompletion comp;
-            RemoveFromCache? removeJob = null;
+            DataConverter dataConverter = options.DataConverter;
+            WorkflowCodecHelper.WorkflowCodecContext? codecContext = null;
 
             // Catch any exception as a completion failure
             try
             {
-                // Decode the activation if there is a codec
-                if (codec != null)
+                // Create data converter with context before doing any work
+                if (runningWorkflows.TryGetValue(act.RunId, out var inst))
                 {
-                    await WorkflowCodecHelper.DecodeAsync(codec, act).ConfigureAwait(false);
+                    codecContext = new(
+                        Namespace: options.Namespace,
+                        WorkflowId: inst.Info.WorkflowId,
+                        WorkflowType: inst.Info.WorkflowType,
+                        TaskQueue: options.TaskQueue,
+                        Instance: inst);
+                }
+                else if (act.Jobs.Select(j => j.InitializeWorkflow).FirstOrDefault(s => s != null) is { } initJob)
+                {
+                    codecContext = new(
+                        Namespace: options.Namespace,
+                        WorkflowId: initJob.WorkflowId,
+                        WorkflowType: initJob.WorkflowType,
+                        TaskQueue: options.TaskQueue,
+                        Instance: null);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Missing workflow start (unexpectedly evicted?)");
+                }
+                dataConverter = dataConverter.WithSerializationContext(
+                    new ISerializationContext.Workflow(
+                        Namespace: codecContext.Namespace, WorkflowId: codecContext.WorkflowId));
+
+                // Decode the activation if there is a codec
+                if (dataConverter.PayloadCodec is { } decodeCodec)
+                {
+                    await WorkflowCodecHelper.DecodeAsync(decodeCodec, codecContext, act).ConfigureAwait(false);
                 }
 
                 // Log proto at trace level
                 logger.LogTrace("Received workflow activation: {Activation}", act);
 
-                // We only have to run if there are any non-remove jobs
-                removeJob = act.Jobs.Select(job => job.RemoveFromCache).FirstOrDefault(job => job != null);
-                if (act.Jobs.Count > 1 || removeJob == null)
+                // If the activation never completed before, we need to assume continually
+                // deadlocked and just rethrow the same exception as before
+                if (deadlockedWorkflows.ContainsKey(act.RunId))
                 {
-                    // If the activation never completed before, we need to assume continually
-                    // deadlocked and just rethrow the same exception as before
-                    if (deadlockedWorkflows.ContainsKey(act.RunId))
-                    {
-                        throw new InvalidOperationException($"[TMPRL1101] Workflow with ID {act.RunId} deadlocked after {deadlockTimeout}");
-                    }
-
-                    // If the workflow is not yet running, create it. We know that we will only get
-                    // one activation per workflow at a time, so GetOrAdd is safe for our use.
-                    var workflow = runningWorkflows.GetOrAdd(act.RunId, _ => CreateInstance(act));
-
-                    // Activate or timeout with deadlock timeout
-                    // TODO(cretz): Any reason for users to need to customize factory here?
-                    // TODO(cretz): Since deadlocks can cause unreclaimed threads, we are setting
-                    // LongRunning here. That means they may oversubscribe and create a new thread
-                    // just for this, is that ok?
-                    var workflowTask = Task.Factory.StartNew(
-                        () => workflow.Activate(act),
-                        default,
-                        TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach | TaskCreationOptions.PreferFairness,
-                        TaskScheduler.Current);
-                    using (var timeoutCancel = new CancellationTokenSource())
-                    {
-                        // We create a delay task to catch any deadlock timeouts, and if it didn't
-                        // deadlock, cancel the task
-                        // TODO(cretz): For newer .NET, use WaitAsync which is cheaper
-                        var timeoutTask = Task.Delay(deadlockTimeout, timeoutCancel.Token);
-                        if (timeoutTask == await Task.WhenAny(workflowTask, timeoutTask).ConfigureAwait(false))
-                        {
-                            // Hit deadlock timeout, add this to deadlocked set. This is only for the
-                            // next activation which will be a remove job.
-                            deadlockedWorkflows[act.RunId] = workflowTask;
-                            throw new InvalidOperationException(
-                                $"[TMPRL1101] Workflow with ID {act.RunId} deadlocked after {deadlockTimeout}");
-                        }
-                        // Cancel deadlock timeout timer since we didn't hit it
-                        timeoutCancel.Cancel();
-                    }
-                    comp = await workflowTask.ConfigureAwait(false);
+                    throw new InvalidOperationException($"[TMPRL1101] Workflow with ID {act.RunId} deadlocked after {deadlockTimeout}");
                 }
-                else
+
+                // If the workflow is not yet running, create it. We know that we will only get
+                // one activation per workflow at a time, so GetOrAdd is safe for our use.
+                var workflow = runningWorkflows.GetOrAdd(act.RunId, _ => CreateInstance(act, dataConverter));
+                codecContext = codecContext with { Instance = workflow };
+
+                // Activate or timeout with deadlock timeout
+                // TODO(cretz): Any reason for users to need to customize factory here?
+                // TODO(cretz): Since deadlocks can cause unreclaimed threads, we are setting
+                // LongRunning here. That means they may oversubscribe and create a new thread
+                // just for this, is that ok?
+                var workflowTask = Task.Factory.StartNew(
+                    () => workflow.Activate(act),
+                    default,
+                    TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach | TaskCreationOptions.PreferFairness,
+                    TaskScheduler.Current);
+                using (var timeoutCancel = new CancellationTokenSource())
                 {
-                    comp = new() { Successful = new() };
+                    // We create a delay task to catch any deadlock timeouts, and if it didn't
+                    // deadlock, cancel the task
+                    // TODO(cretz): For newer .NET, use WaitAsync which is cheaper
+                    var timeoutTask = Task.Delay(deadlockTimeout, timeoutCancel.Token);
+                    if (timeoutTask == await Task.WhenAny(workflowTask, timeoutTask).ConfigureAwait(false))
+                    {
+                        // Hit deadlock timeout, add this to deadlocked set. This is only for the
+                        // next activation which will be a remove job.
+                        deadlockedWorkflows[act.RunId] = workflowTask;
+                        throw new InvalidOperationException(
+                            $"[TMPRL1101] Workflow with ID {act.RunId} deadlocked after {deadlockTimeout}");
+                    }
+                    // Cancel deadlock timeout timer since we didn't hit it
+                    timeoutCancel.Cancel();
                 }
+                comp = await workflowTask.ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -188,8 +218,9 @@ namespace Temporalio.Worker
                 comp = new() { Failed = new() };
                 try
                 {
-                    comp.Failed.Failure_ = options.DataConverter.FailureConverter.ToFailure(
-                        e, options.DataConverter.PayloadConverter);
+                    // Failure converter needs to be in workflow context
+                    comp.Failed.Failure_ = dataConverter.FailureConverter.ToFailure(
+                        e, dataConverter.PayloadConverter);
                 }
                 catch (Exception inner)
                 {
@@ -202,43 +233,16 @@ namespace Temporalio.Worker
             comp.RunId = act.RunId;
 
             // Encode the completion if there is a codec
-            if (codec != null)
+            if (dataConverter.PayloadCodec is { } encodeCodec && codecContext is { } encodeContext)
             {
                 try
                 {
-                    await WorkflowCodecHelper.EncodeAsync(codec, comp).ConfigureAwait(false);
+                    await WorkflowCodecHelper.EncodeAsync(encodeCodec, encodeContext, comp).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
                     logger.LogError(e, "Failed encoding completion on workflow with run ID {RunId}", act.RunId);
                     comp.Failed = new() { Failure_ = new() { Message = $"Failed encoding completion: {e}" } };
-                }
-            }
-
-            // Remove from cache if requested
-            if (removeJob != null)
-            {
-                logger.LogDebug(
-                    "Evicting workflow with run ID {RunId}, message: {Message}",
-                    act.RunId,
-                    removeJob.Message);
-                runningWorkflows.TryRemove(act.RunId, out _);
-                onEviction?.Invoke(act.RunId, removeJob);
-                // If this is a deadlocked workflow task, we attach remove completion to task
-                // completion
-                if (deadlockedWorkflows.TryRemove(act.RunId, out var task))
-                {
-                    _ = task.ContinueWith(
-                        async _ =>
-                        {
-                            logger.LogDebug(
-                                "Notify core of deadlocked workflow eviction for run ID {RunId}",
-                                act.RunId);
-                            await options.BridgeWorker.CompleteWorkflowActivationAsync(comp).ConfigureAwait(false);
-                        },
-                        TaskScheduler.Current);
-                    // Do not send completion, workflow is deadlocked
-                    return;
                 }
             }
 
@@ -250,11 +254,54 @@ namespace Temporalio.Worker
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Failed completing activation on  {RunId}", act.RunId);
+                logger.LogError(e, "Failed completing activation on {RunId}", act.RunId);
             }
         }
 
-        private IWorkflowInstance CreateInstance(WorkflowActivation act)
+        private async Task HandleCacheEvictionAsync(WorkflowActivation act, RemoveFromCache job)
+        {
+            logger.LogDebug(
+                "Evicting workflow with run ID {RunId}, message: {Message}",
+                act.RunId,
+                job.Message);
+            runningWorkflows.TryRemove(act.RunId, out _);
+            onEviction?.Invoke(act.RunId, job);
+            var comp = new WorkflowActivationCompletion() { RunId = act.RunId, Successful = new() };
+            // If this is a deadlocked workflow task, we attach remove completion to task
+            // completion
+            if (deadlockedWorkflows.TryRemove(act.RunId, out var task))
+            {
+                _ = task.ContinueWith(
+                    async _ =>
+                    {
+                        logger.LogDebug(
+                            "Notify core of deadlocked workflow eviction for run ID {RunId}",
+                            act.RunId);
+                        try
+                        {
+                            await options.BridgeWorker.CompleteWorkflowActivationAsync(comp).ConfigureAwait(false);
+                        }
+                        catch (Exception e)
+                        {
+                            logger.LogError(e, "Failed completing eviction on {RunId}", act.RunId);
+                        }
+                    },
+                    TaskScheduler.Current);
+                // Do not send completion, workflow is deadlocked
+                return;
+            }
+            // Send eviction completion
+            try
+            {
+                await options.BridgeWorker.CompleteWorkflowActivationAsync(comp).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed completing eviction on {RunId}", act.RunId);
+            }
+        }
+
+        private IWorkflowInstance CreateInstance(WorkflowActivation act, DataConverter dataConverter)
         {
             var init = act.Jobs.Select(j => j.InitializeWorkflow).FirstOrDefault(s => s != null) ??
                 throw new InvalidOperationException("Missing workflow start (unexpectedly evicted?)");
@@ -277,8 +324,8 @@ namespace Temporalio.Worker
                     InitialActivation: act,
                     Init: init,
                     Interceptors: options.Interceptors,
-                    PayloadConverter: options.DataConverter.PayloadConverter,
-                    FailureConverter: options.DataConverter.FailureConverter,
+                    PayloadConverter: dataConverter.PayloadConverter,
+                    FailureConverter: dataConverter.FailureConverter,
                     LoggerFactory: options.LoggerFactory,
                     DisableTracingEvents: options.DisableWorkflowTracingEventListener,
                     WorkflowStackTrace: options.WorkflowStackTrace,

--- a/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
@@ -17,6 +17,13 @@ public class WorkflowCodecHelperTests : TestBase
     {
     }
 
+    internal static WorkflowCodecHelper.WorkflowCodecContext SimpleCodecContext { get; } = new(
+        Namespace: "my-namespace",
+        WorkflowId: "my-workflow-id",
+        WorkflowType: "my-workflow-type",
+        TaskQueue: "my-task-queue",
+        Instance: null);
+
     [Fact]
     public async Task CreateAndVisitPayload_Visiting_ReachesAllExpectedValues()
     {
@@ -51,7 +58,7 @@ public class WorkflowCodecHelperTests : TestBase
             Assert.DoesNotContain("encoded", payload().Metadata.Keys);
             foreach (var codec in codecs)
             {
-                await WorkflowCodecHelper.EncodeAsync(codec, comp);
+                await WorkflowCodecHelper.EncodeAsync(codec, SimpleCodecContext, comp);
                 if (!payload().Metadata.ContainsKey("encoded"))
                 {
                     Assert.Fail($"Payload at path {ctx.Path} not encoded with codec {codec}");
@@ -75,7 +82,7 @@ public class WorkflowCodecHelperTests : TestBase
             Assert.DoesNotContain("decoded", payload().Metadata.Keys);
             foreach (var codec in codecs)
             {
-                await WorkflowCodecHelper.DecodeAsync(codec, act);
+                await WorkflowCodecHelper.DecodeAsync(codec, SimpleCodecContext, act);
                 if (!payload().Metadata.ContainsKey("decoded"))
                 {
                     Assert.Fail($"Payload at path {ctx.Path} not decoded with codec {codec}");
@@ -99,7 +106,7 @@ public class WorkflowCodecHelperTests : TestBase
             if (propInfo?.PropertyType == typeof(Payload))
             {
                 propInfo.SetValue(msg, null);
-                await WorkflowCodecHelper.EncodeAsync(codec, comp);
+                await WorkflowCodecHelper.EncodeAsync(codec, SimpleCodecContext, comp);
             }
         });
     }

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -4,8 +4,11 @@
 namespace Temporalio.Tests.Worker;
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq.Expressions;
+using System.Text;
 using System.Threading.Tasks.Dataflow;
+using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Temporalio.Activities;
 using Temporalio.Api.Common.V1;
@@ -6606,6 +6609,424 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             "some-id", TestUtils.ReadAllFileText("Histories/multi-wait-condition.pre-dotnet-flag.json")));
         // Has wrong order
         Assert.Equal(new List<string> { "one", "two", "four", "three" }, MultiWaitConditionPreSdkFlagWorkflow.Stages);
+    }
+
+    public record ContextValue(string Name, List<ContextValue.ContextEvent> Events)
+    {
+        public record ContextEvent(bool Outbound, ContextInfo Info);
+
+        public override string ToString() => $"{{ Name = {Name}, Events = [{string.Join(", ", Events)}] }}";
+
+        public virtual bool Equals(ContextValue? other) =>
+            other != null &&
+            Name == other.Name &&
+            Events.SequenceEqual(other.Events);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(Name, Events.Aggregate(0, HashCode.Combine));
+
+        public void AssertWorkflowEqual(
+            string expectedName,
+            string workflowId,
+            bool activity = false,
+            bool? activityInboundOverride = null) =>
+            Assert.Equal(
+                new ContextValue(
+                    Name: expectedName,
+                    Events: new List<ContextEvent>
+                    {
+                        new(true, new(Activity: activity, Workflow: !activity, WorkflowId: workflowId)),
+                        new(false, new(
+                            Activity: activityInboundOverride ?? activity,
+                            Workflow: !(activityInboundOverride ?? activity),
+                            WorkflowId: workflowId)),
+                    }),
+                this);
+    }
+
+    public record ContextInfo(
+        bool Activity = false,
+        bool Workflow = false,
+        string WorkflowId = "<unknown>")
+    {
+        public static ContextInfo Create(ISerializationContext context) =>
+            new(
+                Activity: context is ISerializationContext.Activity,
+                Workflow: context is ISerializationContext.Workflow,
+                WorkflowId: ((ISerializationContext.IHasWorkflow)context).WorkflowId);
+    }
+
+    public class ContextJsonPlainConverter : JsonPlainConverter, IWithSerializationContext<IEncodingConverter>
+    {
+        private readonly ContextInfo contextInfo;
+
+        public ContextJsonPlainConverter(ContextInfo contextInfo)
+            : base(new()) => this.contextInfo = contextInfo;
+
+        public IEncodingConverter WithSerializationContext(ISerializationContext context) =>
+            new ContextJsonPlainConverter(ContextInfo.Create(context));
+
+        public override bool TryToPayload(object? value, out Payload? payload)
+        {
+            if (value is ContextValue contextValue)
+            {
+                contextValue.Events.Add(new(true, contextInfo));
+            }
+            return base.TryToPayload(value, out payload);
+        }
+
+        public override object? ToValue(Payload payload, Type type)
+        {
+            var value = base.ToValue(payload, type);
+            if (value is ContextValue contextValue)
+            {
+                contextValue.Events.Add(new(false, contextInfo));
+            }
+            return value;
+        }
+    }
+
+    public class ContextFailureConverter : DefaultFailureConverter, IWithSerializationContext<IFailureConverter>
+    {
+        private readonly ContextInfo contextInfo;
+
+        public ContextFailureConverter(ContextInfo contextInfo) => this.contextInfo = contextInfo;
+
+        public override Failure ToFailure(Exception exception, IPayloadConverter payloadConverter)
+        {
+            var failure = base.ToFailure(exception, payloadConverter);
+            if (failure.ApplicationFailureInfo != null && !failure.Message.Contains("[activity:"))
+            {
+                var activity = contextInfo.Activity ? "true" : "false";
+                failure.Message += $" [activity: {activity}, workflow-id: {contextInfo.WorkflowId}]";
+            }
+            return failure;
+        }
+
+        public IFailureConverter WithSerializationContext(ISerializationContext context) =>
+            new ContextFailureConverter(ContextInfo.Create(context));
+    }
+
+    public class ContextPayloadCodec : IPayloadCodec, IWithSerializationContext<IPayloadCodec>
+    {
+        public const string EncodingName = "context-encoding";
+        private readonly ContextInfo contextInfo;
+
+        public ContextPayloadCodec(ContextInfo contextInfo) => this.contextInfo = contextInfo;
+
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult<IReadOnlyCollection<Payload>>(payloads.Select(p =>
+                new Payload()
+                {
+                    Data = ByteString.CopyFrom(
+                        Convert.ToBase64String(p.ToByteArray()),
+                        Encoding.ASCII),
+                    Metadata =
+                    {
+                        new Dictionary<string, ByteString>
+                        {
+                            ["encoding"] = ByteString.CopyFromUtf8(EncodingName),
+                            ["activity"] = ByteString.CopyFromUtf8(contextInfo.Activity ? "true" : "false"),
+                            ["workflow-id"] = ByteString.CopyFromUtf8(contextInfo.WorkflowId),
+                        },
+                    },
+                }).ToList());
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult<IReadOnlyCollection<Payload>>(payloads.Select(p =>
+            {
+                Assert.Equal(EncodingName, p.Metadata["encoding"].ToStringUtf8());
+                Assert.Equal(contextInfo.Activity, p.Metadata["activity"].ToStringUtf8() == "true");
+                Assert.Equal(contextInfo.WorkflowId, p.Metadata["workflow-id"].ToStringUtf8());
+                return Payload.Parser.ParseFrom(
+                    Convert.FromBase64String(p.Data.ToString(Encoding.ASCII)));
+            }).ToList());
+
+        public IPayloadCodec WithSerializationContext(ISerializationContext context) =>
+            new ContextPayloadCodec(ContextInfo.Create(context));
+    }
+
+    public record ContextHistoryExpectation(
+        string Name,
+        Func<HistoryEvent, Payload?> Predicate,
+        bool Activity = false)
+    {
+        public async Task AssertInHistoryAsync(WorkflowHistory history)
+        {
+            try
+            {
+                Payload? payload = null;
+                // Find by predicate and name match
+                foreach (var maybePayload in history.Events.Select(Predicate))
+                {
+                    if (maybePayload != null)
+                    {
+                        var decoded = Payload.Parser.ParseFrom(Convert.FromBase64String(maybePayload.Data.ToString(Encoding.ASCII)));
+                        var value = await DataConverter.Default.ToValueAsync<ContextValue>(decoded);
+                        if (Name == value.Name)
+                        {
+                            payload = maybePayload;
+                            break;
+                        }
+                    }
+                }
+                Assert.NotNull(payload);
+                Assert.Equal(ContextPayloadCodec.EncodingName, payload.Metadata["encoding"].ToStringUtf8());
+                Assert.Equal(Activity ? "true" : "false", payload.Metadata["activity"].ToStringUtf8());
+                Assert.Equal(history.Id, payload.Metadata["workflow-id"].ToStringUtf8());
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException($"Failed for {Name}", e);
+            }
+        }
+    }
+
+    [Workflow]
+    public class ConverterContextWorkflow
+    {
+        private bool complete;
+
+        [WorkflowRun]
+        public async Task<ContextValue> RunAsync(ContextValue value)
+        {
+            value.AssertWorkflowEqual("workflow-input", Workflow.Info.WorkflowId);
+            await Workflow.WaitConditionAsync(() => complete);
+            return new("workflow-result", new());
+        }
+
+        [WorkflowSignal]
+        public async Task CompleteAsync() => complete = true;
+
+        [WorkflowSignal]
+        public async Task SomeSignalAsync(ContextValue value)
+        {
+            value.AssertWorkflowEqual("signal-input", Workflow.Info.WorkflowId);
+        }
+
+        [WorkflowQuery]
+        public ContextValue SomeQuery(ContextValue value)
+        {
+            value.AssertWorkflowEqual("query-input", Workflow.Info.WorkflowId);
+            return new("query-result", new());
+        }
+
+        [WorkflowUpdate]
+        public async Task<ContextValue> SomeUpdateAsync(ContextValue value)
+        {
+            value.AssertWorkflowEqual("update-input", Workflow.Info.WorkflowId);
+            return new("update-result", new());
+        }
+
+        [WorkflowUpdate]
+        public async Task SignalExternalAsync(string workflowId)
+        {
+            var handle = Workflow.GetExternalWorkflowHandle<ConverterContextWorkflow>(workflowId);
+            await handle.SignalAsync(wf => wf.SomeSignalAsync(new("signal-input", new())));
+        }
+
+        [WorkflowUpdate]
+        public async Task DoChildAsync()
+        {
+            // Start child
+            var handle = await Workflow.StartChildWorkflowAsync(
+                (ConverterContextWorkflow wf) => wf.RunAsync(new("workflow-input", new())));
+            await handle.SignalAsync(wf => wf.SomeSignalAsync(new("signal-input", new())));
+            await handle.SignalAsync(wf => wf.CompleteAsync());
+            var res = await handle.GetResultAsync();
+            res.AssertWorkflowEqual("workflow-result", handle.Id);
+        }
+
+        [WorkflowUpdate]
+        public async Task DoActivityAsync()
+        {
+            // Regular activity
+            var res = await Workflow.ExecuteActivityAsync(
+                () => SomeActivity(new("activity-input", new())),
+                new() { StartToCloseTimeout = TimeSpan.FromSeconds(30) });
+            res.AssertWorkflowEqual("activity-result", Workflow.Info.WorkflowId, activity: true);
+
+            // Local activity
+            res = await Workflow.ExecuteLocalActivityAsync(
+                () => SomeActivity(new("activity-input", new())),
+                new() { StartToCloseTimeout = TimeSpan.FromSeconds(30) });
+            res.AssertWorkflowEqual("activity-result", Workflow.Info.WorkflowId, activity: true);
+        }
+
+        [Activity]
+        public static ContextValue SomeActivity(ContextValue value)
+        {
+            value.AssertWorkflowEqual(
+                "activity-input",
+                ActivityExecutionContext.Current.Info.WorkflowId,
+                activity: true);
+            return new("activity-result", new());
+        }
+
+        [WorkflowUpdate]
+        public async Task DoUpdateAndActivityFailureAsync()
+        {
+            try
+            {
+                await Workflow.ExecuteActivityAsync(
+                    () => SomeFailingActivity(),
+                    new() { StartToCloseTimeout = TimeSpan.FromSeconds(10) });
+                throw new InvalidOperationException("Expected failure");
+            }
+            catch (ActivityFailureException e) when (e.InnerException?.Message?.StartsWith("Intentional activity failure") == true)
+            {
+                throw new ApplicationFailureException(
+                    "Intentional update failure",
+                    e,
+                    details: new[] { new ContextValue("update-failure", new()) });
+            }
+        }
+
+        [Activity]
+        public static void SomeFailingActivity() =>
+            throw new ApplicationFailureException(
+                "Intentional activity failure",
+                nonRetryable: true,
+                details: new[] { new ContextValue("activity-failure", new()) });
+
+        [WorkflowUpdate]
+        public async Task DoAsyncActivityCompletionAsync()
+        {
+            var res = await Workflow.ExecuteActivityAsync(
+                () => SomeAsyncCompletingActivity(),
+                new() { StartToCloseTimeout = TimeSpan.FromSeconds(30) });
+            res.AssertWorkflowEqual("activity-async-result", Workflow.Info.WorkflowId, activity: true);
+        }
+
+        [Activity]
+        public static ContextValue SomeAsyncCompletingActivity()
+        {
+            // Schedule completion in the background
+            var handle = ActivityExecutionContext.Current.TemporalClient.GetAsyncActivityHandle(
+                ActivityExecutionContext.Current.Info.TaskToken).WithSerializationContext(
+                    new ISerializationContext.Activity(ActivityExecutionContext.Current.Info));
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(300);
+                await handle.CompleteAsync(new ContextValue("activity-async-result", new()));
+            });
+            throw new CompleteAsyncException();
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_ConverterContext_ProperlyAvailable()
+    {
+        // It is accepted that this does not test every pemutation of every way a payload converter,
+        // failure converter, and codec are used in clients, workflows, and activities.
+
+        // Context-aware data converter
+        var dataConverter = new DataConverter(
+            PayloadConverter: new DefaultPayloadConverter(
+                ((DefaultPayloadConverter)Client.Options.DataConverter.PayloadConverter).EncodingConverters.Select(e =>
+                    e is JsonPlainConverter ? new ContextJsonPlainConverter(new()) : e).ToArray()),
+            FailureConverter: new ContextFailureConverter(new()),
+            PayloadCodec: new ContextPayloadCodec(new()));
+
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = dataConverter;
+        var client = new TemporalClient(Client.Connection, newOptions);
+
+        await ExecuteWorkerAsync<ConverterContextWorkflow>(
+            async worker =>
+            {
+                var historyExpects = new List<ContextHistoryExpectation>();
+
+                // Start the workflow
+                var handle = await client.StartWorkflowAsync(
+                    (ConverterContextWorkflow wf) => wf.RunAsync(new("workflow-input", new())),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+                historyExpects.Add(new(
+                    "workflow-input",
+                    e => e.WorkflowExecutionStartedEventAttributes?.Input?.Payloads_?.FirstOrDefault()));
+                historyExpects.Add(new(
+                    "workflow-result",
+                    e => e.WorkflowExecutionCompletedEventAttributes?.Result?.Payloads_?.FirstOrDefault()));
+
+                // Signal
+                await handle.SignalAsync(wf => wf.SomeSignalAsync(new("signal-input", new())));
+                historyExpects.Add(new(
+                    "signal-input",
+                    e => e.WorkflowExecutionSignaledEventAttributes?.Input?.Payloads_?.FirstOrDefault()));
+
+                // Query
+                var res = await handle.QueryAsync(wf => wf.SomeQuery(new("query-input", new())));
+                res.AssertWorkflowEqual("query-result", handle.Id);
+
+                // Update
+                res = await handle.ExecuteUpdateAsync(wf => wf.SomeUpdateAsync(new("update-input", new())));
+                res.AssertWorkflowEqual("update-result", handle.Id);
+                historyExpects.Add(new(
+                    "update-input",
+                    e => e.WorkflowExecutionUpdateAcceptedEventAttributes?.AcceptedRequest?.Input?.Args?.Payloads_?.FirstOrDefault()));
+                historyExpects.Add(new(
+                    "update-result",
+                    e => e.WorkflowExecutionUpdateCompletedEventAttributes?.Outcome?.Success?.Payloads_?.FirstOrDefault()));
+
+                // Start another for external and signal it
+                var externalHandle = await client.StartWorkflowAsync(
+                    (ConverterContextWorkflow wf) => wf.RunAsync(new("workflow-input", new())),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+                await handle.ExecuteUpdateAsync(wf => wf.SignalExternalAsync(externalHandle.Id));
+                await externalHandle.SignalAsync(wf => wf.CompleteAsync());
+                res = await externalHandle.GetResultAsync();
+                res.AssertWorkflowEqual("workflow-result", externalHandle.Id);
+
+                // Do some child work too
+                await handle.ExecuteUpdateAsync(wf => wf.DoChildAsync());
+
+                // And activity work
+                await handle.ExecuteUpdateAsync(wf => wf.DoActivityAsync());
+                historyExpects.Add(new(
+                    "activity-input",
+                    e => e.ActivityTaskScheduledEventAttributes?.Input?.Payloads_?.FirstOrDefault(),
+                    Activity: true));
+                historyExpects.Add(new(
+                    "activity-result",
+                    e => e.ActivityTaskCompletedEventAttributes?.Result?.Payloads_?.FirstOrDefault(),
+                    Activity: true));
+
+                // Update and activity failure
+                var err = await Assert.ThrowsAsync<WorkflowUpdateFailedException>(() =>
+                    handle.ExecuteUpdateAsync(wf => wf.DoUpdateAndActivityFailureAsync()));
+                var err2 = Assert.IsType<ApplicationFailureException>(err.InnerException);
+                Assert.EndsWith($"[activity: false, workflow-id: {handle.Id}]", err2.Message);
+                err2.Details.ElementAt<ContextValue>(0).AssertWorkflowEqual(
+                    "update-failure", handle.Id);
+                var err3 = Assert.IsType<ActivityFailureException>(err2.InnerException);
+                var err4 = Assert.IsType<ApplicationFailureException>(err3.InnerException);
+                Assert.EndsWith($"[activity: true, workflow-id: {handle.Id}]", err4.Message);
+                // This is a strange case where we use the activity context to convert to payload,
+                // but the client context here to convert from payload.
+                err4.Details.ElementAt<ContextValue>(0).AssertWorkflowEqual(
+                    "activity-failure", handle.Id, activity: true, activityInboundOverride: false);
+
+                // Async activity completion
+                await handle.ExecuteUpdateAsync(wf => wf.DoAsyncActivityCompletionAsync());
+                historyExpects.Add(new(
+                    "activity-async-result",
+                    e => e.ActivityTaskCompletedEventAttributes?.Result?.Payloads_?.FirstOrDefault(),
+                    Activity: true));
+
+                // Complete, check result
+                await handle.SignalAsync(wf => wf.CompleteAsync());
+                res = await handle.GetResultAsync();
+                res.AssertWorkflowEqual("workflow-result", handle.Id);
+
+                // Check that the codec did the right things
+                var history = await handle.FetchHistoryAsync();
+                foreach (var historyExpect in historyExpects)
+                {
+                    await historyExpect.AssertInHistoryAsync(history);
+                }
+            },
+            new TemporalWorkerOptions().AddAllActivities<ConverterContextWorkflow>(null),
+            client);
     }
 
     internal static Task AssertTaskFailureContainsEventuallyAsync(


### PR DESCRIPTION
## What was changed

* Added `IWithSerializationContext<T>` that can be implemented by data converters (and is), payload converters, encoding-specific payload converters, failure converters, and payload codecs to provide context-specific versions of themselves
* Added `ISerializationContext` as a base/marker interface for the contexts and nested `Activity` and `Workflow` class implementations of it
* Updated workflow client, schedule client, async activity client, workflow worker, activity worker, workflow outbound child, and workflow outbound external code to use context-specific converters/codecs.
* Added test to test most of those paths

## Checklist

1. Closes #438