### PR TITLE
Improve code analyze of not null member on ActivityDefinition

### DIFF
--- a/src/Temporalio/Activities/ActivityDefinition.cs
+++ b/src/Temporalio/Activities/ActivityDefinition.cs
@@ -57,6 +57,7 @@ namespace Temporalio.Activities
         /// <summary>
         /// Gets a value indicating whether the activity is dynamic.
         /// </summary>
+        [MemberNotNullWhen(true, nameof(Name))]
         public bool Dynamic => Name == null;
 
         /// <summary>


### PR DESCRIPTION
This pull request introduces a small enhancement to the `ActivityDefinition` class in `src/Temporalio/Activities/ActivityDefinition.cs`. The change adds a `[MemberNotNullWhen]` attribute to the `Dynamic` property, improving nullability annotations and ensuring better static analysis.
