### PR TITLE
Remove experimental notices from worker tuner APIs

### DIFF
--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -342,9 +342,6 @@ namespace Temporalio.Worker
         /// cref="MaxConcurrentActivities"/>, <see cref="MaxConcurrentWorkflowTasks"/> and <see
         /// cref="MaxConcurrentLocalActivities"/>.
         /// </summary>
-        /// <remarks>
-        /// WARNING: WorkerTuners are experimental.
-        /// </remarks>
         public WorkerTuner? Tuner { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Worker/Tuning/CustomSlotSupplier.cs
+++ b/src/Temporalio/Worker/Tuning/CustomSlotSupplier.cs
@@ -7,9 +7,6 @@ namespace Temporalio.Worker.Tuning
     /// <summary>
     /// This class can be implemented to provide custom slot supplier behavior.
     /// </summary>
-    /// <remarks>
-    /// WARNING: Custom slot suppliers are currently experimental.
-    /// </remarks>
     public abstract class CustomSlotSupplier : SlotSupplier
     {
         /// <summary>

--- a/src/Temporalio/Worker/Tuning/ResourceBasedSlotSupplier.cs
+++ b/src/Temporalio/Worker/Tuning/ResourceBasedSlotSupplier.cs
@@ -3,9 +3,6 @@ namespace Temporalio.Worker.Tuning
     /// <summary>
     /// A slot supplier that will dynamically adjust the number of slots based on resource usage.
     /// </summary>
-    /// <remarks>
-    /// WARNING: Resource based tuning is currently experimental.
-    /// </remarks>
     public sealed class ResourceBasedSlotSupplier : SlotSupplier
     {
         /// <summary>

--- a/src/Temporalio/Worker/Tuning/ResourceBasedSlotSupplierOptions.cs
+++ b/src/Temporalio/Worker/Tuning/ResourceBasedSlotSupplierOptions.cs
@@ -16,9 +16,6 @@ namespace Temporalio.Worker.Tuning
     /// time, and thus the system should wait to see how much resources are used before issuing more
     /// slots.
     /// </param>
-    /// <remarks>
-    /// WARNING: Resource based tuning is currently experimental.
-    /// </remarks>
     public sealed record ResourceBasedSlotSupplierOptions(
         int? MinimumSlots = null,
         int? MaximumSlots = null,

--- a/src/Temporalio/Worker/Tuning/ResourceBasedTunerOptions.cs
+++ b/src/Temporalio/Worker/Tuning/ResourceBasedTunerOptions.cs
@@ -10,9 +10,6 @@ namespace Temporalio.Worker.Tuning
     /// <param name="TargetCpuUsage">A value between 0 and 1 that represents the target (system)
     /// CPU usage. This can be set to 1.0 if desired, but it's recommended to leave some
     /// headroom for other processes.</param>
-    /// <remarks>
-    /// WARNING: Resource based tuning is currently experimental.
-    /// </remarks>
     public sealed record ResourceBasedTunerOptions(
         double TargetMemoryUsage,
         double TargetCpuUsage);

--- a/src/Temporalio/Worker/Tuning/SlotInfo.cs
+++ b/src/Temporalio/Worker/Tuning/SlotInfo.cs
@@ -3,9 +3,6 @@ namespace Temporalio.Worker.Tuning
     /// <summary>
     /// Info about a task slot usage.
     /// </summary>
-    /// <remarks>
-    /// WARNING: Custom slot suppliers are currently experimental.
-    /// </remarks>
     public record SlotInfo
     {
         private SlotInfo()

--- a/src/Temporalio/Worker/Tuning/SlotMarkUsedContext.cs
+++ b/src/Temporalio/Worker/Tuning/SlotMarkUsedContext.cs
@@ -6,9 +6,6 @@ namespace Temporalio.Worker.Tuning
     /// <param name="SlotInfo">Info about the task that will be using the slot.</param>
     /// <param name="Permit">The permit that was issued when the slot was reserved.</param>
     /// <remarks>
-    /// WARNING: Custom slot suppliers are currently experimental.
-    /// </remarks>
-    /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>

--- a/src/Temporalio/Worker/Tuning/SlotPermit.cs
+++ b/src/Temporalio/Worker/Tuning/SlotPermit.cs
@@ -4,9 +4,6 @@ namespace Temporalio.Worker.Tuning
     /// A permit to use a slot for a workflow/activity/local activity task. This class can be
     /// extended if desired.
     /// </summary>
-    /// <remarks>
-    /// WARNING: Custom slot suppliers are currently experimental.
-    /// </remarks>
     public class SlotPermit
     {
         /// <summary>

--- a/src/Temporalio/Worker/Tuning/SlotReleaseContext.cs
+++ b/src/Temporalio/Worker/Tuning/SlotReleaseContext.cs
@@ -6,9 +6,6 @@ namespace Temporalio.Worker.Tuning
     /// <param name="SlotInfo">Info about the task that will be using the slot. May be null if the slot was never used.</param>
     /// <param name="Permit">The permit that was issued when the slot was reserved.</param>
     /// <remarks>
-    /// WARNING: Custom slot suppliers are currently experimental.
-    /// </remarks>
-    /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>

--- a/src/Temporalio/Worker/Tuning/SlotReserveContext.cs
+++ b/src/Temporalio/Worker/Tuning/SlotReserveContext.cs
@@ -9,9 +9,6 @@ namespace Temporalio.Worker.Tuning
     /// <param name="WorkerBuildId">The build id of the worker that is requesting the reservation.</param>
     /// <param name="IsSticky">True iff this is a reservation for a sticky poll for a workflow task.</param>
     /// <remarks>
-    /// WARNING: Custom slot suppliers are currently experimental.
-    /// </remarks>
-    /// <remarks>
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>

--- a/src/Temporalio/Worker/Tuning/WorkerTuner.cs
+++ b/src/Temporalio/Worker/Tuning/WorkerTuner.cs
@@ -66,9 +66,6 @@ namespace Temporalio.Worker.Tuning
         /// <param name="localActivityOptions">Options for the local activity slot supplier.</param>
         /// <param name="nexusOptions">Options for the Nexus operation slot supplier.</param>
         /// <returns>The tuner.</returns>
-        /// <remarks>
-        /// WARNING: Resource based tuning is currently experimental.
-        /// </remarks>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
         public static WorkerTuner CreateResourceBased(
             double targetMemoryUsage,


### PR DESCRIPTION
## Summary
- remove experimental warnings from worker tuner APIs, including resource-based tuners and worker options

------
https://chatgpt.com/codex/tasks/task_b_68e94e90e43c833191eda1fa6f353bce