### PR TITLE
VLN-454: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - "releases/*"
+permissions:
+  contents: read
 
 jobs:
   build-lint-test:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # (12 AM PST)
     - cron: "00 07 * * *"
+permissions:
+  contents: read
 
 jobs:
   nightly:

--- a/.github/workflows/omes.yml
+++ b/.github/workflows/omes.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
       - "releases/*"
+permissions:
+  contents: read
 
 jobs:
   omes-image-build:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,6 +5,8 @@ on:
       - main
       - "releases/*"
   workflow_dispatch: {}
+permissions:
+  contents: read
 
 jobs:
   build-bridge-libraries:

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -2,6 +2,8 @@ name: Run Bench
 on:
   workflow_call:
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   run-bench:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added workflow-level permissions block granting contents: read at .github/workflows/ci.yml:8 so setup-protoc and reusable workflow calls run with least-privilege GITHUB_TOKEN; workflow-only edit, no tests executed.
- `.github/workflows/package.yml`: Added contents: read permissions at .github/workflows/package.yml:8 to cover checkout, artifact, and setup-protoc steps without excess token scope; workflow metadata change only, no tests run.
- `.github/workflows/run-bench.yml`: Declared workflow permissions contents: read at .github/workflows/run-bench.yml:5 to limit GITHUB_TOKEN exposure for checkout and setup-protoc when invoked via workflow_call; appended trailing newline.
- `.github/workflows/nightly.yml`: Set permissions: contents: read at .github/workflows/nightly.yml:7 so nightly dispatcher inherits restricted token scope when invoking run-bench; no runtime changes to jobs.
- `.github/workflows/omes.yml`: Introduced workflow-level contents: read permissions at .github/workflows/omes.yml:7 to restrict token used when calling external reusable workflow; no tests required for YAML edit.