### PR TITLE
Add IsReplayingHistoryEvents to allow logging in queries and validators

### DIFF
--- a/src/Temporalio/Worker/ReplaySafeLogger.cs
+++ b/src/Temporalio/Worker/ReplaySafeLogger.cs
@@ -30,7 +30,7 @@ namespace Temporalio.Worker
             Exception exception,
             Func<TState, Exception, string> formatter)
         {
-            if (!Workflows.Workflow.Unsafe.IsReplaying)
+            if (!Workflows.Workflow.Unsafe.IsReplayingHistoryEvents)
             {
                 underlying.Log<TState>(logLevel, eventId, state, exception, formatter);
             }

--- a/src/Temporalio/Worker/ReplaySafeMetricMeter.cs
+++ b/src/Temporalio/Worker/ReplaySafeMetricMeter.cs
@@ -46,7 +46,7 @@ namespace Temporalio.Worker
             public override void Add(
                 T value, IEnumerable<KeyValuePair<string, object>>? extraTags = null)
             {
-                if (!Workflows.Workflow.Unsafe.IsReplaying)
+                if (!Workflows.Workflow.Unsafe.IsReplayingHistoryEvents)
                 {
                     underlying.Add(value, extraTags);
                 }
@@ -68,7 +68,7 @@ namespace Temporalio.Worker
             public override void Record(
                 T value, IEnumerable<KeyValuePair<string, object>>? extraTags = null)
             {
-                if (!Workflows.Workflow.Unsafe.IsReplaying)
+                if (!Workflows.Workflow.Unsafe.IsReplayingHistoryEvents)
                 {
                     underlying.Record(value, extraTags);
                 }
@@ -90,7 +90,7 @@ namespace Temporalio.Worker
             public override void Set(
                 T value, IEnumerable<KeyValuePair<string, object>>? extraTags = null)
             {
-                if (!Workflows.Workflow.Unsafe.IsReplaying)
+                if (!Workflows.Workflow.Unsafe.IsReplayingHistoryEvents)
                 {
                     underlying.Set(value, extraTags);
                 }

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -89,6 +89,11 @@ namespace Temporalio.Workflows
         bool IsReplaying { get; }
 
         /// <summary>
+        /// Gets a value indicating whether <see cref="Workflow.Unsafe.IsReplayingHistoryEvents" /> is true.
+        /// </summary>
+        bool IsReplayingHistoryEvents { get; }
+
+        /// <summary>
         /// Gets value for <see cref="Workflow.Logger" />.
         /// </summary>
         ILogger Logger { get; }

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -1393,10 +1393,20 @@ namespace Temporalio.Workflows
             /// Gets a value indicating whether this workflow is replaying.
             /// </summary>
             /// <remarks>
-            /// This should not be used for most cases. It is only valuable for advanced cases like
-            /// preventing a log or metric from being recorded on replay.
+            /// This returns true during replay, including during queries and update validators that
+            /// are executed during a replaying workflow task. This should not be used for most cases.
             /// </remarks>
             public static bool IsReplaying => Context.IsReplaying;
+
+            /// <summary>
+            /// Gets a value indicating whether this workflow is replaying history events.
+            /// </summary>
+            /// <remarks>
+            /// This returns true during replay, but false during queries and update validators even
+            /// when they are executed during a replaying workflow task. This should not be used for
+            /// most cases.
+            /// </remarks>
+            public static bool IsReplayingHistoryEvents => Context.IsReplayingHistoryEvents;
 
             /// <summary>
             /// Disables the event listener that catches invalid calls and thread operations in


### PR DESCRIPTION
## What was changed

Added `Workflow.Unsafe.IsReplayingHistoryEvents` to distinguish replaying historical events from handling live read operations (queries/update validators). Updated replay-safe logger and metrics to allow logs and metrics during queries and validators.