### PR TITLE
Added Category to ApplicationFailureException

### DIFF
--- a/src/Temporalio/Converters/DefaultFailureConverter.cs
+++ b/src/Temporalio/Converters/DefaultFailureConverter.cs
@@ -155,6 +155,7 @@ namespace Temporalio.Converters
                             appDet.Count == 0
                                 ? null
                                 : new() { Payloads_ = { appDet.Details.Select(conv.ToPayload) } },
+                        Category = appExc.Category,
                     };
                     if (appExc.NextRetryDelay != null)
                     {

--- a/src/Temporalio/Exceptions/ApplicationFailureException.cs
+++ b/src/Temporalio/Exceptions/ApplicationFailureException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Temporalio.Api.Enums.V1;
 using Temporalio.Api.Failure.V1;
 
 namespace Temporalio.Exceptions
@@ -25,18 +26,21 @@ namespace Temporalio.Exceptions
         /// <param name="nonRetryable">If true, marks the exception as non-retryable.</param>
         /// <param name="details">Collection of details to serialize into the exception.</param>
         /// <param name="nextRetryDelay">Override the next retry delay with this value.</param>
+        /// <param name="category">Error category.</param>
         public ApplicationFailureException(
             string message,
             string? errorType = null,
             bool nonRetryable = false,
             IReadOnlyCollection<object?>? details = null,
-            TimeSpan? nextRetryDelay = null)
+            TimeSpan? nextRetryDelay = null,
+            ApplicationErrorCategory category = ApplicationErrorCategory.Unspecified)
             : base(message)
         {
             ErrorType = errorType;
             NonRetryable = nonRetryable;
             Details = new OutboundFailureDetails(details ?? Array.Empty<object?>());
             NextRetryDelay = nextRetryDelay;
+            Category = category;
         }
 
         /// <summary>
@@ -50,19 +54,22 @@ namespace Temporalio.Exceptions
         /// <param name="nonRetryable">If true, marks the exception as non-retryable.</param>
         /// <param name="details">Collection of details to serialize into the exception.</param>
         /// <param name="nextRetryDelay">Override the next retry delay with this value.</param>
+        /// <param name="category">Error category.</param>
         public ApplicationFailureException(
             string message,
             Exception? inner,
             string? errorType = null,
             bool nonRetryable = false,
             IReadOnlyCollection<object?>? details = null,
-            TimeSpan? nextRetryDelay = null)
+            TimeSpan? nextRetryDelay = null,
+            ApplicationErrorCategory category = ApplicationErrorCategory.Unspecified)
             : base(message, inner)
         {
             ErrorType = errorType;
             NonRetryable = nonRetryable;
             Details = new OutboundFailureDetails(details);
             NextRetryDelay = nextRetryDelay;
+            Category = category;
         }
 
         /// <summary>
@@ -84,6 +91,7 @@ namespace Temporalio.Exceptions
             NonRetryable = info.NonRetryable;
             Details = new InboundFailureDetails(converter, info.Details?.Payloads_);
             NextRetryDelay = info.NextRetryDelay?.ToTimeSpan();
+            Category = info.Category;
         }
 
         /// <summary>
@@ -109,5 +117,10 @@ namespace Temporalio.Exceptions
         /// Gets the next retry delay override if any was set.
         /// </summary>
         public TimeSpan? NextRetryDelay { get; protected init; }
+
+        /// <summary>
+        /// Gets the error category.
+        /// </summary>
+        public ApplicationErrorCategory Category { get; protected init; }
     }
 }

--- a/tests/Temporalio.Tests/IKitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/IKitchenSinkWorkflow.cs
@@ -66,7 +66,8 @@ public record KSResultAction(
 public record KSErrorAction(
     [property: JsonPropertyName("message")] string? Message = null,
     [property: JsonPropertyName("details")] object? Details = null,
-    [property: JsonPropertyName("attempt")] bool Attempt = false);
+    [property: JsonPropertyName("attempt")] bool Attempt = false,
+    [property: JsonPropertyName("is_benign")] bool IsBenign = false);
 
 public record KSContinueAsNewAction(
     [property: JsonPropertyName("while_above_zero")] int? WhileAboveZero = null,

--- a/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
@@ -1,3 +1,5 @@
+using Temporalio.Api.Enums.V1;
+
 namespace Temporalio.Tests;
 
 using System.Threading.Tasks;
@@ -76,7 +78,9 @@ public class KitchenSinkWorkflow
                 details = new[] { action.Error.Details };
             }
             throw new ApplicationFailureException(
-                action.Error.Message ?? string.Empty, details: details);
+                action.Error.Message ?? string.Empty,
+                details: details,
+                category: action.Error.IsBenign ? ApplicationErrorCategory.Benign : ApplicationErrorCategory.Unspecified);
         }
         else if (action.ContinueAsNew != null)
         {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added `Category` field to `ApplicationFailureException`.

## Why?
Feature request: https://github.com/temporalio/features/issues/614

## Checklist
<!--- add/delete as needed --->

1. Closes #448

2. How was this tested: Added test `GetResultAsync_BenignFailure_Throws`