### PR TITLE
Handle errors with update result serialization

### DIFF
--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -3081,7 +3081,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         [WorkflowRun]
         public Task RunAsync() => Workflow.WaitConditionAsync(() => false);
 
-        [WorkflowSignal]
+        [WorkflowUpdate]
         public async Task SetHandlersAsync()
         {
             Workflow.DynamicSignal = WorkflowSignalDefinition.CreateWithoutAttribute(
@@ -3106,7 +3106,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 });
         }
 
-        [WorkflowSignal]
+        [WorkflowUpdate]
         public async Task UnsetHandlersAsync()
         {
             Workflow.DynamicSignal = null;
@@ -3138,7 +3138,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
 
                 // Add handlers, and confirm all signals are drained to it and it handles
                 // queries/updates
-                await handle.SignalAsync(wf => wf.SetHandlersAsync());
+                await handle.ExecuteUpdateAsync(wf => wf.SetHandlersAsync());
                 await handle.SignalAsync("SomeSignal2", new[] { "signal arg 2" });
                 Assert.Equal(
                     "done", await handle.QueryAsync<string>("SomeQuery2", new[] { "query arg 2" }));
@@ -3156,7 +3156,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                     (await handle.QueryAsync(wf => wf.Events)).OrderBy(v => v).ToList());
 
                 // Remove handlers and confirm things go back to unhandled
-                await handle.SignalAsync(wf => wf.UnsetHandlersAsync());
+                await handle.ExecuteUpdateAsync(wf => wf.UnsetHandlersAsync());
                 await handle.SignalAsync("SomeSignal3", new[] { "signal arg 3" });
                 queryExc = await Assert.ThrowsAsync<WorkflowQueryFailedException>(
                     () => handle.QueryAsync<string>("SomeQuery3", new[] { "query arg 3" }));


### PR DESCRIPTION
## What was changed

Previously we swallowed failures to serialize update results. Now we will fail the update or the task depending on the error.

## Checklist

1. Closes #465