### PR TITLE
Nexus release seemed to forget to AddNexusService in extensions

### DIFF
--- a/src/Temporalio.Extensions.Hosting/README.md
+++ b/src/Temporalio.Extensions.Hosting/README.md
@@ -85,6 +85,8 @@ For registering workflows on the worker, `AddWorkflow` extension method is avail
 collection because the construction and lifecycle of workflows is managed by Temporal. Dependency injection for
 workflows is intentionally not supported.
 
+The `AddNexusService` extension method is also available. 
+
 Other worker and client options can be configured on the builder via the `ConfigureOptions` extension method. With no
 parameters, this returns an `OptionsBuilder<TemporalWorkerServiceOptions>` to use. When provided an action, the options
 are available as parameters that can be configured. `TemporalWorkerServiceOptions` simply extends

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
@@ -165,6 +165,16 @@ namespace Temporalio.Extensions.Hosting
             builder.ConfigureOptions(options => options.AddWorkflow(type));
 
         /// <summary>
+        /// Add the given Nexus service on this worker service.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="serviceHandler">Service handler.</param>
+        /// <returns>Same builder instance.</returns>
+        public static ITemporalWorkerServiceOptionsBuilder AddNexusService(
+            this ITemporalWorkerServiceOptionsBuilder builder, object serviceHandler) =>
+            builder.ConfigureOptions(options => options.AddNexusService(serviceHandler));
+
+        /// <summary>
         /// Get an options builder to configure worker service options.
         /// </summary>
         /// <param name="builder">Builder to use.</param>


### PR DESCRIPTION
## What was changed
Support AddNexusService same as other worker `Add` calls for convenience.
## Why?
Because digging into `ConfigureOptions` isn't as obvious and we already expose AddX calls in other places. This makes things consistent.

3. Any docs updates needed?
The Extensions project README.md was updated to use `AddNexusService`. 

## Concerns

Ideally, we could use the service provider to register these services instead of forcing ctor while registering...something like:
```
builder.AddNexusService<IHasANexii>()
``` 

I couldn't see a clear way to do this without the terrible pattern:
```
var serviceProvider = services.BuildServiceProvider();
var nexusService = serviceProvider.GetService<IHasANexii>();
```

Any other ideas we can try to make this more container friendly?