### PR TITLE
Deprecate VersioningIntent

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -986,10 +986,12 @@ namespace Temporalio.Worker
                     {
                         cmd.Headers.Add(headers);
                     }
+#pragma warning disable CS0618
                     if (e.Input.Options?.VersioningIntent is { } vi)
                     {
                         cmd.VersioningIntent = (Bridge.Api.Common.VersioningIntent)(int)vi;
                     }
+#pragma warning restore CS0618
                     AddCommand(new() { ContinueAsNewWorkflowExecution = cmd });
                 }
                 catch (Exception e) when (
@@ -2094,10 +2096,12 @@ namespace Temporalio.Worker
                         {
                             cmd.HeartbeatTimeout = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(heartbeat);
                         }
+#pragma warning disable CS0618
                         if (input.Options.VersioningIntent is { } vi)
                         {
                             cmd.VersioningIntent = (Bridge.Api.Common.VersioningIntent)(int)vi;
                         }
+#pragma warning restore CS0618
                         var workflowCommand = new WorkflowCommand() { ScheduleActivity = cmd };
                         if (input.Options.Summary is { } summary)
                         {
@@ -2320,10 +2324,12 @@ namespace Temporalio.Worker
                 {
                     cmd.Headers.Add(headers);
                 }
+#pragma warning disable CS0618
                 if (input.Options?.VersioningIntent is { } vi)
                 {
                     cmd.VersioningIntent = (Bridge.Api.Common.VersioningIntent)(int)vi;
                 }
+#pragma warning restore CS0618
                 if (input.Options?.Priority is { } priority)
                 {
                     cmd.Priority = priority.ToProto();

--- a/src/Temporalio/Workflows/ActivityOptions.cs
+++ b/src/Temporalio/Workflows/ActivityOptions.cs
@@ -90,6 +90,7 @@ namespace Temporalio.Workflows
         /// Gets or sets whether this Activity should run on a worker with a compatible Build Id or not when using the
         /// Worker Versioning feature.
         /// </summary>
+        [Obsolete("Worker Build Id versioning is deprecated in favor of Worker Deployment versioning")]
         public VersioningIntent VersioningIntent { get; set; } = VersioningIntent.Unspecified;
 
         /// <summary>

--- a/src/Temporalio/Workflows/ChildWorkflowOptions.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowOptions.cs
@@ -101,6 +101,7 @@ namespace Temporalio.Workflows
         /// Gets or sets whether this Child Workflow should run on a worker with a compatible Build Id or not when using
         /// the Worker Versioning feature.
         /// </summary>
+        [Obsolete("Worker Build Id versioning is deprecated in favor of Worker Deployment versioning")]
         public VersioningIntent VersioningIntent { get; set; } = VersioningIntent.Unspecified;
 
         /// <summary>

--- a/src/Temporalio/Workflows/ContinueAsNewOptions.cs
+++ b/src/Temporalio/Workflows/ContinueAsNewOptions.cs
@@ -49,6 +49,7 @@ namespace Temporalio.Workflows
         /// Gets or sets whether the continued Workflow should run on a worker with a compatible Build Id or not when
         /// using the Worker Versioning feature.
         /// </summary>
+        [Obsolete("Worker Build Id versioning is deprecated in favor of Worker Deployment versioning")]
         public VersioningIntent VersioningIntent { get; set; } = VersioningIntent.Unspecified;
 
         /// <summary>

--- a/src/Temporalio/Workflows/VersioningIntent.cs
+++ b/src/Temporalio/Workflows/VersioningIntent.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Temporalio.Workflows
 {
     /// <summary>
@@ -8,6 +10,7 @@ namespace Temporalio.Workflows
     /// most sensible default behavior for the type of command, accounting for whether the command will
     /// be run on the same task queue as the current worker.
     /// </summary>
+    [Obsolete("Worker Build Id versioning is deprecated in favor of Worker Deployment versioning")]
     public enum VersioningIntent
     {
         /// <summary>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
VersioningIntent should've been deprecated along with the rest of the old versioning APIs when deployment based versioning was introduced

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
