### PR TITLE
Added retry policy to activity info

### DIFF
--- a/src/Temporalio/Activities/ActivityInfo.cs
+++ b/src/Temporalio/Activities/ActivityInfo.cs
@@ -20,6 +20,10 @@ namespace Temporalio.Activities
     /// <param name="HeartbeatTimeout">Heartbeat timeout set by the caller.</param>
     /// <param name="IsLocal">Whether the activity is a local activity or not.</param>
     /// <param name="Priority">The Priority of this activity.</param>
+    /// <param name="RetryPolicy">
+    /// The retry policy of this activity.
+    /// The server may set a different policy than the one provided when scheduling the activity.
+    /// </param>
     /// <param name="ScheduleToCloseTimeout">Schedule to close timeout set by the caller.</param>
     /// <param name="ScheduledTime">When the activity was scheduled.</param>
     /// <param name="StartToCloseTimeout">Start to close timeout set by the caller.</param>
@@ -44,6 +48,7 @@ namespace Temporalio.Activities
         TimeSpan? HeartbeatTimeout,
         bool IsLocal,
         Temporalio.Common.Priority Priority,
+        Temporalio.Common.RetryPolicy? RetryPolicy,
         TimeSpan? ScheduleToCloseTimeout,
         DateTime ScheduledTime,
         TimeSpan? StartToCloseTimeout,

--- a/src/Temporalio/Activities/ActivityInfo.cs
+++ b/src/Temporalio/Activities/ActivityInfo.cs
@@ -22,7 +22,11 @@ namespace Temporalio.Activities
     /// <param name="Priority">The Priority of this activity.</param>
     /// <param name="RetryPolicy">
     /// The retry policy of this activity.
-    /// The server may set a different policy than the one provided when scheduling the activity.
+    /// <para>
+    /// Note that the server may have set a different policy than the one provided when scheduling the activity.
+    /// If the value is null, it means the server didn't send information about retry policy (e.g. due to old server
+    /// version), but it may still be defined server-side.
+    /// </para>
     /// </param>
     /// <param name="ScheduleToCloseTimeout">Schedule to close timeout set by the caller.</param>
     /// <param name="ScheduledTime">When the activity was scheduled.</param>

--- a/src/Temporalio/Common/RetryPolicy.cs
+++ b/src/Temporalio/Common/RetryPolicy.cs
@@ -65,7 +65,7 @@ namespace Temporalio.Common
         {
             return new()
             {
-                InitialInterval = proto.InitialInterval.ToTimeSpan(),
+                InitialInterval = (proto.InitialInterval ?? new Duration()).ToTimeSpan(),
                 BackoffCoefficient = (float)proto.BackoffCoefficient,
                 MaximumInterval = proto.MaximumInterval?.ToTimeSpan(),
                 MaximumAttempts = proto.MaximumAttempts,

--- a/src/Temporalio/Common/RetryPolicy.cs
+++ b/src/Temporalio/Common/RetryPolicy.cs
@@ -65,7 +65,7 @@ namespace Temporalio.Common
         {
             return new()
             {
-                InitialInterval = (proto.InitialInterval ?? new Duration()).ToTimeSpan(),
+                InitialInterval = proto.InitialInterval.ToTimeSpan(),
                 BackoffCoefficient = (float)proto.BackoffCoefficient,
                 MaximumInterval = proto.MaximumInterval?.ToTimeSpan(),
                 MaximumAttempts = proto.MaximumAttempts,

--- a/src/Temporalio/Testing/ActivityEnvironment.cs
+++ b/src/Temporalio/Testing/ActivityEnvironment.cs
@@ -31,7 +31,7 @@ namespace Temporalio.Testing
             HeartbeatTimeout: null,
             IsLocal: false,
             Priority: new(),
-            RetryPolicy: null,
+            RetryPolicy: new(),
             ScheduleToCloseTimeout: TimeSpan.FromSeconds(1),
             ScheduledTime: new(1970, 1, 1, 1, 1, 1, DateTimeKind.Utc),
             StartToCloseTimeout: TimeSpan.FromSeconds(1),

--- a/src/Temporalio/Testing/ActivityEnvironment.cs
+++ b/src/Temporalio/Testing/ActivityEnvironment.cs
@@ -31,6 +31,7 @@ namespace Temporalio.Testing
             HeartbeatTimeout: null,
             IsLocal: false,
             Priority: new(),
+            RetryPolicy: null,
             ScheduleToCloseTimeout: TimeSpan.FromSeconds(1),
             ScheduledTime: new(1970, 1, 1, 1, 1, 1, DateTimeKind.Utc),
             StartToCloseTimeout: TimeSpan.FromSeconds(1),

--- a/src/Temporalio/Worker/ActivityWorker.cs
+++ b/src/Temporalio/Worker/ActivityWorker.cs
@@ -209,6 +209,7 @@ namespace Temporalio.Worker
                 HeartbeatTimeout: OptionalTimeSpan(start.HeartbeatTimeout),
                 IsLocal: start.IsLocal,
                 Priority: start.Priority is { } p ? new(p) : Priority.Default,
+                RetryPolicy: start.RetryPolicy is { } rp ? RetryPolicy.FromProto(rp) : null,
                 ScheduleToCloseTimeout: OptionalTimeSpan(start.ScheduleToCloseTimeout),
                 ScheduledTime: start.ScheduledTime.ToDateTime(),
                 StartToCloseTimeout: OptionalTimeSpan(start.StartToCloseTimeout),

--- a/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
@@ -1,4 +1,5 @@
 using Temporalio.Api.Enums.V1;
+using Temporalio.Common;
 
 namespace Temporalio.Tests;
 
@@ -54,6 +55,16 @@ public class KitchenSinkWorkflow
     public string SomeQuery(string arg) => throw new NotImplementedException();
 
     public Task SomeSignalAsync(string arg) => Task.CompletedTask;
+
+    public static RetryPolicy CreateRetryPolicy(int? maximumAttempts = null, IReadOnlyCollection<string>? nonRetryableErrorTypes = null) =>
+        new()
+        {
+            InitialInterval = TimeSpan.FromMilliseconds(1),
+            BackoffCoefficient = 1.01F,
+            MaximumInterval = TimeSpan.FromMilliseconds(2),
+            MaximumAttempts = maximumAttempts ?? 1,
+            NonRetryableErrorTypes = nonRetryableErrorTypes,
+        };
 
     private async Task<(bool ShouldReturn, object? Value)> HandleActionAsync(
         KSWorkflowParams args, KSAction action)
@@ -144,14 +155,7 @@ public class KitchenSinkWorkflow
             var opts = new ActivityOptions()
             {
                 TaskQueue = action.ExecuteActivity.TaskQueue,
-                RetryPolicy = new()
-                {
-                    InitialInterval = TimeSpan.FromMilliseconds(1),
-                    BackoffCoefficient = 1.01F,
-                    MaximumInterval = TimeSpan.FromMilliseconds(2),
-                    MaximumAttempts = 1,
-                    NonRetryableErrorTypes = action.ExecuteActivity.NonRetryableErrorTypes ?? Array.Empty<string>(),
-                },
+                RetryPolicy = CreateRetryPolicy(action.ExecuteActivity.RetryMaxAttempts, action.ExecuteActivity.NonRetryableErrorTypes),
             };
             if (action.ExecuteActivity.ScheduleToCloseTimeoutMS != null)
             {
@@ -181,10 +185,6 @@ public class KitchenSinkWorkflow
                 action.ExecuteActivity.ScheduleToCloseTimeoutMS == null)
             {
                 opts.ScheduleToCloseTimeout = TimeSpan.FromMinutes(3);
-            }
-            if (action.ExecuteActivity.RetryMaxAttempts != null)
-            {
-                opts.RetryPolicy.MaximumAttempts = action.ExecuteActivity.RetryMaxAttempts.Value;
             }
             // Build cancellation token source for delayed cancelling
             using var cancelSource = CancellationTokenSource.CreateLinkedTokenSource(

--- a/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
@@ -126,6 +126,7 @@ public class ActivityWorkerTests : WorkflowEnvironmentTestBase
         Assert.Equal(1, info.Attempt);
         Assert.InRange(info.CurrentAttemptScheduledTime, beforeNow, afterNow);
         Assert.False(info.IsLocal);
+        Assert.Equal(KitchenSinkWorkflow.CreateRetryPolicy(), info.RetryPolicy);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added retry policy to activity info.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/615

## Checklist
<!--- add/delete as needed --->

1. Closes #457

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added new assertion to `Temporalio.Tests.Worker.ActivityWorkerTests.ExecuteActivityAsync_CheckInfo_IsAccurate`
