### PR TITLE
Remove CLI version pin for internal tests 

### DIFF
--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -80,8 +80,6 @@ public class WorkflowEnvironment : IAsyncLifetime
                         // Enable activity pause
                         "--dynamic-config-value", "frontend.activityAPIsEnabled=true",
                     },
-                    // TODO: Remove after next CLI release
-                    DownloadVersion = "v1.3.1-persistence-fix.0",
                 },
             });
         }


### PR DESCRIPTION
## What was changed

- SDK's internal tests were previously pinned to CLI `v1.3.1-persistence-fix.0`. Removed that pin, so that tests run against latest CLI (v1.4.0 at this time).