### PR TITLE
Add dependency injection support for Nexus services

### DIFF
--- a/src/Temporalio.Extensions.Hosting/README.md
+++ b/src/Temporalio.Extensions.Hosting/README.md
@@ -85,6 +85,18 @@ For registering workflows on the worker, `AddWorkflow` extension method is avail
 collection because the construction and lifecycle of workflows is managed by Temporal. Dependency injection for
 workflows is intentionally not supported.
 
+⚠️WARNING: Nexus support is experimental.
+
+For adding Nexus service handlers to the service collection and registering operations with the worker, the following
+extensions methods exist on the builder each accepting Nexus service handler type:
+
+* `AddSingletonOperations` - `TryAddSingleton` + register operations on worker
+* `AddScopedOperations` - `TryAddScoped` + register operations on worker
+* `AddTransientOperations` - `TryAddTransient` + register operations on worker
+
+These all expect the Nexus service handler to have the `NexusServiceHandler` attribute that references the service
+interface and the Nexus operation handlers to have the `NexusOperationHandler` attribute.
+
 Other worker and client options can be configured on the builder via the `ConfigureOptions` extension method. With no
 parameters, this returns an `OptionsBuilder<TemporalWorkerServiceOptions>` to use. When provided an action, the options
 are available as parameters that can be configured. `TemporalWorkerServiceOptions` simply extends

--- a/src/Temporalio.Extensions.Hosting/README.md
+++ b/src/Temporalio.Extensions.Hosting/README.md
@@ -90,9 +90,9 @@ workflows is intentionally not supported.
 For adding Nexus service handlers to the service collection and registering operations with the worker, the following
 extensions methods exist on the builder each accepting Nexus service handler type:
 
-* `AddSingletonOperations` - `TryAddSingleton` + register operations on worker
-* `AddScopedOperations` - `TryAddScoped` + register operations on worker
-* `AddTransientOperations` - `TryAddTransient` + register operations on worker
+* `AddSingletonNexusService` - `TryAddSingleton` + register Nexus service handler on worker
+* `AddScopedNexusService` - `TryAddScoped` + register Nexus service handler on worker
+* `AddTransientNexusService` - `TryAddTransient` + register Nexus service handler on worker
 
 These all expect the Nexus service handler to have the `NexusServiceHandler` attribute that references the service
 interface and the Nexus operation handlers to have the `NexusOperationHandler` attribute.

--- a/src/Temporalio.Extensions.Hosting/ServiceHandlerInstanceHelper.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceHandlerInstanceHelper.cs
@@ -18,7 +18,7 @@ namespace Temporalio.Extensions.Hosting
         /// <summary>
         /// Create a service handler instance from the given service handler type and handler factory.
         /// </summary>
-        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <param name="serviceHandlerType">The type of the Nexus service handler.</param>
         /// <param name="handlerFactory">A factory that converts method information into an operation handler.</param>
         /// <returns>A <see cref="ServiceHandlerInstance"/> for the given <paramref name="serviceHandlerType"/> type.</returns>
         public static ServiceHandlerInstance FromType(Type serviceHandlerType, Func<MethodInfo, IOperationHandler<object?, object?>> handlerFactory)
@@ -36,8 +36,8 @@ namespace Temporalio.Extensions.Hosting
         /// <summary>
         /// Creates a <see cref="ServiceDefinition"/> for the given service handler type.
         /// </summary>
-        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
-        /// <returns>A <see cref="ServiceDefinition"/> for the given service handler type.</returns>
+        /// <param name="serviceHandlerType">The type of the Nexus service handler.</param>
+        /// <returns>A <see cref="ServiceDefinition"/> for the given  <paramref name="serviceHandlerType"/> type.</returns>
         private static ServiceDefinition GetServiceDefinition(Type serviceHandlerType)
         {
             // Make sure the attribute is on the declaring type of the instance
@@ -49,7 +49,7 @@ namespace Temporalio.Extensions.Hosting
         /// <summary>
         /// Collects all public methods from the given type and its base types recursively.
         /// </summary>
-        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <param name="serviceHandlerType">The type of the Nexus service handler.</param>
         /// <param name="methods">The list to which discovered methods are added.</param>
         private static void CollectTypeMethods(Type serviceHandlerType, List<MethodInfo> methods)
         {
@@ -72,7 +72,7 @@ namespace Temporalio.Extensions.Hosting
         }
 
         /// <summary>
-        /// Validates and adds an operation handler created from the given method.
+        /// Validates and adds an operation handler created from the given operation handler method.
         /// </summary>
         /// <param name="serviceDef">A <see cref="ServiceDefinition"/> for the given service handler type.</param>
         /// <param name="method">The method from which an operation hander is created.</param>
@@ -133,7 +133,7 @@ namespace Temporalio.Extensions.Hosting
         /// Creates a mapping of operation names to operation handlers for the given service handler type.
         /// </summary>
         /// <param name="serviceDef">A <see cref="ServiceDefinition"/> for the given service handler type.</param>
-        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <param name="serviceHandlerType">The type of the Nexus service handler.</param>
         /// <param name="handlerFactory">A factory that creates an operation handler for a given method.</param>
         /// <returns>A mapping of operation names to operation handlers.</returns>
         private static Dictionary<string, IOperationHandler<object?, object?>> CreateHandlers(

--- a/src/Temporalio.Extensions.Hosting/ServiceHandlerInstanceHelper.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceHandlerInstanceHelper.cs
@@ -126,9 +126,7 @@ namespace Temporalio.Extensions.Hosting
                 throw new ArgumentException($"Duplicate operation handler named ${opDef.Name}");
             }
 
-            opHandlers[opDef.Name] = OperationHandler.WrapAsGenericHandler(
-                handlerFactory(method),
-                method.ReturnType);
+            opHandlers[opDef.Name] = handlerFactory(method);
         }
 
         /// <summary>

--- a/src/Temporalio.Extensions.Hosting/ServiceHandlerInstanceHelper.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceHandlerInstanceHelper.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NexusRpc;
+using NexusRpc.Handlers;
+
+namespace Temporalio.Extensions.Hosting
+{
+    /// <summary>
+    /// Helper for contructing <see cref="ServiceHandlerInstance"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is internal and should be moved to NexusRpc in the future.
+    /// </remarks>
+    internal static class ServiceHandlerInstanceHelper
+    {
+        /// <summary>
+        /// Create a service handler instance from the given service handler type and handler factory.
+        /// </summary>
+        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <param name="handlerFactory">A factory that converts method information into an operation handler.</param>
+        /// <returns>A <see cref="ServiceHandlerInstance"/> for the given <paramref name="serviceHandlerType"/> type.</returns>
+        public static ServiceHandlerInstance FromType(Type serviceHandlerType, Func<MethodInfo, IOperationHandler<object?, object?>> handlerFactory)
+        {
+            var serviceDef = GetServiceDefinition(serviceHandlerType);
+
+            return new ServiceHandlerInstance(
+                serviceDef,
+                CreateHandlers(
+                    serviceDef,
+                    serviceHandlerType,
+                    handlerFactory));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ServiceDefinition"/> for the given service handler type.
+        /// </summary>
+        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <returns>A <see cref="ServiceDefinition"/> for the given service handler type.</returns>
+        private static ServiceDefinition GetServiceDefinition(Type serviceHandlerType)
+        {
+            // Make sure the attribute is on the declaring type of the instance
+            var handlerAttr = serviceHandlerType.GetCustomAttribute<NexusServiceHandlerAttribute>() ??
+                throw new ArgumentException("Missing NexusServiceHandler attribute");
+            return ServiceDefinition.FromType(handlerAttr.ServiceType);
+        }
+
+        /// <summary>
+        /// Collects all public methods from the given type and its base types recursively.
+        /// </summary>
+        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <param name="methods">The list to which discovered methods are added.</param>
+        private static void CollectTypeMethods(Type serviceHandlerType, List<MethodInfo> methods)
+        {
+            // Add all declared public static/instance methods that do not already have one like
+            // it present
+            foreach (var method in serviceHandlerType.GetMethods(
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            {
+                // Only add if there isn't already one that matches the base definition
+                var baseDef = method.GetBaseDefinition();
+                if (!methods.Any(m => baseDef == m.GetBaseDefinition()))
+                {
+                    methods.Add(method);
+                }
+            }
+            if (serviceHandlerType.BaseType is { } baseType)
+            {
+                CollectTypeMethods(baseType, methods);
+            }
+        }
+
+        /// <summary>
+        /// Validates and adds an operation handler created from the given method.
+        /// </summary>
+        /// <param name="serviceDef">A <see cref="ServiceDefinition"/> for the given service handler type.</param>
+        /// <param name="method">The method from which an operation hander is created.</param>
+        /// <param name="handlerFactory">A factory that creates an operation handler for a given method.</param>
+        /// <param name="opHandlers">The mapping of operation names to operation handlers.</param>
+        private static void AddOperationHandler(
+            ServiceDefinition serviceDef,
+            MethodInfo method,
+            Func<MethodInfo, IOperationHandler<object?, object?>> handlerFactory,
+            Dictionary<string, IOperationHandler<object?, object?>> opHandlers)
+        {
+            // Validate
+            if (method.GetParameters().Length != 0)
+            {
+                throw new ArgumentException("Cannot have parameters");
+            }
+            if (method.ContainsGenericParameters)
+            {
+                throw new ArgumentException("Cannot be generic");
+            }
+            if (!method.IsPublic)
+            {
+                throw new ArgumentException("Must be public");
+            }
+
+            // Find definition by the method name
+            var opDef = serviceDef.Operations.Values.FirstOrDefault(o => o.MethodInfo?.Name == method.Name) ??
+                throw new ArgumentException("No matching NexusOperation on the service interface");
+
+            // Check return
+            var goodReturn = false;
+            if (method.ReturnType.IsGenericType &&
+                method.ReturnType.GetGenericTypeDefinition() == typeof(IOperationHandler<,>))
+            {
+                var args = method.ReturnType.GetGenericArguments();
+                goodReturn = args.Length == 2 &&
+                    NoValue.NormalizeVoidType(args[0]) == opDef.InputType &&
+                    NoValue.NormalizeVoidType(args[1]) == opDef.OutputType;
+            }
+            if (!goodReturn)
+            {
+                var inType = opDef.InputType == typeof(void) ? typeof(NoValue) : opDef.InputType;
+                var outType = opDef.OutputType == typeof(void) ? typeof(NoValue) : opDef.OutputType;
+                throw new ArgumentException(
+                    $"Expected return type of IOperationHandler<{inType.Name}, {outType.Name}>");
+            }
+
+            // Confirm not present already
+            if (opHandlers.ContainsKey(opDef.Name))
+            {
+                throw new ArgumentException($"Duplicate operation handler named ${opDef.Name}");
+            }
+
+            opHandlers[opDef.Name] = OperationHandler.WrapAsGenericHandler(
+                handlerFactory(method),
+                method.ReturnType);
+        }
+
+        /// <summary>
+        /// Creates a mapping of operation names to operation handlers for the given service handler type.
+        /// </summary>
+        /// <param name="serviceDef">A <see cref="ServiceDefinition"/> for the given service handler type.</param>
+        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <param name="handlerFactory">A factory that creates an operation handler for a given method.</param>
+        /// <returns>A mapping of operation names to operation handlers.</returns>
+        private static Dictionary<string, IOperationHandler<object?, object?>> CreateHandlers(
+            ServiceDefinition serviceDef,
+            Type serviceHandlerType,
+            Func<MethodInfo, IOperationHandler<object?, object?>> handlerFactory)
+        {
+            // Collect all methods recursively
+            var methods = new List<MethodInfo>();
+            CollectTypeMethods(serviceHandlerType, methods);
+
+            // Collect handlers from the method list
+            var opHandlers = new Dictionary<string, IOperationHandler<object?, object?>>();
+            foreach (var method in methods)
+            {
+                // Only care about ones with operation attribute
+                if (method.GetCustomAttribute<NexusOperationHandlerAttribute>() == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    AddOperationHandler(serviceDef, method, handlerFactory, opHandlers);
+                }
+                catch (Exception e)
+                {
+                    throw new ArgumentException(
+                        $"Failed obtaining operation handler from {method.Name}", e);
+                }
+            }
+
+            return opHandlers;
+        }
+    }
+}

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -212,8 +212,7 @@ namespace Temporalio.Extensions.Hosting
                         // Create the instance if not static and not already created
                         var serviceHandlerInstance = this.serviceOperationMethod.IsStatic
                             ? null
-                            : ActivityScope.ScopedInstance ?? scope.ServiceProvider.GetRequiredService(this.serviceHandlerType);
-                        ActivityScope.ScopedInstance = serviceHandlerInstance;
+                            : scope.ServiceProvider.GetRequiredService(this.serviceHandlerType);
 
                         handler = this.serviceOperationMethod.Invoke(serviceHandlerInstance, null) ??
                             throw new ArgumentException("Operation handler was null");

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -197,11 +197,10 @@ namespace Temporalio.Extensions.Hosting
 
             private async Task<T> InvokeWithScopeAsync<T>(Func<IOperationHandler<object?, object?>, Task<T>> handlerInvoker)
             {
-                IServiceScope scope;
 #if NET6_0_OR_GREATER
-                scope = this.serviceProvider.CreateAsyncScope();
+                AsyncServiceScope scope = this.serviceProvider.CreateAsyncScope();
 #else
-                scope = this.serviceProvider.CreateScope();
+                IServiceScope scope = this.serviceProvider.CreateScope();
 #endif
 
                 try
@@ -234,14 +233,7 @@ namespace Temporalio.Extensions.Hosting
                 finally
                 {
 #if NET6_0_OR_GREATER
-                    if (scope is AsyncServiceScope asyncScope)
-                    {
-                        await asyncScope.DisposeAsync().ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        scope.Dispose();
-                    }
+                    await scope.DisposeAsync().ConfigureAwait(false);
 #else
                     scope.Dispose();
 #endif

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -153,9 +153,9 @@ namespace Temporalio.Extensions.Hosting
         /// </summary>
         /// <param name="provider">Service provider for creating the service instance if the
         /// method is non-static.</param>
-        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <param name="serviceHandlerType">The type of the Nexus service handler.</param>
         /// <returns>Created <see cref="ServiceHandlerInstance"/>.</returns>
-        public static ServiceHandlerInstance CreateNexusServiceHandlerInstance(
+        internal static ServiceHandlerInstance CreateNexusServiceHandlerInstance(
             this IServiceProvider provider,
             Type serviceHandlerType) =>
             ServiceHandlerInstanceHelper.FromType(
@@ -165,6 +165,10 @@ namespace Temporalio.Extensions.Hosting
                     serviceOperationMethod,
                     provider));
 
+        /// <summary>
+        /// An operation handler that defers the resolution of the Nexus service handler and the invocation
+        /// of a Nexus operation to be within a service scope.
+        /// </summary>
         private sealed class ScopedNexusOperationHandler :
             IOperationHandler<object?, object?>
         {

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -5,6 +5,8 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using NexusRpc;
+using NexusRpc.Handlers;
 using Temporalio.Activities;
 
 namespace Temporalio.Extensions.Hosting
@@ -142,6 +144,110 @@ namespace Temporalio.Extensions.Hosting
                 }
             }
             return ActivityDefinition.Create(method, Invoker);
+        }
+
+        /// <summary>
+        /// Create <see cref="ServiceHandlerInstance"/> for the given nexus-attributed service handler type.
+        /// If a service handler method is non-static, this will use the service provider to get the service
+        /// instance to call the method on.
+        /// </summary>
+        /// <param name="provider">Service provider for creating the service instance if the
+        /// method is non-static.</param>
+        /// <param name="serviceHandlerType">The concrete type of the Nexus service handler.</param>
+        /// <returns>Created <see cref="ServiceHandlerInstance"/>.</returns>
+        public static ServiceHandlerInstance CreateNexusServiceHandlerInstance(
+            this IServiceProvider provider,
+            Type serviceHandlerType) =>
+            ServiceHandlerInstanceHelper.FromType(
+                serviceHandlerType,
+                serviceOperationMethod => new ScopedNexusOperationHandler(
+                    serviceHandlerType,
+                    serviceOperationMethod,
+                    provider));
+
+        private sealed class ScopedNexusOperationHandler :
+            IOperationHandler<object?, object?>
+        {
+            private readonly Type serviceHandlerType;
+            private readonly MethodInfo serviceOperationMethod;
+            private readonly IServiceProvider serviceProvider;
+
+            public ScopedNexusOperationHandler(Type serviceHandlerType, MethodInfo serviceOperationMethod, IServiceProvider serviceProvider)
+            {
+                this.serviceHandlerType = serviceHandlerType;
+                this.serviceOperationMethod = serviceOperationMethod;
+                this.serviceProvider = serviceProvider;
+            }
+
+            public async Task<OperationStartResult<object?>> StartAsync(OperationStartContext context, object? input) =>
+                await InvokeWithScopeAsync(handler => handler.StartAsync(context, input)).ConfigureAwait(false);
+
+            public async Task CancelAsync(OperationCancelContext context) =>
+                await InvokeWithScopeAsync(handler => handler.CancelAsync(context).ContinueWith(
+                    _ => ValueTuple.Create(),
+                    default,
+                    TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion,
+                    TaskScheduler.Current)).ConfigureAwait(false);
+
+            public async Task<OperationInfo> FetchInfoAsync(OperationFetchInfoContext context) =>
+                await InvokeWithScopeAsync(handler => handler.FetchInfoAsync(context)).ConfigureAwait(false);
+
+            public async Task<object?> FetchResultAsync(OperationFetchResultContext context) =>
+                await InvokeWithScopeAsync(handler => handler.FetchResultAsync(context)).ConfigureAwait(false);
+
+            private async Task<T> InvokeWithScopeAsync<T>(Func<IOperationHandler<object?, object?>, Task<T>> handlerInvoker)
+            {
+                IServiceScope scope;
+#if NET6_0_OR_GREATER
+                scope = this.serviceProvider.CreateAsyncScope();
+#else
+                scope = this.serviceProvider.CreateScope();
+#endif
+
+                try
+                {
+                    object handler;
+                    try
+                    {
+                        // Create the instance if not static and not already created
+                        var serviceHandlerInstance = this.serviceOperationMethod.IsStatic
+                            ? null
+                            : ActivityScope.ScopedInstance ?? scope.ServiceProvider.GetRequiredService(this.serviceHandlerType);
+                        ActivityScope.ScopedInstance = serviceHandlerInstance;
+
+                        handler = this.serviceOperationMethod.Invoke(serviceHandlerInstance, null) ??
+                            throw new ArgumentException("Operation handler was null");
+                    }
+                    catch (TargetInvocationException e)
+                    {
+#if NET6_0_OR_GREATER
+                        ExceptionDispatchInfo.Capture(e.InnerException!).Throw();
+#else
+                        ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+#endif
+                        // Unreachable
+                        throw new InvalidOperationException("Unreachable");
+                    }
+
+                    var genericHandler = OperationHandler.WrapAsGenericHandler(handler, this.serviceOperationMethod.ReturnType);
+                    return await handlerInvoker(genericHandler).ConfigureAwait(false);
+                }
+                finally
+                {
+#if NET6_0_OR_GREATER
+                    if (scope is AsyncServiceScope asyncScope)
+                    {
+                        await asyncScope.DisposeAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        scope.Dispose();
+                    }
+#else
+                    scope.Dispose();
+#endif
+                }
+            }
         }
     }
 }

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
@@ -181,7 +181,7 @@ namespace Temporalio.Extensions.Hosting
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
         public static ITemporalWorkerServiceOptionsBuilder AddTransientOperations<T>(
             this ITemporalWorkerServiceOptionsBuilder builder) =>
-            builder.AddScopedOperations(typeof(T));
+            builder.AddTransientOperations(typeof(T));
 
         /// <summary>
         /// Register the given type as transient if not already done and all operations of the

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
@@ -53,9 +53,9 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="builder">Builder to use.</param>
         /// <returns>Same builder instance.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static ITemporalWorkerServiceOptionsBuilder AddSingletonOperations<T>(
+        public static ITemporalWorkerServiceOptionsBuilder AddSingletonNexusService<T>(
             this ITemporalWorkerServiceOptionsBuilder builder) =>
-            builder.AddSingletonOperations(typeof(T));
+            builder.AddSingletonNexusService(typeof(T));
 
         /// <summary>
         /// Register the given type as a singleton if not already done and all operations of the
@@ -68,7 +68,7 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
         /// <returns>Same builder instance.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static ITemporalWorkerServiceOptionsBuilder AddSingletonOperations(
+        public static ITemporalWorkerServiceOptionsBuilder AddSingletonNexusService(
             this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
         {
             builder.Services.TryAddSingleton(serviceHandlerType);
@@ -116,9 +116,9 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="builder">Builder to use.</param>
         /// <returns>Same builder instance.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static ITemporalWorkerServiceOptionsBuilder AddScopedOperations<T>(
+        public static ITemporalWorkerServiceOptionsBuilder AddScopedNexusService<T>(
             this ITemporalWorkerServiceOptionsBuilder builder) =>
-            builder.AddScopedOperations(typeof(T));
+            builder.AddScopedNexusService(typeof(T));
 
         /// <summary>
         /// Register the given type as scoped if not already done and all operations of the
@@ -131,7 +131,7 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
         /// <returns>Same builder instance.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static ITemporalWorkerServiceOptionsBuilder AddScopedOperations(
+        public static ITemporalWorkerServiceOptionsBuilder AddScopedNexusService(
             this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
         {
             builder.Services.TryAddScoped(serviceHandlerType);
@@ -179,9 +179,9 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="builder">Builder to use.</param>
         /// <returns>Same builder instance.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static ITemporalWorkerServiceOptionsBuilder AddTransientOperations<T>(
+        public static ITemporalWorkerServiceOptionsBuilder AddTransientNexusService<T>(
             this ITemporalWorkerServiceOptionsBuilder builder) =>
-            builder.AddTransientOperations(typeof(T));
+            builder.AddTransientNexusService(typeof(T));
 
         /// <summary>
         /// Register the given type as transient if not already done and all operations of the
@@ -194,7 +194,7 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
         /// <returns>Same builder instance.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static ITemporalWorkerServiceOptionsBuilder AddTransientOperations(
+        public static ITemporalWorkerServiceOptionsBuilder AddTransientNexusService(
             this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
         {
             builder.Services.TryAddTransient(serviceHandlerType);

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
@@ -47,7 +47,7 @@ namespace Temporalio.Extensions.Hosting
         /// given type to the worker. Basically
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton{TService}(IServiceCollection)" />
         /// +
-        /// <see cref="ApplyNexusOperations{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// <see cref="ApplyNexusService{T}(ITemporalWorkerServiceOptionsBuilder)" />.
         /// </summary>
         /// <typeparam name="T">Service handler type for which operations are registered.</typeparam>
         /// <param name="builder">Builder to use.</param>
@@ -62,7 +62,7 @@ namespace Temporalio.Extensions.Hosting
         /// given type to the worker. Basically
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton(IServiceCollection, Type)" />
         /// +
-        /// <see cref="ApplyNexusOperations(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// <see cref="ApplyNexusService(ITemporalWorkerServiceOptionsBuilder, Type)" />.
         /// </summary>
         /// <param name="builder">Builder to use.</param>
         /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
@@ -72,7 +72,7 @@ namespace Temporalio.Extensions.Hosting
             this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
         {
             builder.Services.TryAddSingleton(serviceHandlerType);
-            return builder.ApplyNexusOperations(serviceHandlerType);
+            return builder.ApplyNexusService(serviceHandlerType);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Temporalio.Extensions.Hosting
         /// given type to the worker. Basically
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddScoped{TService}(IServiceCollection)" />
         /// +
-        /// <see cref="ApplyNexusOperations{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// <see cref="ApplyNexusService{T}(ITemporalWorkerServiceOptionsBuilder)" />.
         /// </summary>
         /// <typeparam name="T">Service handler type for which operations are registered.</typeparam>
         /// <param name="builder">Builder to use.</param>
@@ -125,7 +125,7 @@ namespace Temporalio.Extensions.Hosting
         /// given type to the worker. Basically
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddScoped(IServiceCollection, Type)" />
         /// +
-        /// <see cref="ApplyNexusOperations(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// <see cref="ApplyNexusService(ITemporalWorkerServiceOptionsBuilder, Type)" />.
         /// </summary>
         /// <param name="builder">Builder to use.</param>
         /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
@@ -135,7 +135,7 @@ namespace Temporalio.Extensions.Hosting
             this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
         {
             builder.Services.TryAddScoped(serviceHandlerType);
-            return builder.ApplyNexusOperations(serviceHandlerType);
+            return builder.ApplyNexusService(serviceHandlerType);
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace Temporalio.Extensions.Hosting
         /// given type to the worker. Basically
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddTransient{TService}(IServiceCollection)" />
         /// +
-        /// <see cref="ApplyNexusOperations{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// <see cref="ApplyNexusService{T}(ITemporalWorkerServiceOptionsBuilder)" />.
         /// </summary>
         /// <typeparam name="T">Service handler type for which operations are registered.</typeparam>
         /// <param name="builder">Builder to use.</param>
@@ -188,7 +188,7 @@ namespace Temporalio.Extensions.Hosting
         /// given type to the worker. Basically
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddTransient(IServiceCollection, Type)" />
         /// +
-        /// <see cref="ApplyNexusOperations(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// <see cref="ApplyNexusService(ITemporalWorkerServiceOptionsBuilder, Type)" />.
         /// </summary>
         /// <param name="builder">Builder to use.</param>
         /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
@@ -198,7 +198,7 @@ namespace Temporalio.Extensions.Hosting
             this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
         {
             builder.Services.TryAddTransient(serviceHandlerType);
-            return builder.ApplyNexusOperations(serviceHandlerType);
+            return builder.ApplyNexusService(serviceHandlerType);
         }
 
         /// <summary>
@@ -370,9 +370,9 @@ namespace Temporalio.Extensions.Hosting
         /// <typeparam name="T">Service handler type for which operations are registered.</typeparam>
         /// <returns>Same builder instance.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static ITemporalWorkerServiceOptionsBuilder ApplyNexusOperations<T>(
+        public static ITemporalWorkerServiceOptionsBuilder ApplyNexusService<T>(
             this ITemporalWorkerServiceOptionsBuilder builder) =>
-            builder.ApplyNexusOperations(typeof(T));
+            builder.ApplyNexusService(typeof(T));
 
         /// <summary>
         /// Register the given service handler type's operations. This uses the service provider
@@ -383,7 +383,7 @@ namespace Temporalio.Extensions.Hosting
         /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
         /// <returns>Same builder instance.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static ITemporalWorkerServiceOptionsBuilder ApplyNexusOperations(
+        public static ITemporalWorkerServiceOptionsBuilder ApplyNexusService(
             this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
         {
             builder.ConfigureOptions().PostConfigure<IServiceProvider>((options, provider) =>

--- a/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/TemporalWorkerServiceOptionsBuilderExtensions.cs
@@ -43,6 +43,39 @@ namespace Temporalio.Extensions.Hosting
         }
 
         /// <summary>
+        /// Register the given type as a singleton if not already done and all operations of the
+        /// given type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton{TService}(IServiceCollection)" />
+        /// +
+        /// <see cref="ApplyNexusOperations{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// </summary>
+        /// <typeparam name="T">Service handler type for which operations are registered.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public static ITemporalWorkerServiceOptionsBuilder AddSingletonOperations<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) =>
+            builder.AddSingletonOperations(typeof(T));
+
+        /// <summary>
+        /// Register the given type as a singleton if not already done and all operations of the
+        /// given type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton(IServiceCollection, Type)" />
+        /// +
+        /// <see cref="ApplyNexusOperations(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
+        /// <returns>Same builder instance.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public static ITemporalWorkerServiceOptionsBuilder AddSingletonOperations(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
+        {
+            builder.Services.TryAddSingleton(serviceHandlerType);
+            return builder.ApplyNexusOperations(serviceHandlerType);
+        }
+
+        /// <summary>
         /// Register the given type as scoped if not already done and all activities of the given
         /// type to the worker. Basically
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddScoped{TService}(IServiceCollection)" />
@@ -73,6 +106,39 @@ namespace Temporalio.Extensions.Hosting
         }
 
         /// <summary>
+        /// Register the given type as scoped if not already done and all operations of the
+        /// given type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddScoped{TService}(IServiceCollection)" />
+        /// +
+        /// <see cref="ApplyNexusOperations{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// </summary>
+        /// <typeparam name="T">Service handler type for which operations are registered.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public static ITemporalWorkerServiceOptionsBuilder AddScopedOperations<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) =>
+            builder.AddScopedOperations(typeof(T));
+
+        /// <summary>
+        /// Register the given type as scoped if not already done and all operations of the
+        /// given type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddScoped(IServiceCollection, Type)" />
+        /// +
+        /// <see cref="ApplyNexusOperations(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
+        /// <returns>Same builder instance.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public static ITemporalWorkerServiceOptionsBuilder AddScopedOperations(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
+        {
+            builder.Services.TryAddScoped(serviceHandlerType);
+            return builder.ApplyNexusOperations(serviceHandlerType);
+        }
+
+        /// <summary>
         /// Register the given type as transient if not already done and all activities of the given
         /// type to the worker. Basically
         /// <see cref="ServiceCollectionDescriptorExtensions.TryAddTransient{TService}(IServiceCollection)" />
@@ -100,6 +166,39 @@ namespace Temporalio.Extensions.Hosting
         {
             builder.Services.TryAddTransient(type);
             return builder.ApplyTemporalActivities(type);
+        }
+
+        /// <summary>
+        /// Register the given type as transient if not already done and all operations of the
+        /// given type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddTransient{TService}(IServiceCollection)" />
+        /// +
+        /// <see cref="ApplyNexusOperations{T}(ITemporalWorkerServiceOptionsBuilder)" />.
+        /// </summary>
+        /// <typeparam name="T">Service handler type for which operations are registered.</typeparam>
+        /// <param name="builder">Builder to use.</param>
+        /// <returns>Same builder instance.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public static ITemporalWorkerServiceOptionsBuilder AddTransientOperations<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) =>
+            builder.AddScopedOperations(typeof(T));
+
+        /// <summary>
+        /// Register the given type as transient if not already done and all operations of the
+        /// given type to the worker. Basically
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddTransient(IServiceCollection, Type)" />
+        /// +
+        /// <see cref="ApplyNexusOperations(ITemporalWorkerServiceOptionsBuilder, Type)" />.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
+        /// <returns>Same builder instance.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public static ITemporalWorkerServiceOptionsBuilder AddTransientOperations(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
+        {
+            builder.Services.TryAddTransient(serviceHandlerType);
+            return builder.ApplyNexusOperations(serviceHandlerType);
         }
 
         /// <summary>
@@ -258,6 +357,38 @@ namespace Temporalio.Extensions.Hosting
                 {
                     options.AddActivity(defn);
                 }
+            });
+            return builder;
+        }
+
+        /// <summary>
+        /// Register the given service handler type's operations. This uses the service provider
+        /// to create the instance for non-static methods, but does not register the type/instance
+        /// with the service collection.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <typeparam name="T">Service handler type for which operations are registered.</typeparam>
+        /// <returns>Same builder instance.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public static ITemporalWorkerServiceOptionsBuilder ApplyNexusOperations<T>(
+            this ITemporalWorkerServiceOptionsBuilder builder) =>
+            builder.ApplyNexusOperations(typeof(T));
+
+        /// <summary>
+        /// Register the given service handler type's operations. This uses the service provider
+        /// to create the instance for non-static methods, but does not register the type/instance
+        /// with the service collection.
+        /// </summary>
+        /// <param name="builder">Builder to use.</param>
+        /// <param name="serviceHandlerType">Service handler type for which operations are registered.</param>
+        /// <returns>Same builder instance.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public static ITemporalWorkerServiceOptionsBuilder ApplyNexusOperations(
+            this ITemporalWorkerServiceOptionsBuilder builder, Type serviceHandlerType)
+        {
+            builder.ConfigureOptions().PostConfigure<IServiceProvider>((options, provider) =>
+            {
+                options.AddNexusService(provider.CreateNexusServiceHandlerInstance(serviceHandlerType));
             });
             return builder;
         }

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -466,6 +466,18 @@ namespace Temporalio.Worker
         }
 
         /// <summary>
+        /// Add the given Nexus service handler.
+        /// </summary>
+        /// <param name="serviceHandler">Service handler to add..</param>
+        /// <returns>This options instance for chaining.</returns>
+        /// <remarks>WARNING: Nexus support is experimental.</remarks>
+        public TemporalWorkerOptions AddNexusService(ServiceHandlerInstance serviceHandler)
+        {
+            NexusServices.Add(serviceHandler);
+            return this;
+        }
+
+        /// <summary>
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options and any transitive options fields.

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -94,7 +94,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddSingleton<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddSingletonOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddSingletonNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
@@ -110,7 +110,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddScoped<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddSingletonOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddSingletonNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
@@ -126,7 +126,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddTransient<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddSingletonOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddSingletonNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
@@ -142,7 +142,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddSingleton<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddScopedOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddScopedNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
@@ -158,7 +158,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddScoped<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddScopedOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddScopedNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
@@ -174,7 +174,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddTransient<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddScopedOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddScopedNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
@@ -190,7 +190,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddSingleton<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddTransientOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddTransientNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
@@ -206,7 +206,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddScoped<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddTransientOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddTransientNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
@@ -222,7 +222,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     {
         int result = await ExecuteHostedNexusWithWorkflow(
             configureServices: services => services.AddTransient<ITestCounterService, TestCounterService>(),
-            configureBuilder: builder => builder.AddTransientOperations<TestNexusService>(),
+            configureBuilder: builder => builder.AddTransientNexusService<TestNexusService>(),
             workflowFunc: async client =>
             {
                 await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -117,7 +117,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
                 return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
             });
 
-        // Expect to throw exception since scoped dependency cannot be used in singleton service
+        // Expect 2 since the Nexus service is singleton and should hold onto its dependencies.
         Assert.Equal(2, result);
     }
 

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -1,0 +1,309 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NexusRpc;
+using NexusRpc.Handlers;
+using Temporalio.Client;
+using Temporalio.Extensions.Hosting;
+using Temporalio.Workflows;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Temporalio.Tests.Extensions.Hosting;
+
+public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
+{
+    public NexusWorkerServiceTests(ITestOutputHelper output, WorkflowEnvironment env)
+        : base(output, env)
+    {
+    }
+
+    public interface ITestCounterService :
+        IDisposable
+    {
+        int Increment();
+    }
+
+    public sealed class TestCounterService : ITestCounterService
+    {
+        private bool isDisposed;
+        private int value;
+
+        public TestCounterService()
+        {
+        }
+
+        public int Increment()
+        {
+            if (isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(TestCounterService));
+            }
+            return ++value;
+        }
+
+        public void Dispose()
+        {
+            isDisposed = true;
+        }
+    }
+
+    [NexusService]
+    public interface ITestNexusService
+    {
+        [NexusOperation]
+        int Increment(string unused);
+    }
+
+    [NexusServiceHandler(typeof(ITestNexusService))]
+    public class TestNexusService
+    {
+        private readonly ITestCounterService context;
+
+        public TestNexusService(ITestCounterService context) =>
+            this.context = context;
+
+        [NexusOperationHandler]
+        public IOperationHandler<string, int> Increment() =>
+            new TestOperationHandler(this.context);
+
+        private class TestOperationHandler : IOperationHandler<string, int>
+        {
+            private readonly ITestCounterService context;
+
+            public TestOperationHandler(ITestCounterService context)
+            {
+                this.context = context;
+            }
+
+            public Task<OperationStartResult<int>> StartAsync(OperationStartContext context, string input) =>
+                Task.FromResult(OperationStartResult.SyncResult(this.context.Increment()));
+
+            public Task CancelAsync(OperationCancelContext context) =>
+                throw new NotImplementedException();
+
+            public Task<int> FetchResultAsync(OperationFetchResultContext context) =>
+                throw new NotImplementedException();
+
+            public Task<OperationInfo> FetchInfoAsync(OperationFetchInfoContext context) =>
+                throw new NotImplementedException();
+        }
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_SingletonNexusService_SingletonDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddSingleton<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddSingletonOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect 2 since both the Nexus service and dependency are singleton and dependency is shared across calls
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_SingletonNexusService_ScopedDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddScoped<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddSingletonOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect to throw exception since scoped dependency cannot be used in singleton service
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_SingletonNexusService_TransientDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddTransient<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddSingletonOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect 2 since both the Nexus service is singleton and should hold onto its dependencies
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_ScopedNexusService_SingletonDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddSingleton<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddScopedOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect 2 since the dependency is singleton and is shared across calls
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_ScopedNexusService_ScopedDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddScoped<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddScopedOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect 1 since the dependency is scoped and disposed after the first call
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_ScopedNexusService_TransientDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddTransient<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddScopedOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect 1 since the nexus service is scoped and gets a new transient dependency for each call
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_TransientNexusService_SingletonDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddSingleton<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddTransientOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect 2 since the dependency is singleton and is shared across calls
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_TransientNexusService_ScopedDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddScoped<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddTransientOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect 1 since the dependency is scoped and disposed after the first call
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task NexusWorkerService_TransientNexusService_TransientDependency()
+    {
+        int result = await ExecuteHostedNexusWithWorkflow(
+            configureServices: services => services.AddTransient<ITestCounterService, TestCounterService>(),
+            configureBuilder: builder => builder.AddTransientOperations<TestNexusService>(),
+            workflowFunc: async client =>
+            {
+                await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+                return await client.ExecuteNexusOperationAsync(svc => svc.Increment("unused"));
+            });
+
+        // Expect 1 since the nexus service and dependency are both transient and new instances are created for each call
+        Assert.Equal(1, result);
+    }
+
+    private async Task<int> ExecuteHostedNexusWithWorkflow(
+        Action<IServiceCollection> configureServices,
+        Action<ITemporalWorkerServiceOptionsBuilder> configureBuilder,
+        Func<NexusClient<ITestNexusService>, Task<int>> workflowFunc)
+    {
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var endpointName = $"nexus-endpoint-{taskQueue}";
+
+        Func<Task<int>> outerWorkflowFunc = async () =>
+        {
+            var client = Workflow.CreateNexusClient<ITestNexusService>(endpointName);
+
+            return await workflowFunc(client);
+        };
+
+        var builder = Host.CreateApplicationBuilder();
+
+        var services = builder.Services.
+            AddSingleton(Client);
+        configureServices(services);
+
+        var workerBuilder = services.
+            AddHostedTemporalWorker(taskQueue).
+            ConfigureOptions(options =>
+                {
+                    options.AddWorkflow(WorkflowDefinition.Create(
+                        typeof(CustomFuncWorkflow),
+                        null,
+                        _ => new CustomFuncWorkflow(outerWorkflowFunc)));
+                });
+        configureBuilder(workerBuilder);
+
+        using var host = builder.Build();
+
+        await host.StartAsync();
+
+        try
+        {
+            var endpoint = await Env.TestEnv.CreateNexusEndpointAsync(endpointName, taskQueue);
+
+            try
+            {
+                ITemporalClient client = host.Services.GetRequiredService<ITemporalClient>();
+
+                var handle = await client.StartWorkflowAsync(
+                    (CustomFuncWorkflow wf) => wf.RunAsync(),
+                    new WorkflowOptions(
+                        $"wf-{Guid.NewGuid()}",
+                        taskQueue));
+
+                return await handle.GetResultAsync<int>();
+            }
+            finally
+            {
+                await Env.TestEnv.DeleteNexusEndpointAsync(endpoint);
+            }
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
+    }
+
+    [Workflow]
+    public class CustomFuncWorkflow
+    {
+        private readonly Func<Task<int>> func;
+
+        public CustomFuncWorkflow(Func<Task<int>> func) => this.func = func;
+
+        [WorkflowRun]
+        public Task<int> RunAsync() => func();
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add [dependency injection[(https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) support for Nexus services, similar to that of activities. Public methods were named similar to the Activity-based counter parts.

## Why?
Enable registration of Nexus services via dependency injection in .NET host applications.

## Checklist
<!--- add/delete as needed --->

1. Closes #536 

2. How was this tested:
- [x] Tests are not implemented yet

4. Any docs updates needed?
- [x] Will check with team where appropriate documentation should be done in repo.
- [ ] Will check with team if docs.temporal.io needs to be updated.
- [x] Proposing to add new samples to https://github.com/temporalio/samples-dotnet
