### PR TITLE
Improve/verbosify error messages in various ToInteropOptions methods

### DIFF
--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -150,7 +150,7 @@ namespace Temporalio.Bridge
         {
             if (string.IsNullOrEmpty(options.Filter.FilterString))
             {
-                throw new ArgumentException($"FilterString is required when {nameof(Temporalio.Runtime.LoggingOptions)} is configured");
+                throw new ArgumentException($"FilterString is required when {nameof(Temporalio.Runtime.TelemetryFilterOptions)} is configured");
             }
             return new Interop.LoggingOptions()
             {

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -71,7 +71,7 @@ namespace Temporalio.Bridge
         {
             if (options.Url == null)
             {
-                throw new ArgumentException("OpenTelemetry URL is required");
+                throw new ArgumentException($"OpenTelemetry URL is required when {nameof(Temporalio.Runtime.OpenTelemetryOptions)} is configured");
             }
             Interop.OpenTelemetryMetricTemporality temporality;
             switch (options.MetricTemporality)
@@ -125,7 +125,7 @@ namespace Temporalio.Bridge
         {
             if (string.IsNullOrEmpty(options.BindAddress))
             {
-                throw new ArgumentException("Prometheus options must have bind address");
+                throw new ArgumentException($"BindAddress is required when {nameof(Temporalio.Runtime.PrometheusOptions)} is configured");
             }
             return new Interop.PrometheusOptions()
             {
@@ -150,7 +150,7 @@ namespace Temporalio.Bridge
         {
             if (string.IsNullOrEmpty(options.Filter.FilterString))
             {
-                throw new ArgumentException("Logging filter string is required");
+                throw new ArgumentException($"FilterString is required when {nameof(Temporalio.Runtime.LoggingOptions)} is configured");
             }
             return new Interop.LoggingOptions()
             {
@@ -283,7 +283,7 @@ namespace Temporalio.Bridge
             if (hasClientCert != hasClientKey)
             {
                 throw new ArgumentException(
-                    "Client cert and private key must both be present or neither");
+                    $"Client cert and private key must both be present or neither when {nameof(Temporalio.Client.TlsOptions)} is configured");
             }
             return new Interop.ClientTlsOptions()
             {
@@ -341,7 +341,7 @@ namespace Temporalio.Bridge
         {
             if (string.IsNullOrEmpty(options.TargetHost))
             {
-                throw new ArgumentException("TargetHost is required");
+                throw new ArgumentException($"{nameof(options.TargetHost)} is required when {nameof(Temporalio.Client.HttpConnectProxyOptions)} is configured");
             }
 
             return new ClientHttpConnectProxyOptions
@@ -448,7 +448,7 @@ namespace Temporalio.Bridge
         {
             if (options.TaskQueue == null)
             {
-                throw new ArgumentException("Task queue must be provided in worker options");
+                throw new ArgumentException($"Task queue must be provided when {nameof(Temporalio.Worker.TemporalWorkerOptions)} is configured");
             }
 #pragma warning disable 0618
             var buildId = options.DeploymentOptions?.Version?.BuildId ?? options.BuildId;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This a small change to make (most of) the ArgumentException messages in OptionsExtensions more verbose. Specifically, this change focuses on errors caused by the absence of a property being set, and includes the name of the options class that it is missing from.

## Why?
<!-- Tell your future self why have you made these changes -->
The various `ToInteropOptions(...)` methods are the first place where options classes get checked for correctness. Since these are "deeper" in the SDK than what most users are digging into, it can make the error challenging to interpret.

For example, we can look at an error thrown when `TargetHost` is not set for `HttpConnectProxyOptions`:

![image](https://github.com/user-attachments/assets/1e064369-c3a5-414e-9654-f3d45228bd65)

1. The call stack is unrelated to the location where a user might configure these client options, such as `Program.cs` or `Startup.cs`, so it can be unclear that this is a user error
2. "TargetHost" is an overloaded property name throughout the SDK, so disambiguating it to `HttpConnectProxyOptions` would be helpful

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

4. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Not necessary; no functional changes.

5. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
None known.