### PR TITLE
Allow absent payloads on some responses

### DIFF
--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -418,9 +418,10 @@ namespace Temporalio.Client
                     throw new WorkflowQueryRejectedException(resp.QueryRejected.Status);
                 }
 
-                if (resp.QueryResult == null)
+                // Use default value if no result present
+                if (resp.QueryResult == null || resp.QueryResult.Payloads_.Count == 0)
                 {
-                    throw new InvalidOperationException("No result present");
+                    return default!;
                 }
                 return await Client.Options.DataConverter.ToSingleValueAsync<TResult>(
                     resp.QueryResult.Payloads_).ConfigureAwait(false);

--- a/src/Temporalio/Client/WorkflowHandle.cs
+++ b/src/Temporalio/Client/WorkflowHandle.cs
@@ -109,15 +109,11 @@ namespace Temporalio.Client
                                 histRunId = compAttr.NewExecutionRunId;
                                 break;
                             }
-                            // Ignore return if they didn't want it
-                            if (typeof(TResult) == typeof(ValueTuple))
+                            // Use default if they are ignoring result or payload not present
+                            if (typeof(TResult) == typeof(ValueTuple) ||
+                                compAttr.Result == null || compAttr.Result.Payloads_.Count == 0)
                             {
                                 return default!;
-                            }
-                            // Otherwise we expect a single payload
-                            if (compAttr.Result == null)
-                            {
-                                throw new InvalidOperationException("No result present");
                             }
                             return await Client.Options.DataConverter.ToSingleValueAsync<TResult>(
                                 compAttr.Result.Payloads_).ConfigureAwait(false);

--- a/src/Temporalio/Client/WorkflowUpdateHandle.cs
+++ b/src/Temporalio/Client/WorkflowUpdateHandle.cs
@@ -52,8 +52,9 @@ namespace Temporalio.Client
             }
             else if (KnownOutcome.Success is { } success)
             {
-                // Ignore return if they didn't want it
-                if (typeof(TResult) == typeof(ValueTuple))
+                // Use default if they are ignoring result or payload not present
+                if (typeof(TResult) == typeof(ValueTuple) ||
+                    success == null || success.Payloads_.Count == 0)
                 {
                     return default!;
                 }

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -6608,6 +6608,72 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         Assert.Equal(new List<string> { "one", "two", "four", "three" }, MultiWaitConditionPreSdkFlagWorkflow.Stages);
     }
 
+    [Workflow]
+    public class PayloadMissingWorkflow
+    {
+        [WorkflowRun]
+        public async Task<string?> RunAsync(bool returnImmediately)
+        {
+            if (returnImmediately)
+            {
+                return null;
+            }
+            // Run child that returns immediately, run activity that does the same
+            await Workflow.ExecuteChildWorkflowAsync<string?>(
+                "PayloadMissingWorkflow",
+                new object?[] { true });
+            await Workflow.ExecuteActivityAsync<string?>(
+                "DoSomething",
+                Array.Empty<object?>(),
+                new() { StartToCloseTimeout = TimeSpan.FromSeconds(30) });
+            return null;
+        }
+
+        [Activity]
+        public static string? DoSomething() => null;
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_PayloadMissing_StillWorks()
+    {
+        // This test confirms that the absence of a payload inside activity and child workflow
+        // result is ok. This can happen when calling an activity or child in another SDK like Go.
+
+        // Run workflow and get handle
+        var handle = await ExecuteWorkerAsync<PayloadMissingWorkflow, WorkflowHandle>(
+            async worker =>
+            {
+                var handle = await Client.StartWorkflowAsync(
+                    (PayloadMissingWorkflow wf) => wf.RunAsync(false),
+                    new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
+                await handle.GetResultAsync();
+                return handle;
+            },
+            new TemporalWorkerOptions().AddAllActivities<PayloadMissingWorkflow>(null));
+
+        // Get history and confirm it can replay
+        var replayer = new WorkflowReplayer(
+            new WorkflowReplayerOptions().AddWorkflow<PayloadMissingWorkflow>());
+        var history = await handle.FetchHistoryAsync();
+        await replayer.ReplayWorkflowAsync(history);
+
+        // Now complete remove the activity and child complete payloads. This used to break.
+        foreach (var evt in history.Events)
+        {
+            if (evt.ChildWorkflowExecutionCompletedEventAttributes is { } childEvent)
+            {
+                Assert.NotNull(childEvent.Result);
+                childEvent.Result = null;
+            }
+            else if (evt.ActivityTaskCompletedEventAttributes is { } actEvent)
+            {
+                Assert.NotNull(actEvent.Result);
+                actEvent.Result = null;
+            }
+        }
+        await replayer.ReplayWorkflowAsync(history);
+    }
+
     internal static Task AssertTaskFailureContainsEventuallyAsync(
         WorkflowHandle handle, string messageContains)
     {


### PR DESCRIPTION
## What was changed

In some SDKs like Go, the absence of a response is no payload rather than a null payload. .NET did not expect the concept of an absent payload in activities, child workflows, and other places. This allows them to work.

## Checklist

1. Closes #445
