### PR TITLE
Fail the workflow task if a requested local activity is not registered

### DIFF
--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -143,7 +143,7 @@ namespace Temporalio.Worker
         /// Checks if the given activity type is registered on this worker.
         /// </summary>
         /// <param name="activityType">The type of activity to look up. </param>
-        /// <returns>Null if the activity type is registered, an error message for providing other available
+        /// <returns>Null if the activity type is registered, a list of alternative activities otherwise
         /// activities otherwise. </returns>
         public string? ActivityLookup(string activityType)
         {

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -140,6 +140,24 @@ namespace Temporalio.Worker
         }
 
         /// <summary>
+        /// Checks if the given activity type is registered on this worker.
+        /// </summary>
+        /// <param name="activityType">The type of activity to look up. </param>
+        /// <returns>Null if the activity type is registered, an error message for providing other available
+        /// activities otherwise. </returns>
+        public string? ActivityLookup(string activityType)
+        {
+            if (activities.ContainsKey(activityType))
+            {
+                return null;
+            }
+
+            var avail = activities.Keys.ToList();
+            avail.Sort();
+            return string.Join(", ", avail);
+        }
+
+        /// <summary>
         /// Dispose the worker.
         /// </summary>
         /// <param name="disposing">Whether disposing.</param>

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -93,7 +93,7 @@ namespace Temporalio.Worker
                     RuntimeMetricMeter: MetricMeter,
                     WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
                     DisableEagerActivityExecution: options.DisableEagerActivityExecution,
-                    ActivityLookup: (activityType) => activityWorker?.ActivityLookup(activityType) ?? null));
+                    AssertValidActivity: (activityType) => activityWorker?.AssertValidActivity(activityType)));
             }
         }
 

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -92,7 +92,8 @@ namespace Temporalio.Worker
                     OnTaskCompleted: options.OnTaskCompleted,
                     RuntimeMetricMeter: MetricMeter,
                     WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
-                    DisableEagerActivityExecution: options.DisableEagerActivityExecution));
+                    DisableEagerActivityExecution: options.DisableEagerActivityExecution,
+                    ActivityLookup: (activityType) => activityWorker?.ActivityLookup(activityType) ?? null));
             }
         }
 

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -93,7 +93,11 @@ namespace Temporalio.Worker
                     RuntimeMetricMeter: MetricMeter,
                     WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
                     DisableEagerActivityExecution: options.DisableEagerActivityExecution,
-                    AssertValidActivity: (activityType) => activityWorker?.AssertValidActivity(activityType)));
+                    AssertValidLocalActivity: (activityType) => (activityWorker ??
+                                throw new InvalidOperationException(
+                                    $"Activity {activityType} is not registered on this worker," +
+                                    $" no available activities."))
+                                .AssertValidActivity(activityType)));
             }
         }
 

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -203,7 +203,7 @@ namespace Temporalio.Worker
             TracingEventsEnabled = !details.DisableTracingEvents;
             workerLevelFailureExceptionTypes = details.WorkerLevelFailureExceptionTypes;
             disableEagerActivityExecution = details.DisableEagerActivityExecution;
-            AssertValidActivity = details.AssertValidActivity;
+            AssertValidLocalActivity = details.AssertValidLocalActivity;
         }
 
         /// <summary>
@@ -350,7 +350,7 @@ namespace Temporalio.Worker
         /// <summary>
         /// Gets the activity lookup function.
         /// </summary>
-        internal Action<string> AssertValidActivity { get; private init; }
+        internal Action<string> AssertValidLocalActivity { get; private init; }
 
         /// <inheritdoc/>
         public ContinueAsNewException CreateContinueAsNewException(
@@ -2086,7 +2086,7 @@ namespace Temporalio.Worker
                     throw new ArgumentException("Activity options must have StartToCloseTimeout or ScheduleToCloseTimeout");
                 }
 
-                instance.AssertValidActivity(input.Activity);
+                instance.AssertValidLocalActivity(input.Activity);
 
                 // Get payload converter with context
                 var serializationContext = new ISerializationContext.Activity(

--- a/src/Temporalio/Worker/WorkflowInstanceDetails.cs
+++ b/src/Temporalio/Worker/WorkflowInstanceDetails.cs
@@ -27,7 +27,7 @@ namespace Temporalio.Worker
     /// <param name="RuntimeMetricMeter">Lazy runtime-level metric meter.</param>
     /// <param name="WorkerLevelFailureExceptionTypes">Failure exception types at worker level.</param>
     /// <param name="DisableEagerActivityExecution">Whether to disable eager at the worker level.</param>
-    /// <param name="AssertValidActivity">Checks the validity of the activity and throws if it is invalid.</param>
+    /// <param name="AssertValidLocalActivity">Checks the validity of the local activity and throws if it is invalid.</param>
     internal record WorkflowInstanceDetails(
         string Namespace,
         string TaskQueue,
@@ -45,5 +45,5 @@ namespace Temporalio.Worker
         Lazy<MetricMeter> RuntimeMetricMeter,
         IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
         bool DisableEagerActivityExecution,
-        Action<string> AssertValidActivity);
+        Action<string> AssertValidLocalActivity);
 }

--- a/src/Temporalio/Worker/WorkflowInstanceDetails.cs
+++ b/src/Temporalio/Worker/WorkflowInstanceDetails.cs
@@ -27,6 +27,7 @@ namespace Temporalio.Worker
     /// <param name="RuntimeMetricMeter">Lazy runtime-level metric meter.</param>
     /// <param name="WorkerLevelFailureExceptionTypes">Failure exception types at worker level.</param>
     /// <param name="DisableEagerActivityExecution">Whether to disable eager at the worker level.</param>
+    /// <param name="ActivityLookup">Function which provides error information if an activity doesn't exist.</param>
     internal record WorkflowInstanceDetails(
         string Namespace,
         string TaskQueue,
@@ -43,5 +44,6 @@ namespace Temporalio.Worker
         Action<WorkflowInstance, Exception?> OnTaskCompleted,
         Lazy<MetricMeter> RuntimeMetricMeter,
         IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
-        bool DisableEagerActivityExecution);
+        bool DisableEagerActivityExecution,
+        Func<string, string?> ActivityLookup);
 }

--- a/src/Temporalio/Worker/WorkflowInstanceDetails.cs
+++ b/src/Temporalio/Worker/WorkflowInstanceDetails.cs
@@ -27,7 +27,7 @@ namespace Temporalio.Worker
     /// <param name="RuntimeMetricMeter">Lazy runtime-level metric meter.</param>
     /// <param name="WorkerLevelFailureExceptionTypes">Failure exception types at worker level.</param>
     /// <param name="DisableEagerActivityExecution">Whether to disable eager at the worker level.</param>
-    /// <param name="ActivityLookup">Function which provides error information if an activity doesn't exist.</param>
+    /// <param name="AssertValidActivity">Checks the validity of the activity and throws if it is invalid.</param>
     internal record WorkflowInstanceDetails(
         string Namespace,
         string TaskQueue,
@@ -45,5 +45,5 @@ namespace Temporalio.Worker
         Lazy<MetricMeter> RuntimeMetricMeter,
         IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
         bool DisableEagerActivityExecution,
-        Func<string, string?> ActivityLookup);
+        Action<string> AssertValidActivity);
 }

--- a/src/Temporalio/Worker/WorkflowReplayer.cs
+++ b/src/Temporalio/Worker/WorkflowReplayer.cs
@@ -174,7 +174,8 @@ namespace Temporalio.Worker
                             OnTaskCompleted: options.OnTaskCompleted,
                             RuntimeMetricMeter: new(() => runtime.MetricMeter),
                             WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
-                            DisableEagerActivityExecution: false),
+                            DisableEagerActivityExecution: false,
+                            ActivityLookup: _ => null),
                         (runId, removeFromCache) => SetResult(removeFromCache));
                 }
                 catch

--- a/src/Temporalio/Worker/WorkflowReplayer.cs
+++ b/src/Temporalio/Worker/WorkflowReplayer.cs
@@ -175,7 +175,7 @@ namespace Temporalio.Worker
                             RuntimeMetricMeter: new(() => runtime.MetricMeter),
                             WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
                             DisableEagerActivityExecution: false,
-                            AssertValidActivity: _ => { }),
+                            AssertValidLocalActivity: _ => { }),
                         (runId, removeFromCache) => SetResult(removeFromCache));
                 }
                 catch

--- a/src/Temporalio/Worker/WorkflowReplayer.cs
+++ b/src/Temporalio/Worker/WorkflowReplayer.cs
@@ -175,7 +175,7 @@ namespace Temporalio.Worker
                             RuntimeMetricMeter: new(() => runtime.MetricMeter),
                             WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
                             DisableEagerActivityExecution: false,
-                            ActivityLookup: _ => null),
+                            AssertValidActivity: _ => { }),
                         (runId, removeFromCache) => SetResult(removeFromCache));
                 }
                 catch

--- a/src/Temporalio/Worker/WorkflowWorker.cs
+++ b/src/Temporalio/Worker/WorkflowWorker.cs
@@ -333,7 +333,8 @@ namespace Temporalio.Worker
                     OnTaskCompleted: options.OnTaskCompleted,
                     RuntimeMetricMeter: options.RuntimeMetricMeter,
                     WorkerLevelFailureExceptionTypes: options.WorkerLevelFailureExceptionTypes,
-                    DisableEagerActivityExecution: options.DisableEagerActivityExecution));
+                    DisableEagerActivityExecution: options.DisableEagerActivityExecution,
+                    ActivityLookup: options.ActivityLookup));
         }
     }
 }

--- a/src/Temporalio/Worker/WorkflowWorker.cs
+++ b/src/Temporalio/Worker/WorkflowWorker.cs
@@ -334,7 +334,7 @@ namespace Temporalio.Worker
                     RuntimeMetricMeter: options.RuntimeMetricMeter,
                     WorkerLevelFailureExceptionTypes: options.WorkerLevelFailureExceptionTypes,
                     DisableEagerActivityExecution: options.DisableEagerActivityExecution,
-                    ActivityLookup: options.ActivityLookup));
+                    AssertValidActivity: options.AssertValidActivity));
         }
     }
 }

--- a/src/Temporalio/Worker/WorkflowWorker.cs
+++ b/src/Temporalio/Worker/WorkflowWorker.cs
@@ -334,7 +334,7 @@ namespace Temporalio.Worker
                     RuntimeMetricMeter: options.RuntimeMetricMeter,
                     WorkerLevelFailureExceptionTypes: options.WorkerLevelFailureExceptionTypes,
                     DisableEagerActivityExecution: options.DisableEagerActivityExecution,
-                    AssertValidActivity: options.AssertValidActivity));
+                    AssertValidLocalActivity: options.AssertValidLocalActivity));
         }
     }
 }

--- a/src/Temporalio/Worker/WorkflowWorkerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowWorkerOptions.cs
@@ -23,5 +23,5 @@ namespace Temporalio.Worker
         Lazy<MetricMeter> RuntimeMetricMeter,
         IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
         bool DisableEagerActivityExecution,
-        Action<string> AssertValidActivity);
+        Action<string> AssertValidLocalActivity);
 }

--- a/src/Temporalio/Worker/WorkflowWorkerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowWorkerOptions.cs
@@ -23,5 +23,5 @@ namespace Temporalio.Worker
         Lazy<MetricMeter> RuntimeMetricMeter,
         IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
         bool DisableEagerActivityExecution,
-        Func<string, string?> ActivityLookup);
+        Action<string> AssertValidActivity);
 }

--- a/src/Temporalio/Worker/WorkflowWorkerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowWorkerOptions.cs
@@ -22,5 +22,6 @@ namespace Temporalio.Worker
         Action<WorkflowInstance, Exception?> OnTaskCompleted,
         Lazy<MetricMeter> RuntimeMetricMeter,
         IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
-        bool DisableEagerActivityExecution);
+        bool DisableEagerActivityExecution,
+        Func<string, string?> ActivityLookup);
 }

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -7226,18 +7226,16 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     [Fact]
     public async Task ExecuteWorkflowAsync_LocalActivityMissing()
     {
-        var err = await Assert.ThrowsAsync<WorkflowFailedException>(() => ExecuteWorkerAsync<LocalActivityMissingWorkflow, WorkflowHandle>(
+        var err = await ExecuteWorkerAsync<LocalActivityMissingWorkflow, WorkflowHandle>(
             async worker =>
             {
                 var handle = await Client.StartWorkflowAsync(
                     (LocalActivityMissingWorkflow wf) => wf.RunAsync(),
                     new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
-                await handle.GetResultAsync();
+                await AssertTaskFailureContainsEventuallyAsync(handle, "Activity invalid_activity is not registered");
                 return handle;
             },
-            new TemporalWorkerOptions().AddAllActivities<LocalActivityMissingWorkflow>(null)));
-        var err2 = Assert.IsType<ApplicationFailureException>(err.InnerException);
-        Assert.Contains("Activity invalid_activity is not registered", err2.Message);
+            new TemporalWorkerOptions().AddAllActivities<LocalActivityMissingWorkflow>(null));
     }
 
     internal static Task AssertTaskFailureContainsEventuallyAsync(

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -7226,14 +7226,13 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     [Fact]
     public async Task ExecuteWorkflowAsync_LocalActivityMissing()
     {
-        var err = await ExecuteWorkerAsync<LocalActivityMissingWorkflow, WorkflowHandle>(
+        await ExecuteWorkerAsync<LocalActivityMissingWorkflow>(
             async worker =>
             {
                 var handle = await Client.StartWorkflowAsync(
                     (LocalActivityMissingWorkflow wf) => wf.RunAsync(),
                     new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
                 await AssertTaskFailureContainsEventuallyAsync(handle, "Activity invalid_activity is not registered on this worker, available activities: DoSomething");
-                return handle;
             },
             new TemporalWorkerOptions().AddAllActivities<LocalActivityMissingWorkflow>(null));
     }
@@ -7254,7 +7253,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     [Fact]
     public async Task ExecuteWorkflowAsync_LocalActivityMissing_Dynamic()
     {
-        var err = await ExecuteWorkerAsync<LocalActivityMissingDynamicWorkflow>(
+        await ExecuteWorkerAsync<LocalActivityMissingDynamicWorkflow>(
             async worker =>
             {
                 var result = await Client.ExecuteWorkflowAsync(
@@ -7278,16 +7277,14 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     [Fact]
     public async Task ExecuteWorkflowAsync_LocalActivityMissing_NoActivities()
     {
-        var err = await ExecuteWorkerAsync<LocalActivityMissingNoActivitiesWorkflow, WorkflowHandle>(
+        await ExecuteWorkerAsync<LocalActivityMissingNoActivitiesWorkflow>(
             async worker =>
             {
                 var handle = await Client.StartWorkflowAsync(
                     (LocalActivityMissingNoActivitiesWorkflow wf) => wf.RunAsync(),
                     new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
                 await AssertTaskFailureContainsEventuallyAsync(handle, "Activity invalid_activity is not registered on this worker, no available activities.");
-                return handle;
-            },
-            new TemporalWorkerOptions());
+            });
     }
 
     internal static Task AssertTaskFailureContainsEventuallyAsync(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Executing an unregistered local activity will fail the workflow task rather than just the activity.

## Why?
Reduces unhelpful retries.

## Checklist
<!--- add/delete as needed --->

1. Closes 463

2. How was this tested:
New unit test added to WorkflowWorkerTests

3. Any docs updates needed?
None
