### PR TITLE
Replace BuildJet in build-binary smoke test

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -155,7 +155,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-arm, alpine-latest, macos-intel, macos-arm, windows-latest]
         include:
           - os: ubuntu-arm
-            runsOn: buildjet-4vcpu-ubuntu-2204-arm
+            runsOn: ubuntu-24.04-arm64-2-core
           - os: alpine-latest
             container: mcr.microsoft.com/dotnet/sdk:6.0-alpine
             runsOn: ubuntu-latest


### PR DESCRIPTION
## What was changed

Fix issue where we forgot to change an ARM server in a build-binary smoke test step when we switched others

## Checklist

1. Closes #461