### PR TITLE
Remove erroneous `Temporalio.Workflows.NexusOperationOptions.OperationName`

### DIFF
--- a/src/Temporalio/Workflows/NexusOperationOptions.cs
+++ b/src/Temporalio/Workflows/NexusOperationOptions.cs
@@ -10,11 +10,6 @@ namespace Temporalio.Workflows
     public class NexusOperationOptions : ICloneable
     {
         /// <summary>
-        /// Gets or sets the operation name.
-        /// </summary>
-        public string? OperationName { get; set; }
-
-        /// <summary>
         /// Gets or sets the schedule to close timeout.
         /// </summary>
         public TimeSpan? ScheduleToCloseTimeout { get; set; }


### PR DESCRIPTION
## What was changed

Remove name property from Nexus caller options that is clearly part of Nexus call signature

## Checklist

1. Closes #537