### PR TITLE
Update tests and generator to .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ jobs:
           - os: ubuntu-latest
             docsTarget: true
             cloudTestTarget: true
-            # This is here alongside docsTarget because newer docfx doesn't work
-            # with .NET 6.
-            dotNetVersionOverride: |
-              6.x
-              8.x
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-intel
@@ -54,7 +49,7 @@ jobs:
         with:
           # Specific .NET version required because GitHub macos ARM image has
           # bad pre-installed .NET version
-          dotnet-version: ${{ matrix.dotNetVersionOverride || '6.x' }}
+          dotnet-version: '10.x'
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -136,6 +136,8 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
 
       - name: Build package
         run: dotnet pack -c Release /p:BridgeLibraryRoot=${{ github.workspace }}/bridge-libraries

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -32,7 +32,7 @@ jobs:
             out-file: libtemporal_sdk_core_c_bridge.so
             out-prefix: linux-musl-x64
             # Need Alpine container since GH runner doesn't have one
-            container: mcr.microsoft.com/dotnet/sdk:8.0-alpine
+            container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
             runsOn: ubuntu-latest
           - os: macos-intel
@@ -164,7 +164,7 @@ jobs:
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
           - os: alpine-latest
-            container: mcr.microsoft.com/dotnet/sdk:6.0-alpine
+            container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
             runsOn: ubuntu-latest
           - os: macos-intel
             runsOn: macos-13
@@ -192,11 +192,7 @@ jobs:
         with:
           # Specific .NET version required because GitHub macos ARM image has
           # bad pre-installed .NET version
-          dotnet-version: 6.x
-
-      - name: Setup .NET (Alpine)
-        if: ${{ matrix.os == 'alpine-latest' }}
-        run: apk add dotnet6-sdk
+          dotnet-version: 10.x
 
       - name: Run smoke test (non-Windows)
         if: ${{ matrix.os != 'windows-latest' && matrix.os != 'windows-arm' }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,5 @@
 name: Build Package
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,6 @@
 name: Build Package
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -803,6 +803,9 @@ dotnet_diagnostic.CA1024.severity = none
 # Don't force workflows to have static methods
 dotnet_diagnostic.CA1822.severity = none
 
+# Don't force workflows to call async methods
+dotnet_diagnostic.CA1849.severity = none
+
 # Do not need ConfigureAwait for workflows
 dotnet_diagnostic.CA2007.severity = none
 
@@ -814,6 +817,9 @@ dotnet_diagnostic.CA5394.severity = none
 
 # Allow async methods to not have await in them
 dotnet_diagnostic.CS1998.severity = none
+
+# Don't force workflows to call async methods
+dotnet_diagnostic.VSTHRD103.severity = none
 
 # Don't avoid, but rather encourage things using TaskScheduler.Current in workflows
 dotnet_diagnostic.VSTHRD105.severity = none

--- a/src/Temporalio.Api.Generator/Temporal.Api.Generator.csproj
+++ b/src/Temporalio.Api.Generator/Temporal.Api.Generator.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tests/Temporalio.SimpleBench/Program.cs
+++ b/tests/Temporalio.SimpleBench/Program.cs
@@ -77,7 +77,7 @@ cmd.SetHandler(async ctx =>
     resultWatch.Stop();
 
     // Cancel worker and wait for cancelled
-    cancelSource.Cancel();
+    await cancelSource.CancelAsync();
     try
     {
         await workerTask;

--- a/tests/Temporalio.SimpleBench/Temporalio.SimpleBench.csproj
+++ b/tests/Temporalio.SimpleBench/Temporalio.SimpleBench.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Temporalio\Temporalio.csproj" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Temporalio.SmokeTest/Temporalio.SmokeTest.csproj
+++ b/tests/Temporalio.SmokeTest/Temporalio.SmokeTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!--

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -34,10 +34,8 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
 
         public int Increment()
         {
-            if (isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(TestCounterService));
-            }
+            ObjectDisposedException.ThrowIf(isDisposed, nameof(TestCounterService));
+
             return ++value;
         }
 

--- a/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
+++ b/tests/Temporalio.Tests/KitchenSinkWorkflow.cs
@@ -195,7 +195,12 @@ public class KitchenSinkWorkflow
                 tasks.Add(Task.Factory.StartNew(async () =>
                 {
                     await Workflow.DelayAsync((int)action.ExecuteActivity.CancelAfterMS);
+#pragma warning disable CA1849 // Call async methods when in an async method
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
+                    // https://github.com/temporalio/sdk-dotnet/issues/327
                     cancelSource.Cancel();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
+#pragma warning restore CA1849 // Call async methods when in an async method
                 }).Unwrap());
             }
             // Start all activities

--- a/tests/Temporalio.Tests/Temporalio.Tests.csproj
+++ b/tests/Temporalio.Tests/Temporalio.Tests.csproj
@@ -6,27 +6,20 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.4.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.console" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-
-    <!-- Resolve https://github.com/advisories/GHSA-7jgj-8wvc-jh57 -->
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-
-    <!-- Resolve https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Temporalio.Tests/TestUtils.cs
+++ b/tests/Temporalio.Tests/TestUtils.cs
@@ -19,7 +19,7 @@ public static class TestUtils
 
     public static int FreePort()
     {
-        var l = new TcpListener(IPAddress.Loopback, 0);
+        using var l = new TcpListener(IPAddress.Loopback, 0);
         l.Start();
         int port = ((IPEndPoint)l.LocalEndpoint).Port;
         l.Stop();

--- a/tests/Temporalio.Tests/Testing/ActivityEnvironmentTests.cs
+++ b/tests/Temporalio.Tests/Testing/ActivityEnvironmentTests.cs
@@ -23,7 +23,7 @@ public class ActivityEnvironmentTests : TestBase
             Info = ActivityEnvironment.DefaultInfo with { ActivityType = "SomeActivity" },
             Heartbeater = heartbeats.Add,
         };
-        env.WorkerShutdownTokenSource.Cancel();
+        await env.WorkerShutdownTokenSource.CancelAsync();
         env.Cancel(ActivityCancelReason.Timeout);
         var ret = await env.RunAsync(async () =>
         {

--- a/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/ActivityWorkerTests.cs
@@ -433,7 +433,7 @@ public class ActivityWorkerTests : WorkflowEnvironmentTestBase
                 workflowId = handle.Id;
                 // Wait for activity to be reached, then stop the worker
                 await activityReached.Task.WaitAsync(TimeSpan.FromSeconds(20));
-                workerStoppingSource.Cancel();
+                await workerStoppingSource.CancelAsync();
             }));
         Assert.True(gotCancellation);
         // Check the workflow error

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -216,7 +216,12 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                         svc => svc.DoSomething("some-name"),
                         new() { CancellationToken = cancelSource.Token });
                 // Cancel and wait for result to bubble out cancel
+#pragma warning disable CA1849 // Call async methods when in an async method
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
+                // https://github.com/temporalio/sdk-dotnet/issues/327
                 cancelSource.Cancel();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
+#pragma warning restore CA1849 // Call async methods when in an async method
                 await handle.GetResultAsync();
             }));
         var inner = Assert.IsType<NexusOperationFailureException>(wfExc.InnerException);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Updated test projects and generator project to .NET 10.
- Fixed code analysis violations and suppressed those that should not be fixed within workflows.
- Adjusted standard library call tests due to changes in .NET 8+ runtime.

## Why?

Lowest supported .NET version is 8 and both 8 and 9 will be out of support in less than a year at this point. Update to latest LTS (.NET 10) which will be supported for ~3 years.

## Checklist
<!--- add/delete as needed --->

1. Closes #522 

2. How was this tested: Local builds and test runs with only .NET 10 SDK installed. Built and ran all projects found to test the SDK tests, smoke test, benchmark, and docfx generation. Checked test counts before and after changes to check that tests were not dropped.

3. Any docs updates needed? None required. Can consider if the `Task.WhenAny -> Workflow.WhenAnyAsync` recommendation should be adjusted (as well as the SDK implementation of `Workflow.WhenAnyAsync`) for .NET 8+.