### PR TITLE
Accommodate null Address configuration

### DIFF
--- a/src/Temporalio/Common/EnvConfig/ClientEnvConfig.cs
+++ b/src/Temporalio/Common/EnvConfig/ClientEnvConfig.cs
@@ -103,7 +103,7 @@ namespace Temporalio.Common.EnvConfig
             /// <returns>Connection options for a client.</returns>
             public TemporalClientConnectOptions ToClientConnectionOptions()
             {
-                var options = new TemporalClientConnectOptions(Address ?? string.Empty);
+                var options = new TemporalClientConnectOptions() { TargetHost = Address };
                 // Set namespace if provided
                 if (Namespace != null)
                 {

--- a/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
+++ b/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
@@ -53,7 +53,7 @@ client_key_data = ""client-key-data""
         {
         }
 
-        // === PROFILE LOADING TESTS (6 tests) ===
+        // === PROFILE LOADING TESTS (7 tests) ===
         [Fact]
         public void Test_Load_Profile_From_File_Default()
         {
@@ -178,6 +178,22 @@ client_key_data = ""client-key-data""
             Assert.Equal("env-api-key", profile.ApiKey);
             Assert.NotNull(profile.Tls);
             Assert.Equal("env-server-name", profile.Tls.ServerName);
+        }
+
+        [Fact]
+        public void Test_Profile_Null_Address_Preserves_Null_In_Connection_Options()
+        {
+            // Create a profile with no address (null)
+            var profile = new ClientEnvConfig.Profile(
+                Address: null,
+                Namespace: "test-namespace");
+
+            // Convert to connection options
+            var options = profile.ToClientConnectionOptions();
+
+            // TargetHost should be null, not empty string
+            Assert.Null(options.TargetHost);
+            Assert.Equal("test-namespace", options.Namespace);
         }
 
         // === ENVIRONMENT VARIABLES TESTS (4 tests) ===


### PR DESCRIPTION
## What was changed
Change connection option constructor used in envconfig to accommodate null Address configurations.

## Why?
We do not want to use empty strings as address for client configuration...

1. Closes https://github.com/temporalio/sdk-dotnet/issues/559

2. How was this tested:
New test

3. Any docs updates needed?
No?
