### PR TITLE
💥 BREAKING CHANGE - Move EnvConfig from Client to Common

### DIFF
--- a/src/Temporalio/Bridge/EnvConfig.cs
+++ b/src/Temporalio/Bridge/EnvConfig.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Temporalio.Client.EnvConfig;
+using Temporalio.Common.EnvConfig;
 
 namespace Temporalio.Bridge
 {

--- a/src/Temporalio/Common/EnvConfig/ClientEnvConfig.cs
+++ b/src/Temporalio/Common/EnvConfig/ClientEnvConfig.cs
@@ -2,8 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Temporalio.Client;
 
-namespace Temporalio.Client.EnvConfig
+namespace Temporalio.Common.EnvConfig
 {
     /// <summary>
     /// Represents the overall client configuration.

--- a/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
+++ b/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
@@ -1,8 +1,8 @@
-using Temporalio.Client.EnvConfig;
+using Temporalio.Common.EnvConfig;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Temporalio.Tests.Client.EnvConfig
+namespace Temporalio.Tests.Common.EnvConfig
 {
     /// <summary>
     /// Environment configuration tests following Python/TypeScript patterns for cross-SDK consistency.


### PR DESCRIPTION
## What was changed

Move `ClientEnvConfig` from `Temporalio.Client.EnvConfig` to `Temporalio.Common.EnvConfig` to match other SDKs.

This is a 💥 BREAKING CHANGE, but it only affects an experimental feature.

## Checklist

1. Closes #543