### PR TITLE
Fix: load TLS certs from path if specified

### DIFF
--- a/src/Temporalio/Common/EnvConfig/ClientEnvConfig.cs
+++ b/src/Temporalio/Common/EnvConfig/ClientEnvConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Temporalio.Client;
@@ -211,9 +212,9 @@ namespace Temporalio.Common.EnvConfig
                 return new TlsOptions
                 {
                     Domain = ServerName,
-                    ServerRootCACert = ServerRootCACert?.Data,
-                    ClientCert = ClientCert?.Data,
-                    ClientPrivateKey = ClientPrivateKey?.Data,
+                    ServerRootCACert = ServerRootCACert?.GetBytes(),
+                    ClientCert = ClientCert?.GetBytes(),
+                    ClientPrivateKey = ClientPrivateKey?.GetBytes(),
                 };
             }
 
@@ -421,6 +422,25 @@ namespace Temporalio.Common.EnvConfig
             if (dictionary.ContainsKey("path"))
             {
                 return DataSource.FromPath(dictionary["path"]);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the bytes for this data source, reading from file if necessary.
+        /// </summary>
+        /// <returns>The raw bytes, or null if neither Data nor Path is set.</returns>
+        public byte[]? GetBytes()
+        {
+            if (Data != null)
+            {
+                return Data;
+            }
+
+            if (!string.IsNullOrEmpty(Path))
+            {
+                return File.ReadAllBytes(Path);
             }
 
             return null;

--- a/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
+++ b/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
@@ -523,6 +523,13 @@ client_key_path = ""{keyPath.Replace('\\', '/')}""
                 var options = profile.ToClientConnectionOptions();
                 Assert.NotNull(options.Tls);
                 Assert.Equal("custom-server", options.Tls.Domain);
+                // Verify certificate data is loaded from files
+                Assert.NotNull(options.Tls.ServerRootCACert);
+                Assert.Equal("ca-pem-data", System.Text.Encoding.UTF8.GetString(options.Tls.ServerRootCACert));
+                Assert.NotNull(options.Tls.ClientCert);
+                Assert.Equal("client-crt-data", System.Text.Encoding.UTF8.GetString(options.Tls.ClientCert));
+                Assert.NotNull(options.Tls.ClientPrivateKey);
+                Assert.Equal("client-key-data", System.Text.Encoding.UTF8.GetString(options.Tls.ClientPrivateKey));
             }
             finally
             {


### PR DESCRIPTION
## What was changed
Read TLS paths from `DataSource` path if specified.

Literal changes:
- Added GetBytes() method to DataSource that returns Data if set, or reads from Path using File.ReadAllBytes()
- Changed ToTlsOptions() to use ?.GetBytes() instead of ?.Data

## Why?
Bug fix

1. Closes https://github.com/temporalio/sdk-dotnet/issues/584

2. How was this tested:
Modified existing integration test

3. Any docs updates needed?
Don't think so
