### PR TITLE
Stop freeing native resources in finalizers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/temporalio/sdk-dotnet</RepositoryUrl>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/src/Temporalio/Bridge/EnvConfig.cs
+++ b/src/Temporalio/Bridge/EnvConfig.cs
@@ -18,35 +18,33 @@ namespace Temporalio.Bridge
         /// <param name="options">Options for loading the configuration.</param>
         /// <returns>Dictionary of profile name to client configuration profile.</returns>
         public static Dictionary<string, ClientEnvConfig.Profile> LoadClientConfig(
-            ClientEnvConfig.ConfigLoadOptions options)
-        {
-            using var scope = new Scope();
-
-            try
+            ClientEnvConfig.ConfigLoadOptions options) => Scope.WithScope(scope =>
             {
-                var envVarsRef = options.OverrideEnvVars?.Count > 0
-                    ? scope.ByteArray(JsonSerializer.Serialize(options.OverrideEnvVars))
-                    : ByteArrayRef.Empty.Ref;
-
-                unsafe
+                try
                 {
-                    var coreOptions = new Interop.TemporalCoreClientEnvConfigLoadOptions
-                    {
-                        path = scope.ByteArray(options.ConfigSource?.Path),
-                        data = scope.ByteArray(options.ConfigSource?.Data),
-                        config_file_strict = Convert.ToByte(options.ConfigFileStrict),
-                        env_vars = envVarsRef,
-                    };
+                    var envVarsRef = options.OverrideEnvVars?.Count > 0
+                        ? scope.ByteArray(JsonSerializer.Serialize(options.OverrideEnvVars))
+                        : ByteArrayRef.Empty.Ref;
 
-                    var result = Interop.Methods.temporal_core_client_env_config_load(&coreOptions);
-                    return ProcessAllProfilesResult(result);
+                    unsafe
+                    {
+                        var coreOptions = new Interop.TemporalCoreClientEnvConfigLoadOptions
+                        {
+                            path = scope.ByteArray(options.ConfigSource?.Path),
+                            data = scope.ByteArray(options.ConfigSource?.Data),
+                            config_file_strict = Convert.ToByte(options.ConfigFileStrict),
+                            env_vars = envVarsRef,
+                        };
+
+                        var result = Interop.Methods.temporal_core_client_env_config_load(&coreOptions);
+                        return ProcessAllProfilesResult(result);
+                    }
                 }
-            }
-            catch (JsonException ex)
-            {
-                throw new InvalidOperationException($"Failed to deserialize client config: {ex.Message}", ex);
-            }
-        }
+                catch (JsonException ex)
+                {
+                    throw new InvalidOperationException($"Failed to deserialize client config: {ex.Message}", ex);
+                }
+            });
 
         /// <summary>
         /// Loads a specific client configuration profile.
@@ -54,38 +52,36 @@ namespace Temporalio.Bridge
         /// <param name="options">Options for loading the configuration profile.</param>
         /// <returns>Client configuration for the specified profile.</returns>
         public static ClientEnvConfig.Profile LoadClientConfigProfile(
-            ClientEnvConfig.ProfileLoadOptions options)
-        {
-            using var scope = new Scope();
-
-            try
+            ClientEnvConfig.ProfileLoadOptions options) => Scope.WithScope(scope =>
             {
-                var envVarsRef = options.OverrideEnvVars?.Count > 0
-                    ? scope.ByteArray(JsonSerializer.Serialize(options.OverrideEnvVars))
-                    : ByteArrayRef.Empty.Ref;
-
-                unsafe
+                try
                 {
-                    var coreOptions = new Interop.TemporalCoreClientEnvConfigProfileLoadOptions
-                    {
-                        profile = scope.ByteArray(options.Profile),
-                        path = scope.ByteArray(options.ConfigSource?.Path),
-                        data = scope.ByteArray(options.ConfigSource?.Data),
-                        disable_file = Convert.ToByte(options.DisableFile),
-                        disable_env = Convert.ToByte(options.DisableEnv),
-                        config_file_strict = Convert.ToByte(options.ConfigFileStrict),
-                        env_vars = envVarsRef,
-                    };
+                    var envVarsRef = options.OverrideEnvVars?.Count > 0
+                        ? scope.ByteArray(JsonSerializer.Serialize(options.OverrideEnvVars))
+                        : ByteArrayRef.Empty.Ref;
 
-                    var result = Interop.Methods.temporal_core_client_env_config_profile_load(&coreOptions);
-                    return ProcessSingleProfileResult(result);
+                    unsafe
+                    {
+                        var coreOptions = new Interop.TemporalCoreClientEnvConfigProfileLoadOptions
+                        {
+                            profile = scope.ByteArray(options.Profile),
+                            path = scope.ByteArray(options.ConfigSource?.Path),
+                            data = scope.ByteArray(options.ConfigSource?.Data),
+                            disable_file = Convert.ToByte(options.DisableFile),
+                            disable_env = Convert.ToByte(options.DisableEnv),
+                            config_file_strict = Convert.ToByte(options.ConfigFileStrict),
+                            env_vars = envVarsRef,
+                        };
+
+                        var result = Interop.Methods.temporal_core_client_env_config_profile_load(&coreOptions);
+                        return ProcessSingleProfileResult(result);
+                    }
                 }
-            }
-            catch (JsonException ex)
-            {
-                throw new InvalidOperationException($"Failed to deserialize client config profile: {ex.Message}", ex);
-            }
-        }
+                catch (JsonException ex)
+                {
+                    throw new InvalidOperationException($"Failed to deserialize client config profile: {ex.Message}", ex);
+                }
+            });
 
         /// <summary>
         /// Creates a ClientConfigProfile from typed JSON data.

--- a/src/Temporalio/Bridge/Metric.cs
+++ b/src/Temporalio/Bridge/Metric.cs
@@ -8,7 +8,7 @@ namespace Temporalio.Bridge
     /// </summary>
     internal class Metric : SafeHandle
     {
-        private readonly unsafe Interop.TemporalCoreMetric* ptr;
+        private unsafe Interop.TemporalCoreMetric* ptr;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Metric"/> class.
@@ -26,7 +26,7 @@ namespace Temporalio.Bridge
             string? description)
             : base(IntPtr.Zero, true)
         {
-            using (var scope = new Scope())
+            Scope.WithScope(scope =>
             {
                 unsafe
                 {
@@ -40,7 +40,7 @@ namespace Temporalio.Bridge
                     ptr = Interop.Methods.temporal_core_metric_new(meter.Ptr, scope.Pointer(options));
                     SetHandle((IntPtr)ptr);
                 }
-            }
+            });
         }
 
         /// <inheritdoc />

--- a/src/Temporalio/Bridge/Runtime.cs
+++ b/src/Temporalio/Bridge/Runtime.cs
@@ -14,8 +14,8 @@ namespace Temporalio.Bridge
         private static readonly Func<ForwardedLog, Exception?, string> ForwardLogMessageFormatter =
             LogMessageFormatter;
 
-        private readonly bool forwardLoggerIncludeFields;
-        private readonly GCHandle? forwardLoggerCallback;
+        private bool forwardLoggerIncludeFields;
+        private GCHandle? forwardLoggerCallback;
         private ILogger? forwardLogger;
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Temporalio.Bridge
         public Runtime(Temporalio.Runtime.TemporalRuntimeOptions options)
             : base(IntPtr.Zero, true)
         {
-            using (var scope = new Scope())
+            Scope.WithScope(scope =>
             {
                 unsafe
                 {
@@ -67,7 +67,7 @@ namespace Temporalio.Bridge
                     Ptr = res.runtime;
                     SetHandle((IntPtr)Ptr);
                 }
-            }
+            });
             MetricMeter = new(() => Bridge.MetricMeter.CreateFromRuntime(this));
         }
 
@@ -77,7 +77,7 @@ namespace Temporalio.Bridge
         /// <summary>
         /// Gets the pointer to the runtime.
         /// </summary>
-        internal unsafe Interop.TemporalCoreRuntime* Ptr { get; private init; }
+        internal unsafe Interop.TemporalCoreRuntime* Ptr { get; private set; }
 
         /// <summary>
         /// Gets the lazy metric meter for this runtime. Can be null.

--- a/src/Temporalio/Bridge/Scope.cs
+++ b/src/Temporalio/Bridge/Scope.cs
@@ -1,14 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace Temporalio.Bridge
 {
     /// <summary>
     /// Disposable collection of items we need to keep alive while this object is in scope. NOT threadsafe.
     /// </summary>
-    internal sealed class Scope : IDisposable
+    internal class Scope : IDisposable
     {
         private static readonly Interop.TemporalCoreByteArrayRefArray EmptyByteArrayRefArray =
             new()
@@ -20,6 +22,57 @@ namespace Temporalio.Bridge
         private readonly List<GCHandle> gcHandles = new();
         private readonly List<IDisposable> disposables = new();
         private bool disposed;
+
+        private Scope()
+        {
+        }
+
+        public static void WithScope(Action<Scope> fn)
+        {
+            using (var scope = new Scope())
+            {
+                fn(scope);
+            }
+        }
+
+        public static T WithScope<T>(Func<Scope, T> fn)
+        {
+            using (var scope = new Scope())
+            {
+                return fn(scope);
+            }
+        }
+
+        public static Task<TResult> WithScopeAsync<TResult>(
+            SafeHandle handle,
+            Action<WithCallback<TResult>> fn) =>
+            WithScopeAsync(handle, fn, TaskCreationOptions.None);
+
+        // TODO: Document that OnCallbackExit _must_ be run as a finally in the callback (not
+        // somewhere else that feels like finally due to stack semantics in .NET about how finally
+        // works), and that failure of the given lambda is expected to mean that callback wasn't
+        // executed.
+        public static Task<TResult> WithScopeAsync<TResult>(
+            SafeHandle handle,
+            Action<WithCallback<TResult>> fn,
+            TaskCreationOptions creationOptions)
+        {
+            var completion = new TaskCompletionSource<TResult>();
+#pragma warning disable CA2000 // We are delegating dispose to the caller unfortunately
+            var scope = new WithCallback<TResult>(handle, completion);
+#pragma warning restore CA2000
+            try
+            {
+                fn(scope);
+            }
+            catch
+            {
+                // We assume the user was unable to run OnCallbackExit themselves
+                scope.Dispose();
+                throw;
+            }
+            return completion.Task;
+        }
 
         /// <summary>
         /// Create a byte array ref.
@@ -223,25 +276,8 @@ namespace Temporalio.Bridge
             return (T*)handle.AddrOfPinnedObject();
         }
 
-        /// <summary>
-        /// Create function pointer for delegate.
-        /// </summary>
-        /// <typeparam name="T">Delegate type.</typeparam>
-        /// <param name="func">Delegate to create pointer for.</param>
-        /// <returns>Created pointer.</returns>
-        public IntPtr FunctionPointer<T>(T func)
-            where T : Delegate
-        {
-            // The delegate seems to get collected before called sometimes even if we add "func" to
-            // the keep alive list. Delegates are supposed to be reference types, but their pointers
-            // seem unstable. So we're going to alloc a handle for it. We can't pin it though.
-            var handle = GCHandle.Alloc(func);
-            gcHandles.Add(handle);
-            return Marshal.GetFunctionPointerForDelegate(handle.Target!);
-        }
-
         /// <inheritdoc />
-        public void Dispose()
+        public virtual void Dispose()
         {
             // Note, we intentionally do not free or call Dispose from a finalizer. When working
             // with native objects, best practice is to not free in finalizer. On process shutdown,
@@ -261,6 +297,74 @@ namespace Temporalio.Bridge
             }
             disposables.Clear();
             disposed = true;
+        }
+
+        public sealed class WithCallback<T> : Scope
+        {
+            private readonly SafeHandle? handle;
+            private bool callbackPointerObtained;
+            private bool disposed;
+
+            internal WithCallback(SafeHandle handle, TaskCompletionSource<T> completion)
+            {
+                Completion = completion;
+                bool addedRef = false;
+                handle.DangerousAddRef(ref addedRef);
+                if (addedRef)
+                {
+                    this.handle = handle;
+                }
+            }
+
+            ~WithCallback()
+            {
+                Debug.Assert(disposed, "Callback not disposed, was OnCallbackExit called?");
+            }
+
+            public TaskCompletionSource<T> Completion { get; private init; }
+
+            internal bool CallbackExitCalled { get; private set; }
+
+            /// <summary>
+            /// Create function pointer for delegate.
+            /// </summary>
+            /// <typeparam name="TCallback">Delegate type.</typeparam>
+            /// <param name="func">Delegate to create pointer for.</param>
+            /// <returns>Created pointer.</returns>
+            public IntPtr CallbackPointer<TCallback>(TCallback func)
+                where TCallback : Delegate
+            {
+                if (callbackPointerObtained)
+                {
+                    throw new InvalidOperationException("Callback already obtained");
+                }
+                callbackPointerObtained = true;
+
+                // The delegate seems to get collected before called sometimes even if we add "func"
+                // to the keep alive list. Delegates are supposed to be reference types, but their
+                // pointers seem unstable. So we're going to alloc a handle for it. We can't pin it
+                // though.
+                var handle = GCHandle.Alloc(func);
+                gcHandles.Add(handle);
+                return Marshal.GetFunctionPointerForDelegate(handle.Target!);
+            }
+
+            public void OnCallbackExit()
+            {
+                Debug.Assert(!CallbackExitCalled, "Callback exit called multiple times");
+                CallbackExitCalled = true;
+                Dispose();
+            }
+
+            public override void Dispose()
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+                    handle?.DangerousRelease();
+                }
+                base.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
## What was changed

Update interop byte array ref and scope to not free in finalizer, but rather in explicitly-invoked dispose only. See https://github.com/temporalio/sdk-dotnet/issues/577#issuecomment-3675108863.

## Checklist

1. Closes #577
1. Closes #579 