### PR TITLE
Dedicated safe handles for Client and Worker

### DIFF
--- a/src/Temporalio/Bridge/Client.cs
+++ b/src/Temporalio/Bridge/Client.cs
@@ -15,11 +15,11 @@ namespace Temporalio.Bridge
             : base((IntPtr)ptr, true)
         {
             Runtime = runtime;
-            Ptr = ptr;
+            Handle = new SafeClientHandle(ptr);
         }
 
         /// <inheritdoc />
-        public override unsafe bool IsInvalid => Ptr == null;
+        public override bool IsInvalid => Handle.IsInvalid;
 
         /// <summary>
         /// Gets the runtime associated with this client.
@@ -27,9 +27,9 @@ namespace Temporalio.Bridge
         internal Runtime Runtime { get; private init; }
 
         /// <summary>
-        /// Gets the pointer to the client.
+        /// Gets the safe handle for the client.
         /// </summary>
-        internal unsafe Interop.TemporalCoreClient* Ptr { get; private init; }
+        internal SafeClientHandle Handle { get; private init; }
 
         /// <summary>
         /// Connect to Temporal.
@@ -80,7 +80,9 @@ namespace Temporalio.Bridge
             {
                 unsafe
                 {
-                    Interop.Methods.temporal_core_client_update_metadata(Ptr, scope.ByteArrayArray(metadata));
+                    Interop.Methods.temporal_core_client_update_metadata(
+                        scope.Pointer(Handle),
+                        scope.ByteArrayArray(metadata));
                 }
             }
         }
@@ -95,7 +97,9 @@ namespace Temporalio.Bridge
             {
                 unsafe
                 {
-                    Interop.Methods.temporal_core_client_update_binary_metadata(Ptr, scope.ByteArrayArray(metadata));
+                    Interop.Methods.temporal_core_client_update_binary_metadata(
+                        scope.Pointer(Handle),
+                        scope.ByteArrayArray(metadata));
                 }
             }
         }
@@ -110,7 +114,9 @@ namespace Temporalio.Bridge
             {
                 unsafe
                 {
-                    Interop.Methods.temporal_core_client_update_api_key(Ptr, scope.ByteArray(apiKey));
+                    Interop.Methods.temporal_core_client_update_api_key(
+                        scope.Pointer(Handle),
+                        scope.ByteArray(apiKey));
                 }
             }
         }
@@ -148,7 +154,7 @@ namespace Temporalio.Bridge
                 unsafe
                 {
                     Interop.Methods.temporal_core_client_rpc_call(
-                        Ptr,
+                        scope.Pointer(Handle),
                         scope.Pointer(
                             new Interop.TemporalCoreRpcCallOptions()
                             {
@@ -207,7 +213,7 @@ namespace Temporalio.Bridge
         /// <inheritdoc />
         protected override unsafe bool ReleaseHandle()
         {
-            Interop.Methods.temporal_core_client_free(Ptr);
+            Handle.Dispose();
             return true;
         }
     }

--- a/src/Temporalio/Bridge/SafeClientHandle.cs
+++ b/src/Temporalio/Bridge/SafeClientHandle.cs
@@ -1,0 +1,30 @@
+using Temporalio.Bridge.Interop;
+
+namespace Temporalio.Bridge
+{
+    /// <summary>
+    /// Safe handle for a Temporal client.
+    /// </summary>
+    internal sealed class SafeClientHandle :
+        SafeUnmanagedHandle<TemporalCoreClient>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SafeClientHandle" /> class.
+        /// </summary>
+        /// <param name="ptr">Worker pointer.</param>
+        public unsafe SafeClientHandle(TemporalCoreClient* ptr)
+            : base(ptr)
+        {
+        }
+
+        /// <summary>
+        /// Free the client.
+        /// </summary>
+        /// <returns>Always returns <c>true</c>.</returns>
+        protected override unsafe bool ReleaseHandle()
+        {
+            Methods.temporal_core_client_free(UnsafePtr);
+            return true;
+        }
+    }
+}

--- a/src/Temporalio/Bridge/SafeHandleReference.cs
+++ b/src/Temporalio/Bridge/SafeHandleReference.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Temporalio.Bridge
+{
+    /// <summary>
+    /// A reference to a safe handle that can be used to manage the lifecycle of the handle.
+    /// </summary>
+    /// <typeparam name="T">The type of the safe handle to reference.</typeparam>
+    internal sealed class SafeHandleReference<T> :
+        IDisposable
+        where T : SafeHandle
+    {
+        private readonly bool owned;
+
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SafeHandleReference{T}" /> class.
+        /// </summary>
+        /// <param name="handle">The safe handle to add a reference to.</param>
+        /// <param name="owned">Indicates whether the safe handle is owned by this instance.</param>
+        private SafeHandleReference(T handle, bool owned)
+        {
+            Handle = handle;
+            this.owned = owned;
+        }
+
+        /// <summary>
+        /// Gets the safe handle that this reference owns or references.
+        /// </summary>
+        public T Handle { get; private set; }
+
+        /// <summary>
+        /// Creates a new <see cref="SafeHandleReference{T}" /> instance that owns the safe handle.
+        /// </summary>
+        /// <param name="handle">The safe handle to own.</param>
+        /// <returns>A new <see cref="SafeHandleReference{T}" /> instance that owns the safe handle.</returns>
+        public static SafeHandleReference<T> Owned(T handle)
+        {
+            return new SafeHandleReference<T>(handle, owned: true);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="SafeHandleReference{T}" /> instance that references the safe handle.
+        /// </summary>
+        /// <param name="handle">The safe handle to reference.</param>
+        /// <returns>A new <see cref="SafeHandleReference{T}" /> instance that references the safe handle.</returns>
+        /// <remarks>
+        /// This will increment the reference count of the safe handle.
+        /// Dispose the returned instance to decrement the reference count.
+        /// </remarks>
+        public static SafeHandleReference<T> AddRef(T handle)
+        {
+            bool success = false;
+            handle.DangerousAddRef(ref success);
+            if (!success)
+            {
+                // Documentation states that DangerousAddRef will throw if the handle is disposed
+                // (and there should be no other condition under which refAdded would remain false);
+                // throw just in case it returns without throwing.
+                throw new InvalidOperationException("Safe handle is no longer valid.");
+            }
+
+            return new SafeHandleReference<T>(handle, owned: false);
+        }
+
+        /// <summary>
+        /// Releases the reference to the safe handle.
+        /// </summary>
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+            disposed = true;
+
+            if (owned)
+            {
+                Handle.Dispose();
+            }
+            else
+            {
+                Handle.DangerousRelease();
+            }
+        }
+    }
+}

--- a/src/Temporalio/Bridge/SafeUnmanagedHandle.cs
+++ b/src/Temporalio/Bridge/SafeUnmanagedHandle.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Win32.SafeHandles;
+
+namespace Temporalio.Bridge
+{
+    /// <summary>
+    /// Safe handle for unmanaged instance.
+    /// </summary>
+    /// <typeparam name="T">Unmanaged type.</typeparam>
+    internal abstract class SafeUnmanagedHandle<T> :
+        SafeHandleZeroOrMinusOneIsInvalid
+        where T : unmanaged
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SafeUnmanagedHandle{T}" /> class.
+        /// </summary>
+        /// <param name="ptr">Unmanaged pointer.</param>
+        public unsafe SafeUnmanagedHandle(T* ptr)
+            : base(true)
+        {
+            SetHandle((IntPtr)ptr);
+        }
+
+        /// <summary>
+        /// Gets the unsafe pointer of the unmanaged instance.
+        /// </summary>
+        protected unsafe T* UnsafePtr => (T*)DangerousGetHandle();
+    }
+}

--- a/src/Temporalio/Bridge/SafeWorkerHandle.cs
+++ b/src/Temporalio/Bridge/SafeWorkerHandle.cs
@@ -1,0 +1,30 @@
+using Temporalio.Bridge.Interop;
+
+namespace Temporalio.Bridge
+{
+    /// <summary>
+    /// Safe handle for a Temporal worker.
+    /// </summary>
+    internal sealed class SafeWorkerHandle :
+        SafeUnmanagedHandle<TemporalCoreWorker>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SafeWorkerHandle" /> class.
+        /// </summary>
+        /// <param name="worker">Worker pointer.</param>
+        public unsafe SafeWorkerHandle(TemporalCoreWorker* worker)
+            : base(worker)
+        {
+        }
+
+        /// <summary>
+        /// Free the worker.
+        /// </summary>
+        /// <returns>Always returns <c>true</c>.</returns>
+        protected override unsafe bool ReleaseHandle()
+        {
+            Methods.temporal_core_worker_free(UnsafePtr);
+            return true;
+        }
+    }
+}

--- a/src/Temporalio/Bridge/Scope.cs
+++ b/src/Temporalio/Bridge/Scope.cs
@@ -216,6 +216,20 @@ namespace Temporalio.Bridge
         }
 
         /// <summary>
+        /// Increment the reference count of a <see cref="SafeUnmanagedHandle{T}"/> and
+        /// return its underlying pointer.
+        /// </summary>
+        /// <typeparam name="T">Type of the handle.</typeparam>
+        /// <param name="handle">Handle for which its reference count shall be incremented.</param>
+        /// <returns>The underlying pointer of the handle.</returns>
+        public unsafe T* Pointer<T>(SafeUnmanagedHandle<T> handle)
+            where T : unmanaged
+        {
+            disposables.Add(SafeHandleReference<SafeUnmanagedHandle<T>>.AddRef(handle));
+            return (T*)handle.DangerousGetHandle();
+        }
+
+        /// <summary>
         /// Create a stable pointer to an object.
         /// </summary>
         /// <typeparam name="T">Type of the object.</typeparam>

--- a/tests/Temporalio.Tests/Worker/ManualPollCompletionBridgeWorker.cs
+++ b/tests/Temporalio.Tests/Worker/ManualPollCompletionBridgeWorker.cs
@@ -4,11 +4,12 @@ namespace Temporalio.Tests.Worker;
 
 internal class ManualPollCompletionBridgeWorker : Bridge.Worker
 {
-    private readonly Bridge.Worker underlying;
     private Task<ActivityTask?>? leftoverPollTask;
 
     public ManualPollCompletionBridgeWorker(Bridge.Worker underlying)
-        : base(underlying) => this.underlying = underlying;
+        : base(underlying.Runtime, underlying.Handle)
+    {
+    }
 
     public TaskCompletionSource<ActivityTask?> PollActivityCompletion { get; private set; } = new();
 
@@ -27,14 +28,5 @@ internal class ManualPollCompletionBridgeWorker : Bridge.Worker
             PollActivityCompletion = new();
         }
         return await completedTask;
-    }
-
-    protected override bool ReleaseHandle()
-    {
-        // This is only here to remove IDE complain that underlying is never used. We keep a strong
-        // reference to underlying to ensure the handle is not removed before this is collected.
-        GC.KeepAlive(underlying);
-        // Do not call release for underlying one
-        return true;
     }
 }


### PR DESCRIPTION
## What was changed

- Moved lifetime ownership of unmanaged client and worker pointers to new `SafeHandle` classes.
- Update `Worker` no longer be a `SafeHandle` but rather add-ref to an existing `SafeHandle` or create its own.
- Update `Worker` and `Client` to add-ref to their corresponding handle before calling p/invoke functions. This is done using the `Scope.Pointer` method.

## Why?

Moving ownership of lifetime of unmanaged pointers to `SafeHandle`s and performing add-ref and release operations as necessary will prevent the freeing of unamanaged pointers and their related resources. If an add-ref cannot be fulfilled, a managed exception will be thrown instead of AVing in unmanaged code.

This change can be used as a pattern to update the remaining bridge classes to separate unmanaged resource lifetime from the wrapper bridge classes and prevent use-after-free issues of unmanaged pointers.

## Checklist

1. Closes #577 and #579

2. How was this tested: Repeatedly tested in CI tests (about 50 times); no more crashes observed.

3. Any docs updates needed? No
