### PR TITLE
Update smoke test job to use MacOS 15 for Intel variant

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -187,7 +187,7 @@ jobs:
             container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
             runsOn: ubuntu-latest
           - os: macos-intel
-            runsOn: macos-13
+            runsOn: macos-15-intel
           - os: macos-arm
             runsOn: macos-14
           - os: windows-arm


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Update the smoke test job to use MacOS 15 for the Intel variant since MacOS 13 build images are retired.