### PR TITLE
Fixed Temporalio.Bridge.Scope leaking cancellation tokens

### DIFF
--- a/src/Temporalio/Bridge/CancellationToken.cs
+++ b/src/Temporalio/Bridge/CancellationToken.cs
@@ -4,16 +4,17 @@ using System.Runtime.InteropServices;
 namespace Temporalio.Bridge
 {
     /// <summary>
-    /// Core-owned cancellation token.
+    /// Core-owned cancellation token that's bound to the given .NET cancellation token.
     /// </summary>
     internal class CancellationToken : SafeHandle
     {
-        private System.Threading.CancellationTokenRegistration? registration;
+        private readonly System.Threading.CancellationTokenRegistration registration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CancellationToken"/> class.
         /// </summary>
-        public CancellationToken()
+        /// <param name="token">.NET cancellation token to bind.</param>
+        public CancellationToken(System.Threading.CancellationToken token)
             : base(IntPtr.Zero, true)
         {
             unsafe
@@ -21,6 +22,7 @@ namespace Temporalio.Bridge
                 Ptr = Interop.Methods.temporal_core_cancellation_token_new();
                 SetHandle((IntPtr)Ptr);
             }
+            registration = token.Register(Cancel);
         }
 
         /// <inheritdoc/>
@@ -32,20 +34,12 @@ namespace Temporalio.Bridge
         internal unsafe Interop.TemporalCoreCancellationToken* Ptr { get; }
 
         /// <summary>
-        /// Create a core cancellation token from the given cancellation token.
+        /// Cancels the Core-owned token. Does not cancel the bound .NET token.
         /// </summary>
-        /// <param name="token">Threading token.</param>
-        /// <returns>Created cancellation token.</returns>
-        public static CancellationToken FromThreading(System.Threading.CancellationToken token)
-        {
-            var ret = new CancellationToken();
-            ret.registration = token.Register(ret.Cancel);
-            return ret;
-        }
-
-        /// <summary>
-        /// Cancel this token.
-        /// </summary>
+        /// <remarks>
+        /// Cancelling the bound .NET token automatically cancels the Core-owned token,
+        /// but not the other way around.
+        /// </remarks>
         public void Cancel()
         {
             if (!IsClosed)
@@ -60,7 +54,7 @@ namespace Temporalio.Bridge
         /// <inheritdoc/>
         protected override unsafe bool ReleaseHandle()
         {
-            registration?.Dispose();
+            registration.Dispose();
             Interop.Methods.temporal_core_cancellation_token_free(Ptr);
             return true;
         }

--- a/src/Temporalio/Bridge/CancellationToken.cs
+++ b/src/Temporalio/Bridge/CancellationToken.cs
@@ -8,6 +8,8 @@ namespace Temporalio.Bridge
     /// </summary>
     internal class CancellationToken : SafeHandle
     {
+        private System.Threading.CancellationTokenRegistration? registration;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CancellationToken"/> class.
         /// </summary>
@@ -37,7 +39,7 @@ namespace Temporalio.Bridge
         public static CancellationToken FromThreading(System.Threading.CancellationToken token)
         {
             var ret = new CancellationToken();
-            token.Register(ret.Cancel);
+            ret.registration = token.Register(ret.Cancel);
             return ret;
         }
 
@@ -58,6 +60,7 @@ namespace Temporalio.Bridge
         /// <inheritdoc/>
         protected override unsafe bool ReleaseHandle()
         {
+            registration?.Dispose();
             Interop.Methods.temporal_core_cancellation_token_free(Ptr);
             return true;
         }

--- a/src/Temporalio/Bridge/CancellationToken.cs
+++ b/src/Temporalio/Bridge/CancellationToken.cs
@@ -27,7 +27,7 @@ namespace Temporalio.Bridge
         /// <summary>
         /// Gets internal token pointer.
         /// </summary>
-        internal unsafe Interop.TemporalCoreCancellationToken* Ptr { get; private init; }
+        internal unsafe Interop.TemporalCoreCancellationToken* Ptr { get; }
 
         /// <summary>
         /// Create a core cancellation token from the given cancellation token.
@@ -46,9 +46,12 @@ namespace Temporalio.Bridge
         /// </summary>
         public void Cancel()
         {
-            unsafe
+            if (!IsClosed)
             {
-                Interop.Methods.temporal_core_cancellation_token_cancel(Ptr);
+                unsafe
+                {
+                    Interop.Methods.temporal_core_cancellation_token_cancel(Ptr);
+                }
             }
         }
 

--- a/src/Temporalio/Bridge/Scope.cs
+++ b/src/Temporalio/Bridge/Scope.cs
@@ -114,7 +114,7 @@ namespace Temporalio.Bridge
             {
                 return null;
             }
-            var val = Temporalio.Bridge.CancellationToken.FromThreading(token.Value);
+            var val = new CancellationToken(token.Value);
             disposables.Add(val);
             return val.Ptr;
         }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Implemented Dispose pattern in `Temporalio.Bridge.Scope` to correctly release both unmanaged (`GCHandle`) and managed (`CancellationToken`) resources.
- `Temporalio.Bridge.CancellationToken` now unregisters its callback from the associated `System.Threading.CancellationToken` when freeing the handle.

## Why?
<!-- Tell your future self why have you made these changes -->
Fixes memory leak due to undisposed core-owned cancellation tokens.

## Checklist
<!--- add/delete as needed --->

1. Closes #540 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Automated testing is not possible for this bug. Manual testing was done following the "Minimal Reproduction" instructions in the linked issue.