### PR TITLE
Added FirstExecutionRunId to WorkflowInfo

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -183,6 +183,7 @@ namespace Temporalio.Worker
                 ContinuedRunId: NonEmptyOrNull(start.ContinuedFromExecutionRunId),
                 CronSchedule: NonEmptyOrNull(start.CronSchedule),
                 ExecutionTimeout: start.WorkflowExecutionTimeout?.ToTimeSpan(),
+                FirstExecutionRunId: start.FirstExecutionRunId,
                 Headers: start.Headers,
                 LastFailure: lastFailure,
                 LastResult: lastResult,

--- a/src/Temporalio/Workflows/WorkflowInfo.cs
+++ b/src/Temporalio/Workflows/WorkflowInfo.cs
@@ -12,6 +12,7 @@ namespace Temporalio.Workflows
     /// <param name="ContinuedRunId">Run ID if this was continued.</param>
     /// <param name="CronSchedule">Cron schedule if applicable.</param>
     /// <param name="ExecutionTimeout">Execution timeout for the workflow.</param>
+    /// <param name="FirstExecutionRunId">The very first run ID the workflow ever had, following continuation chains.</param>
     /// <param name="Headers">Headers from when the workflow was started.</param>
     /// <param name="LastFailure">Failure if this workflow run is a continuation of a failure.</param>
     /// <param name="LastResult">Successful result if this workflow is a continuation of a success.</param>
@@ -38,6 +39,7 @@ namespace Temporalio.Workflows
         string? ContinuedRunId,
         string? CronSchedule,
         TimeSpan? ExecutionTimeout,
+        string FirstExecutionRunId,
         IReadOnlyDictionary<string, Api.Common.V1.Payload>? Headers,
         Exception? LastFailure,
         IReadOnlyCollection<IRawValue>? LastResult,
@@ -64,6 +66,7 @@ namespace Temporalio.Workflows
         {
             ["Attempt"] = Attempt,
             ["Namespace"] = Namespace,
+            ["FirstExecutionRunId"] = FirstExecutionRunId,
             ["RunId"] = RunId,
             ["TaskQueue"] = TaskQueue,
             ["WorkflowId"] = WorkflowId,

--- a/tests/Temporalio.Tests/IKitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/IKitchenSinkWorkflow.cs
@@ -70,8 +70,7 @@ public record KSErrorAction(
     [property: JsonPropertyName("is_benign")] bool IsBenign = false);
 
 public record KSContinueAsNewAction(
-    [property: JsonPropertyName("while_above_zero")] int? WhileAboveZero = null,
-    [property: JsonPropertyName("result")] object? Result = null);
+    [property: JsonPropertyName("while_above_zero")] int? WhileAboveZero = null);
 
 public record KSSleepAction(
     [property: JsonPropertyName("millis")] long Millis);

--- a/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
@@ -104,7 +104,7 @@ public class KitchenSinkWorkflow
                 throw Workflow.CreateContinueAsNewException(
                     (IKitchenSinkWorkflow wf) => wf.RunAsync(args));
             }
-            return (true, action.ContinueAsNew.Result);
+            return (true, Workflow.Info.FirstExecutionRunId);
         }
         else if (action.Sleep != null)
         {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added `FirstExecutionRunId` property to `WorkflowInfo`.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/29

## Checklist
<!--- add/delete as needed --->

1. Closes #505 

2. How was this tested:
Modified `WorkflowHandleTests.GetResultAsync_ContinueAsNew_ProperlyFollowed` to check `FirstExecutionRunId` value.
