### PR TITLE
💥 BREAKING - Make static summary/details lazy on workflow description

### DIFF
--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -523,8 +523,7 @@ namespace Temporalio.Client
                         },
                     },
                     DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);
-                return await WorkflowExecutionDescription.FromProtoAsync(
-                    resp, dataConverter).ConfigureAwait(false);
+                return new(resp, dataConverter);
             }
 
             /// <inheritdoc />

--- a/src/Temporalio/Client/WorkflowExecutionDescription.cs
+++ b/src/Temporalio/Client/WorkflowExecutionDescription.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Temporalio.Api.WorkflowService.V1;
 using Temporalio.Converters;
@@ -9,39 +10,24 @@ namespace Temporalio.Client
     /// </summary>
     public class WorkflowExecutionDescription : WorkflowExecution
     {
+        private Lazy<Task<(string? Summary, string? Details)>> userMetadata;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkflowExecutionDescription"/> class.
         /// </summary>
         /// <param name="rawDescription">Raw protobuf description.</param>
-        /// <param name="staticSummary">Static summary.</param>
-        /// <param name="staticDetails">Static details.</param>
         /// <param name="dataConverter">Data converter.</param>
         /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
         protected internal WorkflowExecutionDescription(
-            DescribeWorkflowExecutionResponse rawDescription,
-            string? staticSummary,
-            string? staticDetails,
-            DataConverter dataConverter)
+            DescribeWorkflowExecutionResponse rawDescription, DataConverter dataConverter)
             : base(rawDescription.WorkflowExecutionInfo, dataConverter, null)
         {
             RawDescription = rawDescription;
-            StaticSummary = staticSummary;
-            StaticDetails = staticDetails;
+#pragma warning disable VSTHRD011 // This should not be able to deadlock
+            userMetadata = new(() => dataConverter.FromUserMetadataAsync(
+                rawDescription.ExecutionConfig?.UserMetadata));
+#pragma warning restore VSTHRD011
         }
-
-        /// <summary>
-        /// Gets the single-line fixed summary for this workflow execution that may appear in
-        /// UI/CLI. This can be in single-line Temporal markdown format.
-        /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
-        public string? StaticSummary { get; private init; }
-
-        /// <summary>
-        /// Gets the general fixed details for this workflow execution that may appear in UI/CLI.
-        /// This can be in Temporal markdown format and can span multiple lines.
-        /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
-        public string? StaticDetails { get; private init; }
 
         /// <summary>
         /// Gets the raw proto info.
@@ -49,17 +35,21 @@ namespace Temporalio.Client
         internal DescribeWorkflowExecutionResponse RawDescription { get; private init; }
 
         /// <summary>
-        /// Convert from proto.
+        /// Gets the single-line fixed summary for this workflow execution that may appear in
+        /// UI/CLI. This can be in single-line Temporal markdown format.
         /// </summary>
-        /// <param name="rawDescription">Raw description.</param>
-        /// <param name="dataConverter">Data converter.</param>
-        /// <returns>Converted value.</returns>
-        internal static async Task<WorkflowExecutionDescription> FromProtoAsync(
-            DescribeWorkflowExecutionResponse rawDescription, DataConverter dataConverter)
-        {
-            var (staticSummary, staticDetails) = await dataConverter.FromUserMetadataAsync(
-                rawDescription.ExecutionConfig?.UserMetadata).ConfigureAwait(false);
-            return new(rawDescription, staticSummary, staticDetails, dataConverter);
-        }
+        /// <remarks>WARNING: This setting is experimental.</remarks>
+        /// <returns>Static summary.</returns>
+        public async Task<string?> GetStaticSummaryAsync() =>
+            (await userMetadata.Value.ConfigureAwait(false)).Summary;
+
+        /// <summary>
+        /// Gets the general fixed details for this workflow execution that may appear in UI/CLI.
+        /// This can be in Temporal markdown format and can span multiple lines.
+        /// </summary>
+        /// <remarks>WARNING: This setting is experimental.</remarks>
+        /// <returns>Static details.</returns>
+        public async Task<string?> GetStaticDetailsAsync() =>
+            (await userMetadata.Value.ConfigureAwait(false)).Details;
     }
 }

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -6258,8 +6258,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
 
                 // Check description has summary/details
                 var desc = await handle.DescribeAsync();
-                Assert.Equal("my-workflow", desc.StaticSummary);
-                Assert.Equal("my-workflow-details", desc.StaticDetails);
+                Assert.Equal("my-workflow", await desc.GetStaticSummaryAsync());
+                Assert.Equal("my-workflow-details", await desc.GetStaticDetailsAsync());
 
                 // Check history for timer (x2), activity, and child metadata
                 var history = await handle.FetchHistoryAsync();
@@ -6277,8 +6277,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 var child = history.Events.Single(evt => evt.StartChildWorkflowExecutionInitiatedEventAttributes != null);
                 desc = await Client.GetWorkflowHandle(
                     child.StartChildWorkflowExecutionInitiatedEventAttributes.WorkflowId).DescribeAsync();
-                Assert.Equal("my-child", desc.StaticSummary);
-                Assert.Equal("my-child-details", desc.StaticDetails);
+                Assert.Equal("my-child", await desc.GetStaticSummaryAsync());
+                Assert.Equal("my-child-details", await desc.GetStaticDetailsAsync());
             },
             new TemporalWorkerOptions().AddAllActivities<UserMetadataWorkflow>(null));
     }


### PR DESCRIPTION
## What was changed

Changed `WorkflowExecutionDescription` properties of `StaticSummary` and `StaticDetails` to now be methods of `GetStaticSummaryAsync` and `GetStaticDetailsAsync`. This is a breaking change to experimental API.

## Checklist

1. Closes #460