### PR TITLE
Fixed error message of `BinaryProtoConverter.AssertProtoPayload` not filling a placeholder

### DIFF
--- a/src/Temporalio/Converters/BinaryProtoConverter.cs
+++ b/src/Temporalio/Converters/BinaryProtoConverter.cs
@@ -68,7 +68,7 @@ namespace Temporalio.Converters
                 {
                     throw new ArgumentException(
                         $"Payload has protobuf message type {messageType} "
-                            + "but given type's message type is {desc.FullName}");
+                            + $"but given type's message type is {desc.FullName}");
                 }
             }
             else

--- a/tests/Temporalio.Tests/Converters/PayloadConverterTests.cs
+++ b/tests/Temporalio.Tests/Converters/PayloadConverterTests.cs
@@ -92,6 +92,21 @@ public class PayloadConverterTests : TestBase
         Assert.Throws<NotSupportedException>(() => AssertPayload(action, "json/plain"));
     }
 
+    [Fact]
+    public void ToValue_WrongProtoType_Fails()
+    {
+        var proto = new WorkflowType { Name = "WorkflowName" };
+        var payload = AssertPayload(
+            proto,
+            "json/protobuf",
+            expectedJson: "{\"name\":\"WorkflowName\"}");
+        IPayloadConverter converter = DataConverter.Default.PayloadConverter;
+        Assert.Equal(proto, converter.ToValue(payload, typeof(WorkflowType)));
+        var e = Assert.Throws<ArgumentException>(() => converter.ToValue(payload, typeof(ActivityType)));
+        Assert.Contains(WorkflowType.Descriptor.FullName, e.Message);
+        Assert.Contains(ActivityType.Descriptor.FullName, e.Message);
+    }
+
     private static Payload AssertPayload(
         object? value,
         string expectedEncoding,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
In `BinaryProtoConverter.AssertProtoPayload`, the exception thrown when the object had incorrect Proto type was not marked as format string and `{desc.FullName}` was not filled in properly. This PR makes the message a format string.

## Why?
<!-- Tell your future self why have you made these changes -->
Bugfix.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Added `PayloadConverterTests.ToValue_WrongProtoType_Fails`.