### PR TITLE
Add support for more timeouts to Nexus operations 

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -2572,6 +2572,14 @@ namespace Temporalio.Worker
                 {
                     cmd.ScheduleToCloseTimeout = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(schedToCloseTimeout);
                 }
+                if (input.Options.ScheduleToStartTimeout is TimeSpan schedToStartTimeout)
+                {
+                    cmd.ScheduleToStartTimeout = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(schedToStartTimeout);
+                }
+                if (input.Options.StartToCloseTimeout is TimeSpan startToCloseTimeout)
+                {
+                    cmd.StartToCloseTimeout = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(startToCloseTimeout);
+                }
                 if (input.Headers is IDictionary<string, string> headers)
                 {
                     cmd.NexusHeader.Add(headers);

--- a/src/Temporalio/Workflows/NexusOperationOptions.cs
+++ b/src/Temporalio/Workflows/NexusOperationOptions.cs
@@ -11,28 +11,28 @@ namespace Temporalio.Workflows
     {
         /// <summary>
         /// Gets or sets the schedule to close timeout.
+        /// </summary>
         /// <remarks>Indicates how long the caller is willing to wait for operation completion.
         /// Calls are retried internally by the server.</remarks>
-        /// </summary>
         public TimeSpan? ScheduleToCloseTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the schedule to start timeout.
+        /// </summary>
         /// <remarks>Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
         /// by the handler. If the operation is not started within this timeout, it will fail with TIMEOUT_TYPE_SCHEDULE_TO_START.
         /// If not set or zero, no schedule-to-start timeout is enforced.
         /// Requires server version 1.31.0 or later.</remarks>
-        /// </summary>
         public TimeSpan? ScheduleToStartTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the start to close timeout.
+        /// </summary>
         /// <remarks>Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
         /// started. If the operation does not complete within this timeout after starting, it will fail with TIMEOUT_TYPE_START_TO_CLOSE.
         /// Only applies to asynchronous operations. Synchronous operations ignore this timeout.
         /// If not set or zero, no start-to-close timeout is enforced.
         /// Requires server version 1.31.0 or later.</remarks>
-        /// </summary>
         public TimeSpan? StartToCloseTimeout { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Workflows/NexusOperationOptions.cs
+++ b/src/Temporalio/Workflows/NexusOperationOptions.cs
@@ -11,27 +11,27 @@ namespace Temporalio.Workflows
     {
         /// <summary>
         /// Gets or sets the schedule to close timeout.
-        /// Indicates how long the caller is willing to wait for operation completion.
-        /// Calls are retried internally by the server.
+        /// <remarks>Indicates how long the caller is willing to wait for operation completion.
+        /// Calls are retried internally by the server.</remarks>
         /// </summary>
         public TimeSpan? ScheduleToCloseTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the schedule to start timeout.
-        /// Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
+        /// <remarks>Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
         /// by the handler. If the operation is not started within this timeout, it will fail with TIMEOUT_TYPE_SCHEDULE_TO_START.
         /// If not set or zero, no schedule-to-start timeout is enforced.
-        /// Requires server version 1.31.0 or later.
+        /// Requires server version 1.31.0 or later.</remarks>
         /// </summary>
         public TimeSpan? ScheduleToStartTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the start to close timeout.
-        /// Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
+        /// <remarks>Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
         /// started. If the operation does not complete within this timeout after starting, it will fail with TIMEOUT_TYPE_START_TO_CLOSE.
         /// Only applies to asynchronous operations. Synchronous operations ignore this timeout.
         /// If not set or zero, no start-to-close timeout is enforced.
-        /// Requires server version 1.31.0 or later.
+        /// Requires server version 1.31.0 or later.</remarks>
         /// </summary>
         public TimeSpan? StartToCloseTimeout { get; set; }
 

--- a/src/Temporalio/Workflows/NexusOperationOptions.cs
+++ b/src/Temporalio/Workflows/NexusOperationOptions.cs
@@ -11,8 +11,29 @@ namespace Temporalio.Workflows
     {
         /// <summary>
         /// Gets or sets the schedule to close timeout.
+        /// Indicates how long the caller is willing to wait for operation completion.
+        /// Calls are retried internally by the server.
         /// </summary>
         public TimeSpan? ScheduleToCloseTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule to start timeout.
+        /// Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
+        /// by the handler. If the operation is not started within this timeout, it will fail with TIMEOUT_TYPE_SCHEDULE_TO_START.
+        /// If not set or zero, no schedule-to-start timeout is enforced.
+        /// Requires server version 1.31.0 or later.
+        /// </summary>
+        public TimeSpan? ScheduleToStartTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start to close timeout.
+        /// Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
+        /// started. If the operation does not complete within this timeout after starting, it will fail with TIMEOUT_TYPE_START_TO_CLOSE.
+        /// Only applies to asynchronous operations. Synchronous operations ignore this timeout.
+        /// If not set or zero, no start-to-close timeout is enforced.
+        /// Requires server version 1.31.0 or later.
+        /// </summary>
+        public TimeSpan? StartToCloseTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the summary.

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -297,8 +297,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                         svc => svc.DoSomething("some-name"),
                         new() { ScheduleToCloseTimeout = TimeSpan.FromSeconds(2) });
             }));
-        Assert.IsType<TimeoutFailureException>(
-            Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);
         var timeoutExc = Assert.IsType<TimeoutFailureException>(
             Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);
         Assert.Equal(TimeoutType.ScheduleToClose, timeoutExc.TimeoutType);
@@ -352,7 +350,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                     contextSource.SetResult(ctx);
                     try
                     {
-                        await Task.Delay(4000, ctx.CancellationToken);
+                        await Task.Delay(40000, ctx.CancellationToken);
                         return "done";
                     }
                     catch (TaskCanceledException)
@@ -368,7 +366,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                 await Workflow.CreateNexusClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(
                         svc => svc.DoSomething("some-name"),
-                        new() { ScheduleToStartTimeout = TimeSpan.FromSeconds(1) });
+                        new() { ScheduleToStartTimeout = TimeSpan.FromSeconds(2) });
             }));
         var timeoutExc = Assert.IsType<TimeoutFailureException>(
             Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -299,6 +299,9 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             }));
         Assert.IsType<TimeoutFailureException>(
             Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);
+        var timeoutExc = Assert.IsType<TimeoutFailureException>(
+            Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);
+        Assert.Equal(TimeoutType.ScheduleToClose, timeoutExc.TimeoutType);
         // Also check that our cancel token is canceled for the proper reason
         var ctx = await contextSource.Task;
         Assert.True(await Task.Run(() => ctx.CancellationToken.WaitHandle.WaitOne(2000)));
@@ -336,6 +339,75 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         string actualSummary = Client.Options.DataConverter.PayloadConverter.ToValue<string>(
             nexusOperationScheduledEvent.UserMetadata.Summary);
         Assert.Equal(expectedSummary, actualSummary);
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_ScheduleToStartTimeout_FailsAsExpected()
+    {
+        var contextSource = new TaskCompletionSource<OperationStartContext>();
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (ctx, name) =>
+                {
+                    contextSource.SetResult(ctx);
+                    try
+                    {
+                        await Task.Delay(4000, ctx.CancellationToken);
+                        return "done";
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        return "canceled";
+                    }
+                })));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+        // Confirm the workflow fails with the timeout
+        var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
+            RunInWorkflowAsync(workerOptions, async () =>
+            {
+                await Workflow.CreateNexusClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(
+                        svc => svc.DoSomething("some-name"),
+                        new() { ScheduleToStartTimeout = TimeSpan.FromSeconds(1) });
+            }));
+        var timeoutExc = Assert.IsType<TimeoutFailureException>(
+            Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);
+        Assert.Equal(TimeoutType.ScheduleToStart, timeoutExc.TimeoutType);
+        // Also check that our cancel token is canceled for the proper reason
+        var ctx = await contextSource.Task;
+        Assert.True(await Task.Run(() => ctx.CancellationToken.WaitHandle.WaitOne(2000)));
+        Assert.Equal("timed out", ctx.CancellationReason);
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_StartToCloseTimeout_FailsAsExpected()
+    {
+        // Build a workflow-backed async operation that will never complete
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                WorkflowRunOperationHandler.FromHandleFactory(
+                    (WorkflowRunOperationContext context, string input) =>
+                        context.StartWorkflowAsync(
+                            (WaitForeverWorkflow wf) => wf.RunAsync(input),
+                            new() { Id = $"wf-{Guid.NewGuid()}" })))).
+            AddWorkflow<WaitForeverWorkflow>();
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+        // Confirm the workflow fails with the timeout
+        var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
+            RunInWorkflowAsync(workerOptions, async () =>
+            {
+                await Workflow.CreateNexusClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(
+                        svc => svc.DoSomething("some-name"),
+                        new()
+                        {
+                            ScheduleToStartTimeout = TimeSpan.FromSeconds(30),
+                            StartToCloseTimeout = TimeSpan.FromSeconds(2),
+                        });
+            }));
+        var timeoutExc = Assert.IsType<TimeoutFailureException>(
+            Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);
+        Assert.Equal(TimeoutType.StartToClose, timeoutExc.TimeoutType);
     }
 
     [Workflow]

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -67,7 +67,7 @@ public class WorkflowEnvironment : IAsyncLifetime
             {
                 DevServerOptions = new()
                 {
-                    DownloadVersion = "v1.6.1-server-1.31.0-150.0",
+                    DownloadVersion = "v1.6.1-server-1.31.0-151.0",
                     ExtraArgs = new List<string>
                     {
                         // Disable search attribute cache


### PR DESCRIPTION
Add schedule-to-start and start-to-close for Nexus operations

NOTE, before this can be merged the API still needs to be tagged, core changes need to be merged and tests need to be added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow command construction for Nexus operations; incorrect mapping could change timeout behavior or break compatibility with older servers, though coverage is added via new/updated timeout tests.
> 
> **Overview**
> Adds `ScheduleToStartTimeout` and `StartToCloseTimeout` to `NexusOperationOptions` and wires them through `WorkflowInstance.StartNexusOperationAsync` so Nexus operation scheduling can enforce these server-side timeouts (in addition to the existing schedule-to-close).
> 
> Extends Nexus worker tests to assert the correct `TimeoutType` surfaces for schedule-to-close, schedule-to-start, and start-to-close failures, and bumps the local test dev-server download version to pick up the required server support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94ed30aca651d0830e4c83507a12eaf129197b1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->