### PR TITLE
💥 BREAKING CHANGE - Remove assumed use-worker-versioning in DI when build ID present

### DIFF
--- a/src/Temporalio.Extensions.Hosting/ITemporalWorkerServiceOptionsBuilder.cs
+++ b/src/Temporalio.Extensions.Hosting/ITemporalWorkerServiceOptionsBuilder.cs
@@ -15,7 +15,7 @@ namespace Temporalio.Extensions.Hosting
         string TaskQueue { get; }
 
         /// <summary>
-        /// Gets the build ID for this worker service. If unset, versioning is disabled.
+        /// Gets the build ID for this worker service.
         /// </summary>
         string? BuildId { get; }
 

--- a/src/Temporalio.Extensions.Hosting/TemporalHostingServiceCollectionExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalHostingServiceCollectionExtensions.cs
@@ -28,10 +28,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="taskQueue">Task queue for the worker.</param>
         /// <param name="buildId">
-        /// Build ID for the worker. Set to non-null to opt in to versioning. If versioning is
-        /// wanted, this must be set here and not later via configure options. This is because the
-        /// combination of task queue and build ID make up the unique identifier for a worker in the
-        /// service collection.
+        /// Build ID for the worker. It is important to set build ID here and not later via
+        /// configure options. This is because the combination of task queue and build ID make up
+        /// the unique identifier for a worker in the service collection.
         /// </param>
         /// <returns>Options builder to configure the service.</returns>
         public static ITemporalWorkerServiceOptionsBuilder AddHostedTemporalWorker(
@@ -55,10 +54,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">Service collection to create hosted worker on.</param>
         /// <param name="taskQueue">Task queue for the worker.</param>
         /// <param name="buildId">
-        /// Build ID for the worker. Set to non-null to opt in to versioning. If versioning is
-        /// wanted, this must be set here and not later via configure options. This is because the
-        /// combination of task queue and build ID make up the unique identifier for a worker in the
-        /// service collection.
+        /// Build ID for the worker. It is important to set build ID here and not later via
+        /// configure options. This is because the combination of task queue and build ID make up
+        /// the unique identifier for a worker in the service collection.
         /// </param>
         /// <returns>Options builder to configure the service.</returns>
         public static ITemporalWorkerServiceOptionsBuilder AddHostedTemporalWorker(
@@ -75,7 +73,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     options.TaskQueue = taskQueue;
                     options.BuildId = buildId;
-                    options.UseWorkerVersioning = buildId != null;
                 },
                 // Disallow duplicate options registrations because that means multiple worker
                 // services with the same task queue + build ID were added.

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerService.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerService.cs
@@ -135,11 +135,6 @@ namespace Temporalio.Extensions.Hosting
                 throw new InvalidOperationException(
                     $"Build ID '{taskQueueAndBuildId.BuildId ?? "<unset>"}' on constructor different than '{options.BuildId ?? "<unset>"}' on options");
             }
-            if (options.UseWorkerVersioning != (taskQueueAndBuildId.BuildId != null))
-            {
-                throw new InvalidOperationException(
-                    $"Use versioning option is {options.UseWorkerVersioning}, but constructor expects different");
-            }
 
             newClientOptions = options.ClientOptions;
             if (newClientOptions == null)


### PR DESCRIPTION
## What was changed

Today if you use our `IServiceCollection.AddHostedTemporalWorker` extension with a non-null `BuildId`, we assume that meant you wanted to opt in to `TemporalWorkerOptions.UseWorkerVersioning` as `true`. But this is not a correct assumption, there are other uses of build ID.

💥 BREAKING CHANGE - We removed implicitly assuming you want this form of worker versioning when you provide build ID this way. This form of worker versioning is not GA and therefore, while this is a backwards incompatible change, the product is not stable (and will in fact be replaced in the near term with a more modern form of versioning).

## Checklist

1. Closes #442
