### PR TITLE
💥 Fix how serialization context is applied in workflows [MINOR COMPAT BREAK]

### DIFF
--- a/src/Temporalio/Activities/ActivityExecutionContext.cs
+++ b/src/Temporalio/Activities/ActivityExecutionContext.cs
@@ -125,6 +125,10 @@ namespace Temporalio.Activities
         /// <summary>
         /// Gets the payload converter in use by this activity worker.
         /// </summary>
+        /// <remarks>
+        /// If the original converter supported serialization contexts, this is the converter with
+        /// the activity serialization context applied.
+        /// </remarks>
         public IPayloadConverter PayloadConverter { get; private init; }
 
         /// <summary>

--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -20,25 +20,25 @@ namespace Temporalio.Worker
         /// <summary>
         /// Encode the completion.
         /// </summary>
-        /// <param name="codec">Codec to use.</param>
-        /// <param name="codecContext">Codec context.</param>
+        /// <param name="context">Codec context.</param>
         /// <param name="comp">Completion to encode.</param>
         /// <returns>Task for completion.</returns>
         internal static async Task EncodeAsync(
-            IPayloadCodec codec, WorkflowCodecContext codecContext, WorkflowActivationCompletion comp)
+            WorkflowCodecContext context, WorkflowActivationCompletion comp)
         {
             switch (comp.StatusCase)
             {
                 case WorkflowActivationCompletion.StatusOneofCase.Failed:
-                    if (comp.Failed.Failure_ != null)
+                    if (comp.Failed.Failure_ != null && context.CodecWorkflowContext != null)
                     {
-                        await codec.EncodeFailureAsync(comp.Failed.Failure_).ConfigureAwait(false);
+                        await context.CodecWorkflowContext.EncodeFailureAsync(
+                            comp.Failed.Failure_).ConfigureAwait(false);
                     }
                     break;
                 case WorkflowActivationCompletion.StatusOneofCase.Successful:
                     foreach (var cmd in comp.Successful.Commands)
                     {
-                        await EncodeAsync(codec, codecContext, cmd).ConfigureAwait(false);
+                        await EncodeAsync(context, cmd).ConfigureAwait(false);
                     }
                     break;
             }
@@ -47,91 +47,112 @@ namespace Temporalio.Worker
         /// <summary>
         /// Decode the activation.
         /// </summary>
-        /// <param name="codec">Codec to use.</param>
-        /// <param name="codecContext">Codec context.</param>
+        /// <param name="context">Codec context.</param>
         /// <param name="act">Activation to decode.</param>
         /// <returns>Task for completion.</returns>
-        internal static async Task DecodeAsync(IPayloadCodec codec, WorkflowCodecContext codecContext, WorkflowActivation act)
+        internal static async Task DecodeAsync(WorkflowCodecContext context, WorkflowActivation act)
         {
             foreach (var job in act.Jobs)
             {
                 switch (job.VariantCase)
                 {
                     case WorkflowActivationJob.VariantOneofCase.DoUpdate:
-                        await DecodeAsync(codec, job.DoUpdate.Headers).ConfigureAwait(false);
-                        await DecodeAsync(codec, job.DoUpdate.Input).ConfigureAwait(false);
+                        if (context.CodecWorkflowContext != null)
+                        {
+                            await DecodeAsync(context.CodecWorkflowContext, job.DoUpdate.Headers).ConfigureAwait(false);
+                            await DecodeAsync(context.CodecWorkflowContext, job.DoUpdate.Input).ConfigureAwait(false);
+                        }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.QueryWorkflow:
-                        await DecodeAsync(codec, job.QueryWorkflow.Arguments).ConfigureAwait(false);
-                        await DecodeAsync(codec, job.QueryWorkflow.Headers).ConfigureAwait(false);
+                        if (context.CodecWorkflowContext != null)
+                        {
+                            await DecodeAsync(context.CodecWorkflowContext, job.QueryWorkflow.Arguments).ConfigureAwait(false);
+                            await DecodeAsync(context.CodecWorkflowContext, job.QueryWorkflow.Headers).ConfigureAwait(false);
+                        }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.ResolveActivity:
                         // Apply activity context
-                        var actCodec = codec;
-                        if (codec is IWithSerializationContext<IPayloadCodec> withAct &&
-                            codecContext.Instance?.GetPendingActivitySerializationContext(job.ResolveActivity.Seq) is { } actContext)
+                        var actCodec = context.CodecNoContext;
+                        if (actCodec is IWithSerializationContext<IPayloadCodec> withAct &&
+                            context.Instance?.GetPendingActivitySerializationContext(job.ResolveActivity.Seq) is { } actContext)
                         {
                             actCodec = withAct.WithSerializationContext(actContext);
                         }
-                        await DecodeAsync(actCodec, job.ResolveActivity.Result).ConfigureAwait(false);
+                        if (actCodec != null)
+                        {
+                            await DecodeAsync(actCodec, job.ResolveActivity.Result).ConfigureAwait(false);
+                        }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.ResolveChildWorkflowExecution:
                         // Apply child workflow context
-                        var childCodec = codec;
-                        if (codec is IWithSerializationContext<IPayloadCodec> withChild &&
-                            codecContext.Instance?.GetPendingChildSerializationContext(job.ResolveChildWorkflowExecution.Seq) is { } childContext)
+                        var childCodec = context.CodecNoContext;
+                        if (childCodec is IWithSerializationContext<IPayloadCodec> withChild &&
+                            context.Instance?.GetPendingChildSerializationContext(job.ResolveChildWorkflowExecution.Seq) is { } childContext)
                         {
                             childCodec = withChild.WithSerializationContext(childContext);
                         }
-                        await DecodeAsync(
-                            childCodec, job.ResolveChildWorkflowExecution.Result).ConfigureAwait(false);
+                        if (childCodec != null)
+                        {
+                            await DecodeAsync(
+                                childCodec, job.ResolveChildWorkflowExecution.Result).ConfigureAwait(false);
+                        }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.ResolveChildWorkflowExecutionStart:
                         if (job.ResolveChildWorkflowExecutionStart.Cancelled != null
                             && job.ResolveChildWorkflowExecutionStart.Cancelled.Failure != null)
                         {
                             // Apply child workflow context
-                            var childCodec2 = codec;
-                            if (codec is IWithSerializationContext<IPayloadCodec> withChild2 &&
-                                codecContext.Instance?.GetPendingChildSerializationContext(job.ResolveChildWorkflowExecution.Seq) is { } childContext2)
+                            var childCodec2 = context.CodecNoContext;
+                            if (childCodec2 is IWithSerializationContext<IPayloadCodec> withChild2 &&
+                                context.Instance?.GetPendingChildSerializationContext(job.ResolveChildWorkflowExecution.Seq) is { } childContext2)
                             {
                                 childCodec2 = withChild2.WithSerializationContext(childContext2);
                             }
-                            await childCodec2.DecodeFailureAsync(
-                                job.ResolveChildWorkflowExecutionStart.Cancelled.Failure).
-                                ConfigureAwait(false);
+                            if (childCodec2 != null)
+                            {
+                                await childCodec2.DecodeFailureAsync(
+                                    job.ResolveChildWorkflowExecutionStart.Cancelled.Failure).
+                                    ConfigureAwait(false);
+                            }
                         }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.ResolveNexusOperation:
+                        // TODO(cretz): Support Nexus serialization context
+                        if (context.CodecNoContext == null)
+                        {
+                            break;
+                        }
                         if (job.ResolveNexusOperation.Result.Completed != null)
                         {
                             await DecodeAsync(
-                                codec, job.ResolveNexusOperation.Result.Completed).
+                                context.CodecNoContext, job.ResolveNexusOperation.Result.Completed).
                                 ConfigureAwait(false);
                         }
                         else if (job.ResolveNexusOperation.Result.Failed != null)
                         {
-                            await codec.DecodeFailureAsync(
+                            await context.CodecNoContext.DecodeFailureAsync(
                                 job.ResolveNexusOperation.Result.Failed).
                                 ConfigureAwait(false);
                         }
                         else if (job.ResolveNexusOperation.Result.Cancelled != null)
                         {
-                            await codec.DecodeFailureAsync(
+                            await context.CodecNoContext.DecodeFailureAsync(
                                 job.ResolveNexusOperation.Result.Cancelled).
                                 ConfigureAwait(false);
                         }
                         else if (job.ResolveNexusOperation.Result.TimedOut != null)
                         {
-                            await codec.DecodeFailureAsync(
+                            await context.CodecNoContext.DecodeFailureAsync(
                                 job.ResolveNexusOperation.Result.TimedOut).
                                 ConfigureAwait(false);
                         }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.ResolveNexusOperationStart:
-                        if (job.ResolveNexusOperationStart.Failed != null)
+                        // TODO(cretz): Support Nexus serialization context
+                        if (job.ResolveNexusOperationStart.Failed != null
+                            && context.CodecNoContext != null)
                         {
-                            await codec.DecodeFailureAsync(
+                            await context.CodecNoContext.DecodeFailureAsync(
                                 job.ResolveNexusOperationStart.Failed).
                                 ConfigureAwait(false);
                         }
@@ -140,49 +161,221 @@ namespace Temporalio.Worker
                         if (job.ResolveRequestCancelExternalWorkflow.Failure != null)
                         {
                             // Apply external workflow context
-                            var extCanCodec = codec;
-                            if (codec is IWithSerializationContext<IPayloadCodec> withExtCan &&
-                                codecContext.Instance?.GetPendingExternalCancelSerializationContext(job.ResolveRequestCancelExternalWorkflow.Seq) is { } extCanContext)
+                            var extCanCodec = context.CodecNoContext;
+                            if (extCanCodec is IWithSerializationContext<IPayloadCodec> withExtCan &&
+                                context.Instance?.GetPendingExternalCancelSerializationContext(job.ResolveRequestCancelExternalWorkflow.Seq) is { } extCanContext)
                             {
                                 extCanCodec = withExtCan.WithSerializationContext(extCanContext);
                             }
-                            await extCanCodec.DecodeFailureAsync(
-                                job.ResolveRequestCancelExternalWorkflow.Failure).
-                                ConfigureAwait(false);
+                            if (extCanCodec != null)
+                            {
+                                await extCanCodec.DecodeFailureAsync(
+                                    job.ResolveRequestCancelExternalWorkflow.Failure).
+                                    ConfigureAwait(false);
+                            }
                         }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.ResolveSignalExternalWorkflow:
                         if (job.ResolveSignalExternalWorkflow.Failure != null)
                         {
                             // Apply external workflow context
-                            var extSigCodec = codec;
-                            if (codec is IWithSerializationContext<IPayloadCodec> withExtSig &&
-                                codecContext.Instance?.GetPendingExternalSignalSerializationContext(job.ResolveSignalExternalWorkflow.Seq) is { } extSigContext)
+                            var extSigCodec = context.CodecNoContext;
+                            if (extSigCodec is IWithSerializationContext<IPayloadCodec> withExtSig &&
+                                context.Instance?.GetPendingExternalSignalSerializationContext(job.ResolveSignalExternalWorkflow.Seq) is { } extSigContext)
                             {
                                 extSigCodec = withExtSig.WithSerializationContext(extSigContext);
                             }
-                            await extSigCodec.DecodeFailureAsync(
-                                job.ResolveSignalExternalWorkflow.Failure).
-                                ConfigureAwait(false);
+                            if (extSigCodec != null)
+                            {
+                                await extSigCodec.DecodeFailureAsync(
+                                    job.ResolveSignalExternalWorkflow.Failure).
+                                    ConfigureAwait(false);
+                            }
                         }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.SignalWorkflow:
-                        await DecodeAsync(codec, job.SignalWorkflow.Input).ConfigureAwait(false);
-                        await DecodeAsync(codec, job.SignalWorkflow.Headers).ConfigureAwait(false);
+                        if (context.CodecWorkflowContext != null)
+                        {
+                            await DecodeAsync(context.CodecWorkflowContext, job.SignalWorkflow.Input).ConfigureAwait(false);
+                            await DecodeAsync(context.CodecWorkflowContext, job.SignalWorkflow.Headers).ConfigureAwait(false);
+                        }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.InitializeWorkflow:
-                        await DecodeAsync(codec, job.InitializeWorkflow).ConfigureAwait(false);
+                        if (context.CodecWorkflowContext != null)
+                        {
+                            await DecodeAsync(context.CodecWorkflowContext, job.InitializeWorkflow).ConfigureAwait(false);
+                        }
                         break;
                 }
             }
         }
 
-        private static async Task EncodeAsync(
-            IPayloadCodec codec,
-            WorkflowCodecContext codecContext,
-            WorkflowCommand cmd)
+        private static async Task EncodeAsync(WorkflowCodecContext context, WorkflowCommand cmd)
         {
-            if (cmd.UserMetadata != null)
+            // We capture the codec from this switch because user metadata needs it below
+            IPayloadCodec? codec;
+            switch (cmd.VariantCase)
+            {
+                case WorkflowCommand.VariantOneofCase.CompleteWorkflowExecution:
+                    codec = context.CodecWorkflowContext;
+                    if (cmd.CompleteWorkflowExecution.Result != null && codec != null)
+                    {
+                        await EncodeAsync(
+                            codec, cmd.CompleteWorkflowExecution.Result).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.ContinueAsNewWorkflowExecution:
+                    codec = context.CodecWorkflowContext;
+                    if (codec != null)
+                    {
+                        await EncodeAsync(
+                                codec, cmd.ContinueAsNewWorkflowExecution.Arguments).ConfigureAwait(false);
+                        await EncodeAsync(
+                            codec, cmd.ContinueAsNewWorkflowExecution.Memo).ConfigureAwait(false);
+                        await EncodeAsync(
+                            codec, cmd.ContinueAsNewWorkflowExecution.Headers).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.FailWorkflowExecution:
+                    codec = context.CodecWorkflowContext;
+                    if (cmd.FailWorkflowExecution.Failure != null && codec != null)
+                    {
+                        await codec.EncodeFailureAsync(
+                            cmd.FailWorkflowExecution.Failure).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.ModifyWorkflowProperties:
+                    codec = context.CodecWorkflowContext;
+                    if (cmd.ModifyWorkflowProperties.UpsertedMemo != null && codec != null)
+                    {
+                        await EncodeAsync(
+                            codec, cmd.ModifyWorkflowProperties.UpsertedMemo.Fields).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.RespondToQuery:
+                    codec = context.CodecWorkflowContext;
+                    if (cmd.RespondToQuery.Failed != null && codec != null)
+                    {
+                        await codec.EncodeFailureAsync(
+                            cmd.RespondToQuery.Failed).ConfigureAwait(false);
+                    }
+                    else if (cmd.RespondToQuery.Succeeded?.Response != null && codec != null)
+                    {
+                        await EncodeAsync(
+                            codec, cmd.RespondToQuery.Succeeded.Response).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.ScheduleActivity:
+                    // Apply activity context
+                    codec = context.CodecNoContext;
+                    if (codec is IWithSerializationContext<IPayloadCodec> withAct)
+                    {
+                        codec = withAct.WithSerializationContext(
+                            new ISerializationContext.Activity(
+                                Namespace: context.Namespace,
+                                WorkflowId: context.WorkflowId,
+                                WorkflowType: context.WorkflowType,
+                                ActivityType: cmd.ScheduleActivity.ActivityType,
+                                ActivityTaskQueue: cmd.ScheduleActivity.TaskQueue ?? context.TaskQueue,
+                                IsLocal: false));
+                    }
+                    if (codec != null)
+                    {
+                        await EncodeAsync(codec, cmd.ScheduleActivity.Arguments).ConfigureAwait(false);
+                        await EncodeAsync(codec, cmd.ScheduleActivity.Headers).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.ScheduleLocalActivity:
+                    // Apply activity context
+                    codec = context.CodecNoContext;
+                    if (codec is IWithSerializationContext<IPayloadCodec> withLocalAct)
+                    {
+                        codec = withLocalAct.WithSerializationContext(
+                            new ISerializationContext.Activity(
+                                Namespace: context.Namespace,
+                                WorkflowId: context.WorkflowId,
+                                WorkflowType: context.WorkflowType,
+                                ActivityType: cmd.ScheduleLocalActivity.ActivityType,
+                                ActivityTaskQueue: context.TaskQueue,
+                                IsLocal: true));
+                    }
+                    if (codec != null)
+                    {
+                        await EncodeAsync(
+                            codec, cmd.ScheduleLocalActivity.Arguments).ConfigureAwait(false);
+                        await EncodeAsync(
+                            codec, cmd.ScheduleLocalActivity.Headers).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.SignalExternalWorkflowExecution:
+                    // Apply external workflow context
+                    codec = context.CodecNoContext;
+                    if (codec is IWithSerializationContext<IPayloadCodec> withExtSigContext)
+                    {
+                        var workflowId = cmd.SignalExternalWorkflowExecution.HasChildWorkflowId ?
+                            cmd.SignalExternalWorkflowExecution.ChildWorkflowId :
+                            cmd.SignalExternalWorkflowExecution.WorkflowExecution.WorkflowId;
+                        codec = withExtSigContext.WithSerializationContext(
+                            new ISerializationContext.Workflow(
+                                Namespace: context.Namespace,
+                                WorkflowId: workflowId));
+                    }
+                    if (codec != null)
+                    {
+                        await EncodeAsync(
+                            codec, cmd.SignalExternalWorkflowExecution.Args).ConfigureAwait(false);
+                        await EncodeAsync(
+                            codec, cmd.SignalExternalWorkflowExecution.Headers).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.ScheduleNexusOperation:
+                    // TODO(cretz): Support Nexus serialization context
+                    codec = context.CodecNoContext;
+                    if (cmd.ScheduleNexusOperation.Input != null && codec != null)
+                    {
+                        await EncodeAsync(
+                            codec, cmd.ScheduleNexusOperation.Input).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.StartChildWorkflowExecution:
+                    // Apply child workflow context
+                    codec = context.CodecNoContext;
+                    if (codec is IWithSerializationContext<IPayloadCodec> withChild)
+                    {
+                        codec = withChild.WithSerializationContext(
+                            new ISerializationContext.Workflow(
+                                Namespace: context.Namespace,
+                                WorkflowId: cmd.StartChildWorkflowExecution.WorkflowId));
+                    }
+                    if (codec != null)
+                    {
+                        await EncodeAsync(
+                            codec, cmd.StartChildWorkflowExecution.Input).ConfigureAwait(false);
+                        await EncodeAsync(
+                            codec, cmd.StartChildWorkflowExecution.Memo).ConfigureAwait(false);
+                        await EncodeAsync(
+                            codec, cmd.StartChildWorkflowExecution.Headers).ConfigureAwait(false);
+                    }
+                    break;
+                case WorkflowCommand.VariantOneofCase.StartTimer:
+                    codec = context.CodecWorkflowContext;
+                    break;
+                case WorkflowCommand.VariantOneofCase.UpdateResponse:
+                    codec = context.CodecWorkflowContext;
+                    if (cmd.UpdateResponse.Completed is { } updateCompleted && codec != null)
+                    {
+                        await EncodeAsync(codec, updateCompleted).ConfigureAwait(false);
+                    }
+                    else if (cmd.UpdateResponse.Rejected is { } updateRejected && codec != null)
+                    {
+                        await codec.EncodeFailureAsync(updateRejected).ConfigureAwait(false);
+                    }
+                    break;
+                default:
+                    codec = context.CodecWorkflowContext;
+                    break;
+            }
+            if (cmd.UserMetadata != null && codec != null)
             {
                 if (cmd.UserMetadata.Summary != null)
                 {
@@ -192,140 +385,6 @@ namespace Temporalio.Worker
                 {
                     await EncodeAsync(codec, cmd.UserMetadata.Details).ConfigureAwait(false);
                 }
-            }
-            switch (cmd.VariantCase)
-            {
-                case WorkflowCommand.VariantOneofCase.CompleteWorkflowExecution:
-                    if (cmd.CompleteWorkflowExecution.Result != null)
-                    {
-                        await EncodeAsync(
-                            codec, cmd.CompleteWorkflowExecution.Result).ConfigureAwait(false);
-                    }
-                    break;
-                case WorkflowCommand.VariantOneofCase.ContinueAsNewWorkflowExecution:
-                    await EncodeAsync(
-                        codec, cmd.ContinueAsNewWorkflowExecution.Arguments).ConfigureAwait(false);
-                    await EncodeAsync(
-                        codec, cmd.ContinueAsNewWorkflowExecution.Memo).ConfigureAwait(false);
-                    await EncodeAsync(
-                        codec, cmd.ContinueAsNewWorkflowExecution.Headers).ConfigureAwait(false);
-                    break;
-                case WorkflowCommand.VariantOneofCase.FailWorkflowExecution:
-                    if (cmd.FailWorkflowExecution.Failure != null)
-                    {
-                        await codec.EncodeFailureAsync(
-                            cmd.FailWorkflowExecution.Failure).ConfigureAwait(false);
-                    }
-                    break;
-                case WorkflowCommand.VariantOneofCase.ModifyWorkflowProperties:
-                    if (cmd.ModifyWorkflowProperties.UpsertedMemo != null)
-                    {
-                        await EncodeAsync(
-                            codec, cmd.ModifyWorkflowProperties.UpsertedMemo.Fields).ConfigureAwait(false);
-                    }
-                    break;
-                case WorkflowCommand.VariantOneofCase.RespondToQuery:
-                    if (cmd.RespondToQuery.Failed != null)
-                    {
-                        await codec.EncodeFailureAsync(
-                            cmd.RespondToQuery.Failed).ConfigureAwait(false);
-                    }
-                    else if (cmd.RespondToQuery.Succeeded?.Response != null)
-                    {
-                        await EncodeAsync(
-                            codec, cmd.RespondToQuery.Succeeded.Response).ConfigureAwait(false);
-                    }
-                    break;
-                case WorkflowCommand.VariantOneofCase.ScheduleActivity:
-                    // Apply activity context
-                    var actCodec = codec;
-                    if (codec is IWithSerializationContext<IPayloadCodec> withAct)
-                    {
-                        actCodec = withAct.WithSerializationContext(
-                            new ISerializationContext.Activity(
-                                Namespace: codecContext.Namespace,
-                                WorkflowId: codecContext.WorkflowId,
-                                WorkflowType: codecContext.WorkflowType,
-                                ActivityType: cmd.ScheduleActivity.ActivityType,
-                                ActivityTaskQueue: cmd.ScheduleActivity.TaskQueue ?? codecContext.TaskQueue,
-                                IsLocal: false));
-                    }
-                    await EncodeAsync(actCodec, cmd.ScheduleActivity.Arguments).ConfigureAwait(false);
-                    await EncodeAsync(actCodec, cmd.ScheduleActivity.Headers).ConfigureAwait(false);
-                    break;
-                case WorkflowCommand.VariantOneofCase.ScheduleLocalActivity:
-                    // Apply activity context
-                    var localActCodec = codec;
-                    if (codec is IWithSerializationContext<IPayloadCodec> withLocalAct)
-                    {
-                        localActCodec = withLocalAct.WithSerializationContext(
-                            new ISerializationContext.Activity(
-                                Namespace: codecContext.Namespace,
-                                WorkflowId: codecContext.WorkflowId,
-                                WorkflowType: codecContext.WorkflowType,
-                                ActivityType: cmd.ScheduleLocalActivity.ActivityType,
-                                ActivityTaskQueue: codecContext.TaskQueue,
-                                IsLocal: true));
-                    }
-                    await EncodeAsync(
-                        localActCodec, cmd.ScheduleLocalActivity.Arguments).ConfigureAwait(false);
-                    await EncodeAsync(
-                        localActCodec, cmd.ScheduleLocalActivity.Headers).ConfigureAwait(false);
-                    break;
-                case WorkflowCommand.VariantOneofCase.SignalExternalWorkflowExecution:
-                    // Apply external workflow context
-                    var extSigCodec = codec;
-                    if (codec is IWithSerializationContext<IPayloadCodec> withExtSigContext)
-                    {
-                        var workflowId = cmd.SignalExternalWorkflowExecution.HasChildWorkflowId ?
-                            cmd.SignalExternalWorkflowExecution.ChildWorkflowId :
-                            cmd.SignalExternalWorkflowExecution.WorkflowExecution.WorkflowId;
-                        extSigCodec = withExtSigContext.WithSerializationContext(
-                            new ISerializationContext.Workflow(
-                                Namespace: codecContext.Namespace,
-                                WorkflowId: workflowId));
-                    }
-                    await EncodeAsync(
-                        extSigCodec, cmd.SignalExternalWorkflowExecution.Args).ConfigureAwait(false);
-                    await EncodeAsync(
-                        extSigCodec, cmd.SignalExternalWorkflowExecution.Headers).ConfigureAwait(false);
-                    break;
-                case WorkflowCommand.VariantOneofCase.ScheduleNexusOperation:
-                    if (cmd.ScheduleNexusOperation.Input != null)
-                    {
-                        await EncodeAsync(
-                                codec, cmd.ScheduleNexusOperation.Input).ConfigureAwait(false);
-                    }
-                    break;
-                case WorkflowCommand.VariantOneofCase.StartChildWorkflowExecution:
-                    // Apply child workflow context
-                    var childCodec = codec;
-                    if (codec is IWithSerializationContext<IPayloadCodec> withChild)
-                    {
-                        childCodec = withChild.WithSerializationContext(
-                            new ISerializationContext.Workflow(
-                                Namespace: codecContext.Namespace,
-                                WorkflowId: cmd.StartChildWorkflowExecution.WorkflowId));
-                    }
-                    await EncodeAsync(
-                        childCodec, cmd.StartChildWorkflowExecution.Input).ConfigureAwait(false);
-                    await EncodeAsync(
-                        childCodec, cmd.StartChildWorkflowExecution.Memo).ConfigureAwait(false);
-                    await EncodeAsync(
-                        childCodec, cmd.StartChildWorkflowExecution.Headers).ConfigureAwait(false);
-                    break;
-                case WorkflowCommand.VariantOneofCase.StartTimer:
-                    break;
-                case WorkflowCommand.VariantOneofCase.UpdateResponse:
-                    if (cmd.UpdateResponse.Completed is { } updateCompleted)
-                    {
-                        await EncodeAsync(codec, updateCompleted).ConfigureAwait(false);
-                    }
-                    else if (cmd.UpdateResponse.Rejected is { } updateRejected)
-                    {
-                        await codec.EncodeFailureAsync(updateRejected).ConfigureAwait(false);
-                    }
-                    break;
             }
         }
 
@@ -479,6 +538,8 @@ namespace Temporalio.Worker
         }
 
         internal record WorkflowCodecContext(
+            IPayloadCodec? CodecNoContext,
+            IPayloadCodec? CodecWorkflowContext,
             string Namespace,
             string WorkflowId,
             string WorkflowType,

--- a/src/Temporalio/Worker/WorkflowInstanceDetails.cs
+++ b/src/Temporalio/Worker/WorkflowInstanceDetails.cs
@@ -17,8 +17,10 @@ namespace Temporalio.Worker
     /// <param name="InitialActivation">Initial activation for the workflow.</param>
     /// <param name="Init">Start attributes for the workflow.</param>
     /// <param name="Interceptors">Interceptors.</param>
-    /// <param name="PayloadConverter">Payload converter.</param>
-    /// <param name="FailureConverter">Failure converter.</param>
+    /// <param name="PayloadConverterNoContext">Payload converter with no context.</param>
+    /// <param name="PayloadConverterWorkflowContext">Payload converter with workflow context.</param>
+    /// <param name="FailureConverterNoContext">Failure converter with no context.</param>
+    /// <param name="FailureConverterWorkflowContext">Failure converter with workflow context.</param>
     /// <param name="LoggerFactory">Logger factory.</param>
     /// <param name="DisableTracingEvents">Whether tracing events are disabled.</param>
     /// <param name="WorkflowStackTrace">Option for workflow stack trace.</param>
@@ -35,8 +37,10 @@ namespace Temporalio.Worker
         WorkflowActivation InitialActivation,
         InitializeWorkflow Init,
         IReadOnlyCollection<Interceptors.IWorkerInterceptor> Interceptors,
-        IPayloadConverter PayloadConverter,
-        IFailureConverter FailureConverter,
+        IPayloadConverter PayloadConverterNoContext,
+        IPayloadConverter PayloadConverterWorkflowContext,
+        IFailureConverter FailureConverterNoContext,
+        IFailureConverter FailureConverterWorkflowContext,
         ILoggerFactory LoggerFactory,
         bool DisableTracingEvents,
         WorkflowStackTrace WorkflowStackTrace,

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -182,6 +182,10 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Gets the payload converter for the workflow.
         /// </summary>
+        /// <remarks>
+        /// If the original converter supported serialization contexts, this is the converter with
+        /// the workflow serialization context applied.
+        /// </remarks>
         public static IPayloadConverter PayloadConverter => Context.PayloadConverter;
 
         /// <summary>

--- a/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
@@ -17,13 +17,6 @@ public class WorkflowCodecHelperTests : TestBase
     {
     }
 
-    internal static WorkflowCodecHelper.WorkflowCodecContext SimpleCodecContext { get; } = new(
-        Namespace: "my-namespace",
-        WorkflowId: "my-workflow-id",
-        WorkflowType: "my-workflow-type",
-        TaskQueue: "my-task-queue",
-        Instance: null);
-
     [Fact]
     public async Task CreateAndVisitPayload_Visiting_ReachesAllExpectedValues()
     {
@@ -58,7 +51,7 @@ public class WorkflowCodecHelperTests : TestBase
             Assert.DoesNotContain("encoded", payload().Metadata.Keys);
             foreach (var codec in codecs)
             {
-                await WorkflowCodecHelper.EncodeAsync(codec, SimpleCodecContext, comp);
+                await WorkflowCodecHelper.EncodeAsync(CreateSimpleCodecContext(codec), comp);
                 if (!payload().Metadata.ContainsKey("encoded"))
                 {
                     Assert.Fail($"Payload at path {ctx.Path} not encoded with codec {codec}");
@@ -82,7 +75,7 @@ public class WorkflowCodecHelperTests : TestBase
             Assert.DoesNotContain("decoded", payload().Metadata.Keys);
             foreach (var codec in codecs)
             {
-                await WorkflowCodecHelper.DecodeAsync(codec, SimpleCodecContext, act);
+                await WorkflowCodecHelper.DecodeAsync(CreateSimpleCodecContext(codec), act);
                 if (!payload().Metadata.ContainsKey("decoded"))
                 {
                     Assert.Fail($"Payload at path {ctx.Path} not decoded with codec {codec}");
@@ -106,10 +99,19 @@ public class WorkflowCodecHelperTests : TestBase
             if (propInfo?.PropertyType == typeof(Payload))
             {
                 propInfo.SetValue(msg, null);
-                await WorkflowCodecHelper.EncodeAsync(codec, SimpleCodecContext, comp);
+                await WorkflowCodecHelper.EncodeAsync(CreateSimpleCodecContext(codec), comp);
             }
         });
     }
+
+    private static WorkflowCodecHelper.WorkflowCodecContext CreateSimpleCodecContext(IPayloadCodec codec) => new(
+        CodecNoContext: codec,
+        CodecWorkflowContext: codec,
+        Namespace: "my-namespace",
+        WorkflowId: "my-workflow-id",
+        WorkflowType: "my-workflow-type",
+        TaskQueue: "my-task-queue",
+        Instance: null);
 
     // Creates payloads as needed, null context if already seen
     private static async Task CreateAndVisitPayload(

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Threading.Tasks.Dataflow;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
+using NexusRpc;
+using NexusRpc.Handlers;
 using Temporalio.Activities;
 using Temporalio.Api.Common.V1;
 using Temporalio.Api.Enums.V1;
@@ -6796,9 +6798,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
 
     public class ContextJsonPlainConverter : JsonPlainConverter, IWithSerializationContext<IEncodingConverter>
     {
-        private readonly ContextInfo contextInfo;
+        private readonly ContextInfo? contextInfo;
 
-        public ContextJsonPlainConverter(ContextInfo contextInfo)
+        public ContextJsonPlainConverter(ContextInfo? contextInfo = null)
             : base(new()) => this.contextInfo = contextInfo;
 
         public IEncodingConverter WithSerializationContext(ISerializationContext context) =>
@@ -6806,7 +6808,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
 
         public override bool TryToPayload(object? value, out Payload? payload)
         {
-            if (value is ContextValue contextValue)
+            // Do not add an event if we're not context specific
+            if (contextInfo != null && value is ContextValue contextValue)
             {
                 contextValue.Events.Add(new(true, contextInfo));
             }
@@ -6816,7 +6819,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         public override object? ToValue(Payload payload, Type type)
         {
             var value = base.ToValue(payload, type);
-            if (value is ContextValue contextValue)
+            // Do not add an event if we're not context specific
+            if (contextInfo != null && value is ContextValue contextValue)
             {
                 contextValue.Events.Add(new(false, contextInfo));
             }
@@ -6826,14 +6830,16 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
 
     public class ContextFailureConverter : DefaultFailureConverter, IWithSerializationContext<IFailureConverter>
     {
-        private readonly ContextInfo contextInfo;
+        private readonly ContextInfo? contextInfo;
 
-        public ContextFailureConverter(ContextInfo contextInfo) => this.contextInfo = contextInfo;
+        public ContextFailureConverter(ContextInfo? contextInfo = null) => this.contextInfo = contextInfo;
 
         public override Failure ToFailure(Exception exception, IPayloadConverter payloadConverter)
         {
             var failure = base.ToFailure(exception, payloadConverter);
-            if (failure.ApplicationFailureInfo != null && !failure.Message.Contains("[activity:"))
+            // Do not adjust the failure if we're not context specific
+            if (contextInfo != null &&
+                failure.ApplicationFailureInfo != null && !failure.Message.Contains("[activity:"))
             {
                 var activity = contextInfo.Activity ? "true" : "false";
                 failure.Message += $" [activity: {activity}, workflow-id: {contextInfo.WorkflowId}]";
@@ -6848,37 +6854,52 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     public class ContextPayloadCodec : IPayloadCodec, IWithSerializationContext<IPayloadCodec>
     {
         public const string EncodingName = "context-encoding";
-        private readonly ContextInfo contextInfo;
+        private readonly ContextInfo? contextInfo;
 
-        public ContextPayloadCodec(ContextInfo contextInfo) => this.contextInfo = contextInfo;
+        public ContextPayloadCodec(ContextInfo? contextInfo = null) => this.contextInfo = contextInfo;
 
-        public Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
-            Task.FromResult<IReadOnlyCollection<Payload>>(payloads.Select(p =>
+        public async Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads)
+        {
+            // If there is no context info, do not add extra metadata
+            var metadata = new Dictionary<string, ByteString>
+            {
+                ["encoding"] = ByteString.CopyFromUtf8(EncodingName),
+            };
+            if (contextInfo != null)
+            {
+                metadata["activity"] = ByteString.CopyFromUtf8(contextInfo.Activity ? "true" : "false");
+                metadata["workflow-id"] = ByteString.CopyFromUtf8(contextInfo.WorkflowId);
+            }
+            return payloads.Select(p =>
                 new Payload()
                 {
                     Data = ByteString.CopyFrom(
                         Convert.ToBase64String(p.ToByteArray()),
                         Encoding.ASCII),
-                    Metadata =
-                    {
-                        new Dictionary<string, ByteString>
-                        {
-                            ["encoding"] = ByteString.CopyFromUtf8(EncodingName),
-                            ["activity"] = ByteString.CopyFromUtf8(contextInfo.Activity ? "true" : "false"),
-                            ["workflow-id"] = ByteString.CopyFromUtf8(contextInfo.WorkflowId),
-                        },
-                    },
-                }).ToList());
+                    Metadata = { metadata },
+                }).ToList();
+        }
 
-        public Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads) =>
-            Task.FromResult<IReadOnlyCollection<Payload>>(payloads.Select(p =>
+        public async Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads)
+        {
+            return payloads.Select(p =>
             {
                 Assert.Equal(EncodingName, p.Metadata["encoding"].ToStringUtf8());
-                Assert.Equal(contextInfo.Activity, p.Metadata["activity"].ToStringUtf8() == "true");
-                Assert.Equal(contextInfo.WorkflowId, p.Metadata["workflow-id"].ToStringUtf8());
+                // If there is no context info, this is not context specific
+                if (contextInfo == null)
+                {
+                    Assert.False(p.Metadata.ContainsKey("activity"));
+                    Assert.False(p.Metadata.ContainsKey("workflow-id"));
+                }
+                else
+                {
+                    Assert.Equal(contextInfo.Activity, p.Metadata["activity"].ToStringUtf8() == "true");
+                    Assert.Equal(contextInfo.WorkflowId, p.Metadata["workflow-id"].ToStringUtf8());
+                }
                 return Payload.Parser.ParseFrom(
-                    Convert.FromBase64String(p.Data.ToString(Encoding.ASCII)));
-            }).ToList());
+                        Convert.FromBase64String(p.Data.ToString(Encoding.ASCII)));
+            }).ToList();
+        }
 
         public IPayloadCodec WithSerializationContext(ISerializationContext context) =>
             new ContextPayloadCodec(ContextInfo.Create(context));
@@ -6887,7 +6908,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     public record ContextHistoryExpectation(
         string Name,
         Func<HistoryEvent, Payload?> Predicate,
-        bool Activity = false)
+        bool Activity = false,
+        bool NoContextMetadataExpected = false)
     {
         public async Task AssertInHistoryAsync(WorkflowHistory history)
         {
@@ -6910,8 +6932,16 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 }
                 Assert.NotNull(payload);
                 Assert.Equal(ContextPayloadCodec.EncodingName, payload.Metadata["encoding"].ToStringUtf8());
-                Assert.Equal(Activity ? "true" : "false", payload.Metadata["activity"].ToStringUtf8());
-                Assert.Equal(history.Id, payload.Metadata["workflow-id"].ToStringUtf8());
+                if (NoContextMetadataExpected)
+                {
+                    Assert.False(payload.Metadata.ContainsKey("activity"));
+                    Assert.False(payload.Metadata.ContainsKey("workflow-id"));
+                }
+                else
+                {
+                    Assert.Equal(Activity ? "true" : "false", payload.Metadata["activity"].ToStringUtf8());
+                    Assert.Equal(history.Id, payload.Metadata["workflow-id"].ToStringUtf8());
+                }
             }
             catch (Exception e)
             {
@@ -7050,6 +7080,33 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             });
             throw new CompleteAsyncException();
         }
+
+        [NexusService]
+        public interface INexusService
+        {
+            [NexusOperation]
+            ContextValue DoSomething(ContextValue value);
+        }
+
+        [NexusServiceHandler(typeof(INexusService))]
+        public class NexusService
+        {
+            [NexusOperationHandler]
+            public IOperationHandler<ContextValue, ContextValue> DoSomething() =>
+                OperationHandler.Sync<ContextValue, ContextValue>(
+                    async (_, _) => new("nexus-result", new()));
+        }
+
+        [WorkflowUpdate]
+        public async Task DoNexusOperationAsync(string endpoint)
+        {
+            // Call Nexus and confirm no events are on the value because Nexus doesn't go through
+            // context converters at this time
+            var res = await Workflow.CreateNexusClient<INexusService>(endpoint).
+                ExecuteNexusOperationAsync(svc => svc.DoSomething(new("nexus-input", new())));
+            Assert.Equal("nexus-result", res.Name);
+            Assert.Empty(res.Events);
+        }
     }
 
     [Fact]
@@ -7058,17 +7115,25 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         // It is accepted that this does not test every pemutation of every way a payload converter,
         // failure converter, and codec are used in clients, workflows, and activities.
 
-        // Context-aware data converter
+        // Context-aware data converter and client
         var dataConverter = new DataConverter(
             PayloadConverter: new DefaultPayloadConverter(
                 ((DefaultPayloadConverter)Client.Options.DataConverter.PayloadConverter).EncodingConverters.Select(e =>
-                    e is JsonPlainConverter ? new ContextJsonPlainConverter(new()) : e).ToArray()),
-            FailureConverter: new ContextFailureConverter(new()),
-            PayloadCodec: new ContextPayloadCodec(new()));
+                    e is JsonPlainConverter ? new ContextJsonPlainConverter() : e).ToArray()),
+            FailureConverter: new ContextFailureConverter(),
+            PayloadCodec: new ContextPayloadCodec());
+        var newClientOptions = (TemporalClientOptions)Client.Options.Clone();
+        newClientOptions.DataConverter = dataConverter;
+        var client = new TemporalClient(Client.Connection, newClientOptions);
 
-        var newOptions = (TemporalClientOptions)Client.Options.Clone();
-        newOptions.DataConverter = dataConverter;
-        var client = new TemporalClient(Client.Connection, newOptions);
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new ConverterContextWorkflow.NexusService()).
+            AddAllActivities<ConverterContextWorkflow>(null);
+
+        // Nexus endpoint
+        var nexusEndpointName = $"nexus-endpoint-{workerOptions.TaskQueue}";
+        var nexusEndpoint = await Env.TestEnv.CreateNexusEndpointAsync(
+            nexusEndpointName, workerOptions.TaskQueue!);
 
         await ExecuteWorkerAsync<ConverterContextWorkflow>(
             async worker =>
@@ -7151,6 +7216,17 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                     e => e.ActivityTaskCompletedEventAttributes?.Result?.Payloads_?.FirstOrDefault(),
                     Activity: true));
 
+                // Nexus service call
+                await handle.ExecuteUpdateAsync(wf => wf.DoNexusOperationAsync(nexusEndpointName));
+                historyExpects.Add(new(
+                    "nexus-input",
+                    e => e.NexusOperationScheduledEventAttributes?.Input,
+                    NoContextMetadataExpected: true));
+                historyExpects.Add(new(
+                    "nexus-result",
+                    e => e.NexusOperationCompletedEventAttributes?.Result,
+                    NoContextMetadataExpected: true));
+
                 // Complete, check result
                 await handle.SignalAsync(wf => wf.CompleteAsync());
                 res = await handle.GetResultAsync();
@@ -7163,8 +7239,10 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                     await historyExpect.AssertInHistoryAsync(history);
                 }
             },
-            new TemporalWorkerOptions().AddAllActivities<ConverterContextWorkflow>(null),
+            workerOptions,
             client);
+
+        await Env.TestEnv.DeleteNexusEndpointAsync(nexusEndpoint);
     }
 
     [Workflow]


### PR DESCRIPTION
## What was changed

Previously, we applied context-based codecs/converters to everything a workflow does, and then if a workflow _also_ did anything needing more context (e.g. activity or child workflow calls), we applied a context on top of that. Per #523, this was an incorrect approach. We need to apply contexts only in serialization/deserialization situations where the exact same context can be applied on the other side with deserialization/serialization.

There are no test adjustments for this PR because the test coverage from #446 still applies, this just affects the edge case of stacking the codecs/converters.

This is a 💥 breaking change _technically_ because in situations where we used a specific context on top of outer-workflow context before (e.g. working with activity or child), we only apply the specific context now instead. This will only affect users with custom codecs/converters that support serialization contexts and built an expectation on the workflow-context one to be used for _everything_ in a workflow.

## Checklist

1. Closes #523
2. Closes #519