### PR TITLE
Add actions-read permission to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
       - "releases/*"
 permissions:
+  actions: read
   contents: read
 
 jobs:


### PR DESCRIPTION
## What was changed

In https://github.com/temporalio/features/pull/693, an `action: read` permission is required that is not present here on the caller of features workflows, so it is needed here too.