### PR TITLE
💥Enable Worker heartbeating, update Core to 44a6576

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build (non-Docker)
         if: ${{ !matrix.container }}
-        run: cargo build --manifest-path src/Temporalio/Bridge/sdk-core/core-c-bridge/Cargo.toml --profile release-lto
+        run: cargo build --manifest-path src/Temporalio/Bridge/sdk-core/crates/sdk-core-c-bridge/Cargo.toml --profile release-lto
 
       - name: Build (Docker non-Alpine)
         if: ${{ matrix.container && matrix.os != 'alpine-latest' }}
@@ -103,7 +103,7 @@ jobs:
              && curl -LO ${{ matrix.protobuf-url }} \
              && unzip protoc-*.zip -d /usr/local/protobuf \
              && export PATH="$PATH:/usr/local/protobuf/bin" \
-             && cargo build --manifest-path src/Temporalio/Bridge/sdk-core/core-c-bridge/Cargo.toml --profile release-lto \
+             && cargo build --manifest-path src/Temporalio/Bridge/sdk-core/crates/sdk-core-c-bridge/Cargo.toml --profile release-lto \
             '
 
       - name: Build (Docker Alpine)
@@ -118,7 +118,7 @@ jobs:
              && curl -LO ${{ matrix.protobuf-url }} \
              && unzip protoc-*.zip -d /usr/local/protobuf \
              && export PATH="$PATH:/usr/local/protobuf/bin" \
-             && RUSTFLAGS="-C target-feature=-crt-static" cargo build --manifest-path src/Temporalio/Bridge/sdk-core/core-c-bridge/Cargo.toml --profile release-lto \
+             && RUSTFLAGS="-C target-feature=-crt-static" cargo build --manifest-path src/Temporalio/Bridge/sdk-core/crates/sdk-core-c-bridge/Cargo.toml --profile release-lto \
             '
 
       - name: Upload bridge library

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - "releases/*"
-      - worker-heartbeat
+  pull_request:
   workflow_dispatch: {}
 permissions:
   contents: read

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - "releases/*"
-  pull_request:
   workflow_dispatch: {}
 permissions:
   contents: read

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - "releases/*"
+      - worker-heartbeat
   workflow_dispatch: {}
 permissions:
   contents: read
@@ -13,41 +14,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-arm, alpine-latest, macos-intel, macos-arm, windows-latest, windows-arm]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-arm,
+            alpine-latest,
+            macos-intel,
+            macos-arm,
+            windows-latest,
+            windows-arm,
+          ]
         include:
           - os: ubuntu-latest
-            out-file: libtemporal_sdk_core_c_bridge.so
+            out-file: libtemporalio_sdk_core_c_bridge.so
             out-prefix: linux-x64
             # We use the Python manylinux image for glibc compatibility
             container: quay.io/pypa/manylinux2014_x86_64
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
           - os: ubuntu-arm
-            out-file: libtemporal_sdk_core_c_bridge.so
+            out-file: libtemporalio_sdk_core_c_bridge.so
             out-prefix: linux-arm64
             runsOn: ubuntu-24.04-arm64-2-core
             # We use the Python manylinux image for glibc compatibility
             container: quay.io/pypa/manylinux2014_aarch64
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
           - os: alpine-latest
-            out-file: libtemporal_sdk_core_c_bridge.so
+            out-file: libtemporalio_sdk_core_c_bridge.so
             out-prefix: linux-musl-x64
             # Need Alpine container since GH runner doesn't have one
             container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
             runsOn: ubuntu-latest
           - os: macos-intel
-            out-file: libtemporal_sdk_core_c_bridge.dylib
+            out-file: libtemporalio_sdk_core_c_bridge.dylib
             out-prefix: osx-x64
             runsOn: macos-15-intel
           - os: macos-arm
-            out-file: libtemporal_sdk_core_c_bridge.dylib
+            out-file: libtemporalio_sdk_core_c_bridge.dylib
             out-prefix: osx-arm64
             runsOn: macos-14
           - os: windows-latest
-            out-file: temporal_sdk_core_c_bridge.dll
+            out-file: temporalio_sdk_core_c_bridge.dll
             out-prefix: win-x64
           - os: windows-arm
-            out-file: temporal_sdk_core_c_bridge.dll
+            out-file: temporalio_sdk_core_c_bridge.dll
             out-prefix: win-arm64
             runsOn: windows-11-arm
     runs-on: ${{ matrix.runsOn || matrix.os }}
@@ -161,7 +171,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-arm, alpine-latest, macos-intel, macos-arm, windows-latest, windows-arm]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-arm,
+            alpine-latest,
+            macos-intel,
+            macos-arm,
+            windows-latest,
+            windows-arm,
+          ]
         include:
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core

--- a/README.md
+++ b/README.md
@@ -1204,8 +1204,8 @@ See the
 ### Built-in Native Shared Library
 
 This SDK requires a built-in unmanaged, native shared library built in Rust. It is named
-`temporal_sdk_core_c_bridge.dll` on Windows, `libtemporal_sdk_core_c_bridge.so` on Linux, and
-`libtemporal_sdk_core_c_bridge.dylib` on macOS. This is automatically included when using modern versions of .NET
+`temporalio_sdk_core_c_bridge.dll` on Windows, `libtemporalio_sdk_core_c_bridge.so` on Linux, and
+`libtemporalio_sdk_core_c_bridge.dylib` on macOS. This is automatically included when using modern versions of .NET
 on a common platform. If you are using .NET framework, you may have to explicitly set the platform to `x64` or `arm64`
 because `AnyCPU` will not choose the proper library.
 
@@ -1220,7 +1220,7 @@ Redistributable installation).
 
 If the native shared library is not loading for whatever reason, the following error may appear:
 
-> System.DllNotFoundException: Unable to load DLL 'temporal_sdk_core_c_bridge' or one of its dependencies: The specified
+> System.DllNotFoundException: Unable to load DLL 'temporalio_sdk_core_c_bridge' or one of its dependencies: The specified
 > module could not be found.
 
 See the earlier part of this section for details on what environments are supported.

--- a/src/Temporalio/Bridge/GenerateInterop.rsp
+++ b/src/Temporalio/Bridge/GenerateInterop.rsp
@@ -4,11 +4,11 @@ windows-types
 --with-access-specifier
 *=internal
 --file
-src/Temporalio/Bridge/sdk-core/core-c-bridge/include/temporal-sdk-core-c-bridge.h
+src/Temporalio/Bridge/sdk-core/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
 --namespace
 Temporalio.Bridge.Interop
 --libraryPath
-temporal_sdk_core_c_bridge
+temporalio_sdk_core_c_bridge
 --output
 src/Temporalio/Bridge/Interop/Interop.cs
 --additional

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -572,6 +572,9 @@ namespace Temporalio.Bridge.Interop
     {
         [NativeTypeName("const struct TemporalCoreTelemetryOptions *")]
         public TemporalCoreTelemetryOptions* telemetry;
+
+        [NativeTypeName("uint64_t")]
+        public ulong worker_heartbeat_duration_millis;
     }
 
     internal partial struct TemporalCoreTestServerOptions

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -214,6 +214,9 @@ namespace Temporalio.Bridge.Interop
         public IntPtr grpc_override_callback;
 
         public void* grpc_override_callback_user_data;
+
+        [NativeTypeName("struct TemporalCoreByteArrayRefArray")]
+        public TemporalCoreByteArrayRefArray plugin_names;
     }
 
     internal unsafe partial struct TemporalCoreByteArray
@@ -574,7 +577,7 @@ namespace Temporalio.Bridge.Interop
         public TemporalCoreTelemetryOptions* telemetry;
 
         [NativeTypeName("uint64_t")]
-        public ulong worker_heartbeat_duration_millis;
+        public ulong worker_heartbeat_interval_millis;
     }
 
     internal partial struct TemporalCoreTestServerOptions
@@ -1188,6 +1191,9 @@ namespace Temporalio.Bridge.Interop
 
         [NativeTypeName("struct TemporalCoreByteArrayRefArray")]
         public TemporalCoreByteArrayRefArray nondeterminism_as_workflow_fail_for_types;
+
+        [NativeTypeName("struct TemporalCoreByteArrayRefArray")]
+        public TemporalCoreByteArrayRefArray plugins;
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -1115,6 +1115,21 @@ namespace Temporalio.Bridge.Interop
         public UIntPtr size;
     }
 
+    internal partial struct TemporalCoreWorkerTaskTypes
+    {
+        [NativeTypeName("bool")]
+        public byte enable_workflows;
+
+        [NativeTypeName("bool")]
+        public byte enable_local_activities;
+
+        [NativeTypeName("bool")]
+        public byte enable_remote_activities;
+
+        [NativeTypeName("bool")]
+        public byte enable_nexus;
+    }
+
     internal partial struct TemporalCoreWorkerOptions
     {
         [NativeTypeName("struct TemporalCoreByteArrayRef")]
@@ -1135,8 +1150,8 @@ namespace Temporalio.Bridge.Interop
         [NativeTypeName("struct TemporalCoreTunerHolder")]
         public TemporalCoreTunerHolder tuner;
 
-        [NativeTypeName("bool")]
-        public byte no_remote_activities;
+        [NativeTypeName("struct TemporalCoreWorkerTaskTypes")]
+        public TemporalCoreWorkerTaskTypes task_types;
 
         [NativeTypeName("uint64_t")]
         public ulong sticky_queue_schedule_to_start_timeout_millis;
@@ -1198,207 +1213,207 @@ namespace Temporalio.Bridge.Interop
 
     internal static unsafe partial class Methods
     {
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreCancellationToken *")]
         public static extern TemporalCoreCancellationToken* temporal_core_cancellation_token_new();
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_cancellation_token_cancel([NativeTypeName("struct TemporalCoreCancellationToken *")] TemporalCoreCancellationToken* token);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_cancellation_token_free([NativeTypeName("struct TemporalCoreCancellationToken *")] TemporalCoreCancellationToken* token);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_client_connect([NativeTypeName("struct TemporalCoreRuntime *")] TemporalCoreRuntime* runtime, [NativeTypeName("const struct TemporalCoreClientOptions *")] TemporalCoreClientOptions* options, void* user_data, [NativeTypeName("TemporalCoreClientConnectCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_client_free([NativeTypeName("struct TemporalCoreClient *")] TemporalCoreClient* client);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_client_update_metadata([NativeTypeName("struct TemporalCoreClient *")] TemporalCoreClient* client, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef metadata);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_client_update_api_key([NativeTypeName("struct TemporalCoreClient *")] TemporalCoreClient* client, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef api_key);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreByteArrayRef")]
         public static extern TemporalCoreByteArrayRef temporal_core_client_grpc_override_request_service([NativeTypeName("const struct TemporalCoreClientGrpcOverrideRequest *")] TemporalCoreClientGrpcOverrideRequest* req);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreByteArrayRef")]
         public static extern TemporalCoreByteArrayRef temporal_core_client_grpc_override_request_rpc([NativeTypeName("const struct TemporalCoreClientGrpcOverrideRequest *")] TemporalCoreClientGrpcOverrideRequest* req);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("TemporalCoreMetadataRef")]
         public static extern TemporalCoreByteArrayRef temporal_core_client_grpc_override_request_headers([NativeTypeName("const struct TemporalCoreClientGrpcOverrideRequest *")] TemporalCoreClientGrpcOverrideRequest* req);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreByteArrayRef")]
         public static extern TemporalCoreByteArrayRef temporal_core_client_grpc_override_request_proto([NativeTypeName("const struct TemporalCoreClientGrpcOverrideRequest *")] TemporalCoreClientGrpcOverrideRequest* req);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_client_grpc_override_request_respond([NativeTypeName("struct TemporalCoreClientGrpcOverrideRequest *")] TemporalCoreClientGrpcOverrideRequest* req, [NativeTypeName("struct TemporalCoreClientGrpcOverrideResponse")] TemporalCoreClientGrpcOverrideResponse resp);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_client_rpc_call([NativeTypeName("struct TemporalCoreClient *")] TemporalCoreClient* client, [NativeTypeName("const struct TemporalCoreRpcCallOptions *")] TemporalCoreRpcCallOptions* options, void* user_data, [NativeTypeName("TemporalCoreClientRpcCallCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreClientEnvConfigOrFail")]
         public static extern TemporalCoreClientEnvConfigOrFail temporal_core_client_env_config_load([NativeTypeName("const struct TemporalCoreClientEnvConfigLoadOptions *")] TemporalCoreClientEnvConfigLoadOptions* options);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreClientEnvConfigProfileOrFail")]
         public static extern TemporalCoreClientEnvConfigProfileOrFail temporal_core_client_env_config_profile_load([NativeTypeName("const struct TemporalCoreClientEnvConfigProfileLoadOptions *")] TemporalCoreClientEnvConfigProfileLoadOptions* options);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreMetricMeter *")]
         public static extern TemporalCoreMetricMeter* temporal_core_metric_meter_new([NativeTypeName("struct TemporalCoreRuntime *")] TemporalCoreRuntime* runtime);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_metric_meter_free([NativeTypeName("struct TemporalCoreMetricMeter *")] TemporalCoreMetricMeter* meter);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreMetricAttributes *")]
         public static extern TemporalCoreMetricAttributes* temporal_core_metric_attributes_new([NativeTypeName("const struct TemporalCoreMetricMeter *")] TemporalCoreMetricMeter* meter, [NativeTypeName("const struct TemporalCoreMetricAttribute *")] TemporalCoreMetricAttribute* attrs, [NativeTypeName("size_t")] UIntPtr size);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreMetricAttributes *")]
         public static extern TemporalCoreMetricAttributes* temporal_core_metric_attributes_new_append([NativeTypeName("const struct TemporalCoreMetricMeter *")] TemporalCoreMetricMeter* meter, [NativeTypeName("const struct TemporalCoreMetricAttributes *")] TemporalCoreMetricAttributes* orig, [NativeTypeName("const struct TemporalCoreMetricAttribute *")] TemporalCoreMetricAttribute* attrs, [NativeTypeName("size_t")] UIntPtr size);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_metric_attributes_free([NativeTypeName("struct TemporalCoreMetricAttributes *")] TemporalCoreMetricAttributes* attrs);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreMetric *")]
         public static extern TemporalCoreMetric* temporal_core_metric_new([NativeTypeName("const struct TemporalCoreMetricMeter *")] TemporalCoreMetricMeter* meter, [NativeTypeName("const struct TemporalCoreMetricOptions *")] TemporalCoreMetricOptions* options);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_metric_free([NativeTypeName("struct TemporalCoreMetric *")] TemporalCoreMetric* metric);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_metric_record_integer([NativeTypeName("const struct TemporalCoreMetric *")] TemporalCoreMetric* metric, [NativeTypeName("uint64_t")] ulong value, [NativeTypeName("const struct TemporalCoreMetricAttributes *")] TemporalCoreMetricAttributes* attrs);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_metric_record_float([NativeTypeName("const struct TemporalCoreMetric *")] TemporalCoreMetric* metric, double value, [NativeTypeName("const struct TemporalCoreMetricAttributes *")] TemporalCoreMetricAttributes* attrs);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_metric_record_duration([NativeTypeName("const struct TemporalCoreMetric *")] TemporalCoreMetric* metric, [NativeTypeName("uint64_t")] ulong value_ms, [NativeTypeName("const struct TemporalCoreMetricAttributes *")] TemporalCoreMetricAttributes* attrs);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreRandom *")]
         public static extern TemporalCoreRandom* temporal_core_random_new([NativeTypeName("uint64_t")] ulong seed);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_random_free([NativeTypeName("struct TemporalCoreRandom *")] TemporalCoreRandom* random);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
         public static extern int temporal_core_random_int32_range([NativeTypeName("struct TemporalCoreRandom *")] TemporalCoreRandom* random, [NativeTypeName("int32_t")] int min, [NativeTypeName("int32_t")] int max, [NativeTypeName("bool")] byte max_inclusive);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern double temporal_core_random_double_range([NativeTypeName("struct TemporalCoreRandom *")] TemporalCoreRandom* random, double min, double max, [NativeTypeName("bool")] byte max_inclusive);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_random_fill_bytes([NativeTypeName("struct TemporalCoreRandom *")] TemporalCoreRandom* random, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef bytes);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreRuntimeOrFail")]
         public static extern TemporalCoreRuntimeOrFail temporal_core_runtime_new([NativeTypeName("const struct TemporalCoreRuntimeOptions *")] TemporalCoreRuntimeOptions* options);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_runtime_free([NativeTypeName("struct TemporalCoreRuntime *")] TemporalCoreRuntime* runtime);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_byte_array_free([NativeTypeName("struct TemporalCoreRuntime *")] TemporalCoreRuntime* runtime, [NativeTypeName("const struct TemporalCoreByteArray *")] TemporalCoreByteArray* bytes);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreByteArrayRef")]
         public static extern TemporalCoreByteArrayRef temporal_core_forwarded_log_target([NativeTypeName("const struct TemporalCoreForwardedLog *")] TemporalCoreForwardedLog* log);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreByteArrayRef")]
         public static extern TemporalCoreByteArrayRef temporal_core_forwarded_log_message([NativeTypeName("const struct TemporalCoreForwardedLog *")] TemporalCoreForwardedLog* log);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("uint64_t")]
         public static extern ulong temporal_core_forwarded_log_timestamp_millis([NativeTypeName("const struct TemporalCoreForwardedLog *")] TemporalCoreForwardedLog* log);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreByteArrayRef")]
         public static extern TemporalCoreByteArrayRef temporal_core_forwarded_log_fields_json([NativeTypeName("const struct TemporalCoreForwardedLog *")] TemporalCoreForwardedLog* log);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_ephemeral_server_start_dev_server([NativeTypeName("struct TemporalCoreRuntime *")] TemporalCoreRuntime* runtime, [NativeTypeName("const struct TemporalCoreDevServerOptions *")] TemporalCoreDevServerOptions* options, void* user_data, [NativeTypeName("TemporalCoreEphemeralServerStartCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_ephemeral_server_start_test_server([NativeTypeName("struct TemporalCoreRuntime *")] TemporalCoreRuntime* runtime, [NativeTypeName("const struct TemporalCoreTestServerOptions *")] TemporalCoreTestServerOptions* options, void* user_data, [NativeTypeName("TemporalCoreEphemeralServerStartCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_ephemeral_server_free([NativeTypeName("struct TemporalCoreEphemeralServer *")] TemporalCoreEphemeralServer* server);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_ephemeral_server_shutdown([NativeTypeName("struct TemporalCoreEphemeralServer *")] TemporalCoreEphemeralServer* server, void* user_data, [NativeTypeName("TemporalCoreEphemeralServerShutdownCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreWorkerOrFail")]
         public static extern TemporalCoreWorkerOrFail temporal_core_worker_new([NativeTypeName("struct TemporalCoreClient *")] TemporalCoreClient* client, [NativeTypeName("const struct TemporalCoreWorkerOptions *")] TemporalCoreWorkerOptions* options);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_free([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_validate([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, void* user_data, [NativeTypeName("TemporalCoreWorkerCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_replace_client([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, [NativeTypeName("struct TemporalCoreClient *")] TemporalCoreClient* new_client);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_poll_workflow_activation([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, void* user_data, [NativeTypeName("TemporalCoreWorkerPollCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_poll_activity_task([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, void* user_data, [NativeTypeName("TemporalCoreWorkerPollCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_poll_nexus_task([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, void* user_data, [NativeTypeName("TemporalCoreWorkerPollCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_complete_workflow_activation([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef completion, void* user_data, [NativeTypeName("TemporalCoreWorkerCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_complete_activity_task([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef completion, void* user_data, [NativeTypeName("TemporalCoreWorkerCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_complete_nexus_task([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef completion, void* user_data, [NativeTypeName("TemporalCoreWorkerCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const struct TemporalCoreByteArray *")]
         public static extern TemporalCoreByteArray* temporal_core_worker_record_activity_heartbeat([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef heartbeat);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_request_workflow_eviction([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef run_id);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_initiate_shutdown([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_finalize_shutdown([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, void* user_data, [NativeTypeName("TemporalCoreWorkerCallback")] IntPtr callback);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreWorkerReplayerOrFail")]
         public static extern TemporalCoreWorkerReplayerOrFail temporal_core_worker_replayer_new([NativeTypeName("struct TemporalCoreRuntime *")] TemporalCoreRuntime* runtime, [NativeTypeName("const struct TemporalCoreWorkerOptions *")] TemporalCoreWorkerOptions* options);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void temporal_core_worker_replay_pusher_free([NativeTypeName("struct TemporalCoreWorkerReplayPusher *")] TemporalCoreWorkerReplayPusher* worker_replay_pusher);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct TemporalCoreWorkerReplayPushResult")]
         public static extern TemporalCoreWorkerReplayPushResult temporal_core_worker_replay_push([NativeTypeName("struct TemporalCoreWorker *")] TemporalCoreWorker* worker, [NativeTypeName("struct TemporalCoreWorkerReplayPusher *")] TemporalCoreWorkerReplayPusher* worker_replay_pusher, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef workflow_id, [NativeTypeName("struct TemporalCoreByteArrayRef")] TemporalCoreByteArrayRef history);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
         public static extern byte temporal_core_complete_async_reserve([NativeTypeName("const struct TemporalCoreSlotReserveCompletionCtx *")] TemporalCoreSlotReserveCompletionCtx* completion_ctx, [NativeTypeName("uintptr_t")] UIntPtr permit_id);
 
-        [DllImport("temporal_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("temporalio_sdk_core_c_bridge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
         public static extern byte temporal_core_complete_async_cancel_reserve([NativeTypeName("const struct TemporalCoreSlotReserveCompletionCtx *")] TemporalCoreSlotReserveCompletionCtx* completion_ctx);
     }

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -33,7 +33,8 @@ namespace Temporalio.Bridge
             return new Interop.TemporalCoreRuntimeOptions()
             {
                 telemetry = scope.Pointer(options.Telemetry.ToInteropOptions(scope)),
-                worker_heartbeat_interval_millis = (ulong)options.WorkerHeartbeatInterval.TotalMilliseconds,
+                worker_heartbeat_interval_millis =
+                    (ulong)(options.WorkerHeartbeatInterval?.TotalMilliseconds ?? 0),
             };
         }
 
@@ -563,10 +564,10 @@ namespace Temporalio.Bridge
             options.NexusTaskPollerBehavior ??= new PollerBehavior.SimpleMaximum(options.MaxConcurrentNexusTaskPolls);
             var workerPluginNames = options.Plugins?
                 .Select(p => p.Name)
-                .Where(name => !string.IsNullOrEmpty(name)) ?? Enumerable.Empty<string>();
+                ?? Enumerable.Empty<string>();
             var clientPluginNames = clientPlugins?
                 .Select(p => p.Name)
-                .Where(name => !string.IsNullOrEmpty(name)) ?? Enumerable.Empty<string>();
+                ?? Enumerable.Empty<string>();
             var pluginNames = workerPluginNames
                 .Concat(clientPluginNames)
                 .Distinct()

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -33,6 +33,7 @@ namespace Temporalio.Bridge
             return new Interop.TemporalCoreRuntimeOptions()
             {
                 telemetry = scope.Pointer(options.Telemetry.ToInteropOptions(scope)),
+                worker_heartbeat_interval_millis = (ulong)options.WorkerHeartbeatInterval.TotalMilliseconds,
             };
         }
 

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -621,7 +621,6 @@ namespace Temporalio.Bridge
             }
             var pluginNames = options.Plugins?
                 .Select(p => p.Name)
-                .Where(name => !string.IsNullOrEmpty(name))
                 .Distinct()
                 .ToArray() ?? Array.Empty<string>();
             return new()

--- a/src/Temporalio/Bridge/Worker.cs
+++ b/src/Temporalio/Bridge/Worker.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Google.Protobuf;
@@ -19,6 +20,7 @@ namespace Temporalio.Bridge
         /// <param name="options">Options for the worker.</param>
         /// <param name="loggerFactory">Logger factory, used instead of the one in options by
         ///   anything in the bridge that needs it, since it's guaranteed to be set.</param>
+        /// <param name="clientPlugins">Client plugins to include in heartbeat.</param>
         /// <exception cref="Exception">
         /// If any of the options are invalid including improperly defined workflows/activities.
         /// </exception>
@@ -26,7 +28,8 @@ namespace Temporalio.Bridge
             Client client,
             string namespace_,
             Temporalio.Worker.TemporalWorkerOptions options,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IReadOnlyCollection<Temporalio.Client.ITemporalClientPlugin>? clientPlugins = null)
             : base(IntPtr.Zero, true)
         {
             Runtime = client.Runtime;
@@ -36,7 +39,7 @@ namespace Temporalio.Bridge
                 {
                     var workerOrFail = Interop.Methods.temporal_core_worker_new(
                         client.Ptr,
-                        scope.Pointer(options.ToInteropOptions(scope, namespace_, loggerFactory)));
+                        scope.Pointer(options.ToInteropOptions(scope, namespace_, loggerFactory, clientPlugins)));
                     if (workerOrFail.fail != null)
                     {
                         string failStr;

--- a/src/Temporalio/Runtime/TelemetryFilterOptions.cs
+++ b/src/Temporalio/Runtime/TelemetryFilterOptions.cs
@@ -24,7 +24,7 @@ namespace Temporalio.Runtime
             var coreLevel = core.ToString().ToUpper();
             var otherLevel = other.ToString().ToUpper();
             FilterString =
-                $"{otherLevel},temporal_sdk_core={coreLevel},temporal_client={coreLevel},temporal_sdk={coreLevel}";
+                $"{otherLevel},temporalio_sdk_core={coreLevel},temporalio_client={coreLevel},temporalio_sdk={coreLevel}";
         }
 
         /// <summary>
@@ -62,8 +62,8 @@ namespace Temporalio.Runtime
         /// Gets or sets the filter string for telemetry filters.
         /// </summary>
         /// <remarks>
-        /// This is in the Rust log format. For example, "temporal_sdk_core=DEBUG" sets the level
-        /// to <c>DEBUG</c> for the <c>temporal_sdk_core</c> Rust crate.
+        /// This is in the Rust log format. For example, "temporalio_sdk_core=DEBUG" sets the level
+        /// to <c>DEBUG</c> for the <c>temporalio_sdk_core</c> Rust crate.
         /// </remarks>
         public string? FilterString { get; set; }
 

--- a/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
+++ b/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
@@ -18,12 +18,22 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="TemporalRuntimeOptions"/> class.
         /// </summary>
         /// <param name="telemetry"><see cref="Telemetry" />.</param>
-        public TemporalRuntimeOptions(TelemetryOptions telemetry) => Telemetry = telemetry;
+        /// <param name="workerHeartbeatInterval">Worker heartbeat interval. If 0 is specified, heartbeat is disabled.</param>
+        public TemporalRuntimeOptions(TelemetryOptions telemetry, TimeSpan workerHeartbeatInterval)
+        {
+            Telemetry = telemetry;
+            WorkerHeartbeatInterval = workerHeartbeatInterval;
+        }
 
         /// <summary>
         /// Gets or sets the telemetry options.
         /// </summary>
         public TelemetryOptions Telemetry { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the worker heartbeat duration in milliseconds.
+        /// </summary>
+        public TimeSpan WorkerHeartbeatInterval { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// Create a shallow copy of these options.

--- a/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
+++ b/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
@@ -18,22 +18,7 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="TemporalRuntimeOptions"/> class.
         /// </summary>
         /// <param name="telemetry"><see cref="Telemetry" />.</param>
-        public TemporalRuntimeOptions(TelemetryOptions telemetry)
-            : this(telemetry, TimeSpan.FromSeconds(60))
-        {
-            Telemetry = telemetry;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TemporalRuntimeOptions"/> class.
-        /// </summary>
-        /// <param name="telemetry"><see cref="Telemetry" />.</param>
-        /// <param name="workerHeartbeatInterval">Worker heartbeat interval. If 0 is specified, heartbeat is disabled.</param>
-        public TemporalRuntimeOptions(TelemetryOptions telemetry, TimeSpan workerHeartbeatInterval)
-        {
-            Telemetry = telemetry;
-            WorkerHeartbeatInterval = workerHeartbeatInterval;
-        }
+        public TemporalRuntimeOptions(TelemetryOptions telemetry) => Telemetry = telemetry;
 
         /// <summary>
         /// Gets or sets the telemetry options.
@@ -43,7 +28,7 @@ namespace Temporalio.Runtime
         /// <summary>
         /// Gets or sets the worker heartbeat duration in milliseconds.
         /// </summary>
-        public TimeSpan WorkerHeartbeatInterval { get; set; } = TimeSpan.FromSeconds(60);
+        public TimeSpan? WorkerHeartbeatInterval { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// Create a shallow copy of these options.

--- a/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
+++ b/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
@@ -18,6 +18,16 @@ namespace Temporalio.Runtime
         /// Initializes a new instance of the <see cref="TemporalRuntimeOptions"/> class.
         /// </summary>
         /// <param name="telemetry"><see cref="Telemetry" />.</param>
+        public TemporalRuntimeOptions(TelemetryOptions telemetry)
+            : this(telemetry, TimeSpan.FromSeconds(60))
+        {
+            Telemetry = telemetry;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporalRuntimeOptions"/> class.
+        /// </summary>
+        /// <param name="telemetry"><see cref="Telemetry" />.</param>
         /// <param name="workerHeartbeatInterval">Worker heartbeat interval. If 0 is specified, heartbeat is disabled.</param>
         public TemporalRuntimeOptions(TelemetryOptions telemetry, TimeSpan workerHeartbeatInterval)
         {

--- a/src/Temporalio/Temporalio.csproj
+++ b/src/Temporalio/Temporalio.csproj
@@ -34,17 +34,17 @@
   <!-- Build/copy debug/release bridge DLL -->
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <BridgeLibraryFile>temporal_sdk_core_c_bridge.dll</BridgeLibraryFile>
+    <BridgeLibraryFile>temporalio_sdk_core_c_bridge.dll</BridgeLibraryFile>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-    <BridgeLibraryFile>libtemporal_sdk_core_c_bridge.so</BridgeLibraryFile>
+    <BridgeLibraryFile>libtemporalio_sdk_core_c_bridge.so</BridgeLibraryFile>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <BridgeLibraryFile>libtemporal_sdk_core_c_bridge.dylib</BridgeLibraryFile>
+    <BridgeLibraryFile>libtemporalio_sdk_core_c_bridge.dylib</BridgeLibraryFile>
   </PropertyGroup>
 
   <Target Name="CargoBuildDebug" BeforeTargets="DispatchToInnerBuilds" Condition="'$(Configuration)' == 'Debug'">
-    <Exec Command="cargo build" WorkingDirectory="Bridge/sdk-core/core-c-bridge" />
+    <Exec Command="cargo build" WorkingDirectory="Bridge/sdk-core/crates/sdk-core-c-bridge" />
   </Target>
   <Target Name="CopyBridgeDLLDebug" BeforeTargets="PreBuildEvent" Condition="'$(Configuration)' == 'Debug'">
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
@@ -57,10 +57,10 @@
   </Target>
 
   <Target Name="CargoBuildRelease" BeforeTargets="DispatchToInnerBuilds" Condition="'$(Configuration)' == 'Release' AND '$(BridgeLibraryRoot)' == ''">
-    <Exec Command="cargo build --profile release-lto" WorkingDirectory="Bridge/sdk-core/core-c-bridge" />
+    <Exec Command="cargo build --profile release-lto" WorkingDirectory="Bridge/sdk-core/crates/sdk-core-c-bridge" />
   </Target>
   <Target Name="CopyBridgeDLLRelease" BeforeTargets="PreBuildEvent" Condition="'$(Configuration)' == 'Release' AND '$(BridgeLibraryRoot)' == ''">
-    <Exec Command="cargo build --profile release-lto" WorkingDirectory="Bridge/sdk-core/core-c-bridge" />
+    <Exec Command="cargo build --profile release-lto" WorkingDirectory="Bridge/sdk-core/crates/sdk-core-c-bridge" />
     <ItemGroup Condition="'$(Configuration)' == 'Release'">
       <Content Include="Bridge/sdk-core/target/release-lto/$(BridgeLibraryFile)">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Temporalio/Temporalio.csproj
+++ b/src/Temporalio/Temporalio.csproj
@@ -85,26 +85,26 @@
   <!-- Pack the runtime if BridgeLibraryRoot property set -->
   <Target Name="PackBridgeRuntimes" BeforeTargets="DispatchToInnerBuilds" Condition="'$(BridgeLibraryRoot)' != ''">
     <ItemGroup>
-      <Content Include="$(BridgeLibraryRoot)/linux-x64-bridge/libtemporal_sdk_core_c_bridge.so">
-        <PackagePath>runtimes/linux-x64/native/libtemporal_sdk_core_c_bridge.so</PackagePath>
+      <Content Include="$(BridgeLibraryRoot)/linux-x64-bridge/libtemporalio_sdk_core_c_bridge.so">
+        <PackagePath>runtimes/linux-x64/native/libtemporalio_sdk_core_c_bridge.so</PackagePath>
       </Content>
-      <Content Include="$(BridgeLibraryRoot)/linux-arm64-bridge/libtemporal_sdk_core_c_bridge.so">
-        <PackagePath>runtimes/linux-arm64/native/libtemporal_sdk_core_c_bridge.so</PackagePath>
+      <Content Include="$(BridgeLibraryRoot)/linux-arm64-bridge/libtemporalio_sdk_core_c_bridge.so">
+        <PackagePath>runtimes/linux-arm64/native/libtemporalio_sdk_core_c_bridge.so</PackagePath>
       </Content>
-      <Content Include="$(BridgeLibraryRoot)/linux-musl-x64-bridge/libtemporal_sdk_core_c_bridge.so">
-        <PackagePath>runtimes/linux-musl-x64/native/libtemporal_sdk_core_c_bridge.so</PackagePath>
+      <Content Include="$(BridgeLibraryRoot)/linux-musl-x64-bridge/libtemporalio_sdk_core_c_bridge.so">
+        <PackagePath>runtimes/linux-musl-x64/native/libtemporalio_sdk_core_c_bridge.so</PackagePath>
       </Content>
-      <Content Include="$(BridgeLibraryRoot)/osx-x64-bridge/libtemporal_sdk_core_c_bridge.dylib">
-        <PackagePath>runtimes/osx-x64/native/libtemporal_sdk_core_c_bridge.dylib</PackagePath>
+      <Content Include="$(BridgeLibraryRoot)/osx-x64-bridge/libtemporalio_sdk_core_c_bridge.dylib">
+        <PackagePath>runtimes/osx-x64/native/libtemporalio_sdk_core_c_bridge.dylib</PackagePath>
       </Content>
-      <Content Include="$(BridgeLibraryRoot)/osx-arm64-bridge/libtemporal_sdk_core_c_bridge.dylib">
-        <PackagePath>runtimes/osx-arm64/native/libtemporal_sdk_core_c_bridge.dylib</PackagePath>
+      <Content Include="$(BridgeLibraryRoot)/osx-arm64-bridge/libtemporalio_sdk_core_c_bridge.dylib">
+        <PackagePath>runtimes/osx-arm64/native/libtemporalio_sdk_core_c_bridge.dylib</PackagePath>
       </Content>
-      <Content Include="$(BridgeLibraryRoot)/win-x64-bridge/temporal_sdk_core_c_bridge.dll">
-        <PackagePath>runtimes/win-x64/native/temporal_sdk_core_c_bridge.dll</PackagePath>
+      <Content Include="$(BridgeLibraryRoot)/win-x64-bridge/temporalio_sdk_core_c_bridge.dll">
+        <PackagePath>runtimes/win-x64/native/temporalio_sdk_core_c_bridge.dll</PackagePath>
       </Content>
-      <Content Include="$(BridgeLibraryRoot)/win-arm64-bridge/temporal_sdk_core_c_bridge.dll">
-        <PackagePath>runtimes/win-arm64/native/temporal_sdk_core_c_bridge.dll</PackagePath>
+      <Content Include="$(BridgeLibraryRoot)/win-arm64-bridge/temporalio_sdk_core_c_bridge.dll">
+        <PackagePath>runtimes/win-arm64/native/temporalio_sdk_core_c_bridge.dll</PackagePath>
       </Content>
     </ItemGroup>
   </Target>

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -67,7 +67,8 @@ namespace Temporalio.Worker
                     (Bridge.Client)bridgeClient,
                     client.Options.Namespace,
                     options,
-                    loggerFactory);
+                    loggerFactory,
+                    client.Options.Plugins);
                 if (options.Activities.Count == 0 && options.Workflows.Count == 0)
                 {
                     throw new ArgumentException("Must have at least one workflow and/or activity");

--- a/src/Temporalio/build/net462/Temporalio.targets
+++ b/src/Temporalio/build/net462/Temporalio.targets
@@ -2,27 +2,27 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-$(Platform)\native\libtemporal_sdk_core_c_bridge.so">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-$(Platform)\native\libtemporalio_sdk_core_c_bridge.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>libtemporal_sdk_core_c_bridge.so</Link>
+      <Link>libtemporalio_sdk_core_c_bridge.so</Link>
       <Visible>false</Visible>
       <NuGetPackageId>Temporalio</NuGetPackageId>
     </Content>
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-$(Platform)\native\libtemporal_sdk_core_c_bridge.dylib">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-$(Platform)\native\libtemporalio_sdk_core_c_bridge.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>libtemporal_sdk_core_c_bridge.dylib</Link>
+      <Link>libtemporalio_sdk_core_c_bridge.dylib</Link>
       <Visible>false</Visible>
       <NuGetPackageId>Temporalio</NuGetPackageId>
     </Content>
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(Platform)\native\temporal_sdk_core_c_bridge.dll">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(Platform)\native\temporalio_sdk_core_c_bridge.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>temporal_sdk_core_c_bridge.dll</Link>
+      <Link>temporalio_sdk_core_c_bridge.dll</Link>
       <Visible>false</Visible>
       <NuGetPackageId>Temporalio</NuGetPackageId>
     </Content>

--- a/tests/Temporalio.Tests/Common/PluginTests.cs
+++ b/tests/Temporalio.Tests/Common/PluginTests.cs
@@ -179,7 +179,7 @@ public class PluginTests : WorkflowEnvironmentTestBase
 
         using var worker = new TemporalWorker(client, new TemporalWorkerOptions()
         {
-            TaskQueue = "TestSimplePlugin_Basic",
+            TaskQueue = "TestSimplePlugin_Basic" + Guid.NewGuid(),
         });
         Assert.NotNull(client.Options.DataConverter.PayloadCodec);
     }
@@ -200,7 +200,7 @@ public class PluginTests : WorkflowEnvironmentTestBase
 
         using var worker = new TemporalWorker(client, new TemporalWorkerOptions()
         {
-            TaskQueue = "TestSimplePlugin_Function",
+            TaskQueue = "TestSimplePlugin_Function" + Guid.NewGuid(),
         });
         Assert.NotNull(client.Options.DataConverter.PayloadCodec);
     }
@@ -220,7 +220,7 @@ public class PluginTests : WorkflowEnvironmentTestBase
         var client = new TemporalClient(Env.Client.Connection, newOptions);
         using var worker = new TemporalWorker(client, new TemporalWorkerOptions()
         {
-            TaskQueue = "TestSimplePlugin_Function",
+            TaskQueue = "TestSimplePlugin_Function" + Guid.NewGuid(),
         });
         using var cancelToken = new CancellationTokenSource();
         var execution = worker.ExecuteAsync(cancelToken.Token);

--- a/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
+++ b/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
@@ -214,6 +214,7 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
             var runtime = new TemporalRuntime(new()
             {
                 Telemetry = new() { Logging = new() { Forwarding = options } },
+                WorkerHeartbeatInterval = null,
             });
 
             // Connect client with different runtime
@@ -245,14 +246,14 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
         // Try with fields included
         var entry = await RunWorkerUntilFailLogAsync(new());
         Assert.Equal(LogLevel.Warning, entry.Level);
-        Assert.StartsWith("[sdk_core::temporal_sdk_core::worker::workflow] Failing workflow task", entry.Formatted);
+        Assert.StartsWith("[sdk_core::temporalio_sdk_core::worker::workflow] Failing workflow task", entry.Formatted);
         Assert.Contains("Intentional error", entry.Formatted);
         Assert.IsType<ForwardedLog>(entry.State);
         var state = Assert.IsAssignableFrom<IEnumerable<KeyValuePair<string, object?>>>(entry.State);
         var dict = new Dictionary<string, object?>(state);
         Assert.Equal(5, dict.Count);
         Assert.Equal(LogLevel.Warning, dict["Level"]);
-        Assert.Equal("temporal_sdk_core::worker::workflow", dict["Target"]);
+        Assert.Equal("temporalio_sdk_core::worker::workflow", dict["Target"]);
         Assert.Equal("Failing workflow task", dict["Message"]);
         Assert.True(DateTime.UtcNow.Subtract((DateTime)dict["Timestamp"]!).Duration() < TimeSpan.FromMinutes(5));
         var fields = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(dict["JsonFields"]);
@@ -261,7 +262,7 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
 
         // Now without fields included
         entry = await RunWorkerUntilFailLogAsync(new() { IncludeFields = false });
-        Assert.Equal("[sdk_core::temporal_sdk_core::worker::workflow] Failing workflow task", entry.Formatted);
+        Assert.Equal("[sdk_core::temporalio_sdk_core::worker::workflow] Failing workflow task", entry.Formatted);
         state = Assert.IsAssignableFrom<IEnumerable<KeyValuePair<string, object?>>>(entry.State);
         dict = new Dictionary<string, object?>(state);
         Assert.Null(dict["JsonFields"]);

--- a/tests/Temporalio.Tests/TestUtils.cs
+++ b/tests/Temporalio.Tests/TestUtils.cs
@@ -171,9 +171,7 @@ public static class TestUtils
 
     public class CaptureMetricMeter : ICustomMetricMeter
     {
-        private readonly ConcurrentDictionary<string, CaptureMetric> metricsByName = new();
-
-        public ICollection<CaptureMetric> Metrics => metricsByName.Values;
+        public ConcurrentQueue<CaptureMetric> Metrics { get; } = new();
 
         public ICustomMetricCounter<T> CreateCounter<T>(
             string name, string? unit, string? description)
@@ -204,9 +202,12 @@ public static class TestUtils
         }
 
         private TMetric CreateMetric<TValue, TMetric>(string name, string? unit, string? description)
-            where TValue : struct =>
-            (TMetric)(object)metricsByName.GetOrAdd(
-                name, _ => new CaptureMetric<TValue>(name, unit, description));
+            where TValue : struct
+        {
+            var metric = new CaptureMetric<TValue>(name, unit, description);
+            Metrics.Enqueue(metric);
+            return (TMetric)(object)metric;
+        }
     }
 
     public abstract record CaptureMetric(string Name, string? Unit, string? Description)

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -3381,7 +3381,6 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 // We'll also test the metric prefix
                 Metrics = new() { Prometheus = new(promAddr), MetricPrefix = "foo_" },
             },
-            WorkerHeartbeatInterval = null,
         });
         var client = await TemporalClient.ConnectAsync(
             new()
@@ -3487,7 +3486,6 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             {
                 Metrics = new() { CustomMetricMeter = meter, MetricPrefix = "some-prefix_" },
             },
-            WorkerHeartbeatInterval = null,
         });
         var client = await TemporalClient.ConnectAsync(
             new()
@@ -3561,7 +3559,6 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                         CustomMetricMeterOptions = new() { HistogramDurationFormat = durationFormat },
                     },
                 },
-                WorkerHeartbeatInterval = null,
             });
             var client = await TemporalClient.ConnectAsync(
                 new()

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -3381,6 +3381,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 // We'll also test the metric prefix
                 Metrics = new() { Prometheus = new(promAddr), MetricPrefix = "foo_" },
             },
+            WorkerHeartbeatInterval = null,
         });
         var client = await TemporalClient.ConnectAsync(
             new()
@@ -3486,6 +3487,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             {
                 Metrics = new() { CustomMetricMeter = meter, MetricPrefix = "some-prefix_" },
             },
+            WorkerHeartbeatInterval = null,
         });
         var client = await TemporalClient.ConnectAsync(
             new()
@@ -3559,6 +3561,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                         CustomMetricMeterOptions = new() { HistogramDurationFormat = durationFormat },
                     },
                 },
+                WorkerHeartbeatInterval = null,
             });
             var client = await TemporalClient.ConnectAsync(
                 new()

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -3536,7 +3536,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             v.Tags.Contains(new("my-activity-extra-tag", 12.34D)) &&
             (long)v.Value == 34);
         // Check Temporal metric
-        metric = Assert.Single(meter.Metrics, m => m.Name == "some-prefix_workflow_completed");
+        metric = Assert.Single(
+            meter.Metrics, m => m.Name == "some-prefix_workflow_completed" && !m.Values.IsEmpty);
         Assert.Single(metric.Values, v =>
             v.Tags.Contains(new("workflow_type", "CustomMetricsWorkflow")) &&
             (long)v.Value == 1);
@@ -3588,7 +3589,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         var meter = await DoStuffAsync(CustomMetricMeterOptions.DurationFormat.IntegerMilliseconds);
         Assert.Single(
             Assert.Single(meter.Metrics, v =>
-                v.Name == "temporal_workflow_task_execution_latency" && v.Unit == "ms").Values,
+                v.Name == "temporal_workflow_task_execution_latency" && v.Unit == "ms"
+                && !v.Values.IsEmpty).Values,
             v => v.Value is long val);
         Assert.Single(
             Assert.Single(meter.Metrics, v => v.Name == "my-histogram-float").Values,
@@ -3605,7 +3607,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         // Took less than 5s
         Assert.Single(
             Assert.Single(meter.Metrics, v =>
-                v.Name == "temporal_workflow_task_execution_latency" && v.Unit == "s").Values,
+                v.Name == "temporal_workflow_task_execution_latency" && v.Unit == "s"
+                && !v.Values.IsEmpty).Values,
             v => v.Value is double val && val < 5);
         Assert.Single(
             Assert.Single(meter.Metrics, v => v.Name == "my-histogram-duration").Values,
@@ -3616,7 +3619,8 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         // Took less than 5s
         Assert.Single(
             Assert.Single(meter.Metrics, v =>
-                v.Name == "temporal_workflow_task_execution_latency" && v.Unit == "duration").Values,
+                v.Name == "temporal_workflow_task_execution_latency" && v.Unit == "duration"
+                && !v.Values.IsEmpty).Values,
             v => v.Value is TimeSpan val && val < TimeSpan.FromSeconds(5));
         Assert.Single(
             Assert.Single(meter.Metrics, v => v.Name == "my-histogram-duration").Values,


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
- Enabled worker heartbeat
- plumb plugin names (both client and worker) to core
- update core to 44a6576
  - 💥temporal_sdk_core_c_bridge.dll got renamed to temporalio_sdk_core_c_bridge.dll

## Why?
<!-- Tell your future self why have you made these changes -->
New worker heartbeating feature

## Checklist
<!--- add/delete as needed --->

1. Closes #551

2. How was this tested:
Manually tested

3. Any docs updates needed?




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables worker heartbeating, plumbs plugin names to Core, updates interop/bindings and build paths, and renames the native bridge library to temporalio_sdk_core_c_bridge across code, CI, and docs.
> 
> - **Runtime/Worker**:
>   - Add `TemporalRuntimeOptions.WorkerHeartbeatInterval` and propagate to Core (`worker_heartbeat_interval_millis`).
>   - Pass plugin names (client + worker) to Core via `TemporalCoreByteArrayRefArray` on client/worker options.
>   - Replace `no_remote_activities` with `TemporalCoreWorkerTaskTypes` in `TemporalCoreWorkerOptions` and populate based on registered work.
>   - `Bridge.Worker` constructor accepts `clientPlugins` and forwards to interop conversion.
> - **Interop/Core bindings**:
>   - Update header path to `sdk-core/crates/sdk-core-c-bridge` and adjust all `DllImport` names and library path to `temporalio_sdk_core_c_bridge`.
>   - Add new interop structs/fields: `TemporalCoreWorkerTaskTypes`, extra fields on client/runtime/worker options.
>   - Rename Rust crate log/targets in telemetry defaults from `temporal_*` to `temporalio_*`.
> - **Build/CI/Packaging**:
>   - Rename emitted artifacts to `temporalio_sdk_core_c_bridge.*`; update `.csproj`, `build/net462/Temporalio.targets`, and GitHub Actions workflow to new paths and Cargo manifest.
>   - Adjust CI matrices/includes and smoke-test config; use Manylinux Alpine/ARM containers.
> - **Docs/Tests**:
>   - Update README and test expectations for new library name and log targets; minor test fixes (unique task queues, metric assertions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bbb1f484d14b8aca0d7812def95b15c639b4036. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->