### PR TITLE
chore(RID): add musl-arm-64 RID build support #597

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
       - "releases/*"
+  # TODO: Remove before merging, temporary trigger for PR testing
+  pull_request:
+    branches:
+      - main
   workflow_dispatch: {}
 permissions:
   contents: read

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,6 +18,7 @@ jobs:
             ubuntu-latest,
             ubuntu-arm,
             alpine-latest,
+            alpine-arm,
             macos-intel,
             macos-arm,
             windows-latest,
@@ -44,6 +45,13 @@ jobs:
             container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
             runsOn: ubuntu-latest
+          - os: alpine-arm
+            out-file: libtemporalio_sdk_core_c_bridge.so
+            out-prefix: linux-musl-arm64
+            # Need Alpine container since GH runner doesn't have one
+            container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+            protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
+            runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-intel
             out-file: libtemporalio_sdk_core_c_bridge.dylib
             out-prefix: osx-x64
@@ -92,7 +100,7 @@ jobs:
         run: cargo build --manifest-path src/Temporalio/Bridge/sdk-core/crates/sdk-core-c-bridge/Cargo.toml --profile release-lto
 
       - name: Build (Docker non-Alpine)
-        if: ${{ matrix.container && matrix.os != 'alpine-latest' }}
+        if: ${{ matrix.container && matrix.os != 'alpine-latest' && matrix.os != 'alpine-arm' }}
         run: |
           docker run --rm -v "$(pwd):/workspace" -w /workspace \
             ${{ matrix.container }} \
@@ -106,7 +114,7 @@ jobs:
             '
 
       - name: Build (Docker Alpine)
-        if: ${{ matrix.container && matrix.os == 'alpine-latest' }}
+        if: ${{ matrix.container && (matrix.os == 'alpine-latest' || matrix.os == 'alpine-arm') }}
         run: |
           docker run --rm -v "$(pwd):/workspace" -w /workspace \
             ${{ matrix.container }} \
@@ -175,6 +183,7 @@ jobs:
             ubuntu-latest,
             ubuntu-arm,
             alpine-latest,
+            alpine-arm,
             macos-intel,
             macos-arm,
             windows-latest,
@@ -186,6 +195,9 @@ jobs:
           - os: alpine-latest
             container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
             runsOn: ubuntu-latest
+          - os: alpine-arm
+            container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+            runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-intel
             runsOn: macos-15-intel
           - os: macos-arm
@@ -208,7 +220,7 @@ jobs:
 
       - name: Setup .NET (non-Alpine)
         uses: actions/setup-dotnet@v4
-        if: ${{ matrix.os != 'alpine-latest' }}
+        if: ${{ matrix.os != 'alpine-latest' && matrix.os != 'alpine-arm' }}
         with:
           # Specific .NET version required because GitHub macos ARM image has
           # bad pre-installed .NET version

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -197,7 +197,6 @@ jobs:
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
           - os: alpine-latest
-            # Run in Docker manually to avoid JS action limitations
             runsOn: ubuntu-latest
           - os: alpine-arm
             # Run in Docker manually to avoid JS action limitations on ARM64
@@ -223,14 +222,15 @@ jobs:
 
       - name: Setup .NET (non-Alpine)
         uses: actions/setup-dotnet@v4
-        if: ${{ matrix.os != 'alpine-latest' && matrix.os != 'alpine-arm' }}
+        if: ${{ !contains(matrix.os, 'alpine') }}
         with:
           # Specific .NET version required because GitHub macos ARM image has
           # bad pre-installed .NET version
           dotnet-version: 10.x
 
       - name: Run smoke test (Alpine)
-        if: ${{ matrix.os == 'alpine-latest' || matrix.os == 'alpine-arm' }}
+        if: ${{ contains(matrix.os, 'alpine') }}
+        # Use Docker specifically for Alpine ARM 64 to avoid JS action limitations
         run: |
           docker run --rm -v "$(pwd):/workspace" -w /workspace \
             mcr.microsoft.com/dotnet/sdk:10.0-alpine \
@@ -239,14 +239,14 @@ jobs:
              && dotnet run --project tests/Temporalio.SmokeTest \
             '
 
-      - name: Run smoke test (non-Windows, non-Alpine)
-        if: ${{ matrix.os != 'windows-latest' && matrix.os != 'windows-arm' && matrix.os != 'alpine-latest' && matrix.os != 'alpine-arm' }}
+      - name: Run smoke test (Linux/macOS)
+        if: ${{ !contains(matrix.os, 'alpine') && !contains(matrix.os, 'windows') }}
         run: |
           dotnet add tests/Temporalio.SmokeTest package Temporalio -s "$GITHUB_WORKSPACE/nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json" --prerelease
           dotnet run --project tests/Temporalio.SmokeTest
 
       - name: Run smoke test (Windows)
-        if: ${{ matrix.os == 'windows-latest' || matrix.os == 'windows-arm' }}
+        if: ${{ contains(matrix.os, 'windows') }}
         run: |
           dotnet add tests/Temporalio.SmokeTest package Temporalio -s "$env:GITHUB_WORKSPACE/nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json" --prerelease
           dotnet run --project tests/Temporalio.SmokeTest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -197,10 +197,10 @@ jobs:
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
           - os: alpine-latest
-            container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+            # Run in Docker manually to avoid JS action limitations
             runsOn: ubuntu-latest
           - os: alpine-arm
-            container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+            # Run in Docker manually to avoid JS action limitations on ARM64
             runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-intel
             runsOn: macos-15-intel
@@ -209,7 +209,6 @@ jobs:
           - os: windows-arm
             runsOn: windows-11-arm
     runs-on: ${{ matrix.runsOn || matrix.os }}
-    container: ${{ matrix.container }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -230,8 +229,18 @@ jobs:
           # bad pre-installed .NET version
           dotnet-version: 10.x
 
-      - name: Run smoke test (non-Windows)
-        if: ${{ matrix.os != 'windows-latest' && matrix.os != 'windows-arm' }}
+      - name: Run smoke test (Alpine)
+        if: ${{ matrix.os == 'alpine-latest' || matrix.os == 'alpine-arm' }}
+        run: |
+          docker run --rm -v "$(pwd):/workspace" -w /workspace \
+            mcr.microsoft.com/dotnet/sdk:10.0-alpine \
+            sh -c ' \
+                dotnet add tests/Temporalio.SmokeTest package Temporalio -s "/workspace/nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json" --prerelease \
+             && dotnet run --project tests/Temporalio.SmokeTest \
+            '
+
+      - name: Run smoke test (non-Windows, non-Alpine)
+        if: ${{ matrix.os != 'windows-latest' && matrix.os != 'windows-arm' && matrix.os != 'alpine-latest' && matrix.os != 'alpine-arm' }}
         run: |
           dotnet add tests/Temporalio.SmokeTest package Temporalio -s "$GITHUB_WORKSPACE/nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json" --prerelease
           dotnet run --project tests/Temporalio.SmokeTest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - main
       - "releases/*"
-  # TODO: Remove before merging, temporary trigger for PR testing
-  pull_request:
-    branches:
-      - main
   workflow_dispatch: {}
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1210,7 +1210,7 @@ on a common platform. If you are using .NET framework, you may have to explicitl
 because `AnyCPU` will not choose the proper library.
 
 Currently we only support [RIDs](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog)
-`linux-arm64`, `linux-x64`, `linux-musl-x64`, `osx-arm64`, `osx-x64`, `win-arm64`, and `win-x64`.
+`linux-arm64`, `linux-x64`, `linux-musl-arm64`, `linux-musl-x64`, `osx-arm64`, `osx-x64`, `win-arm64`, and `win-x64`.
 Any other platforms needed will require a custom build.
 
 The native shared library on Windows does require a Visual C++ runtime. Some containers, such as Windows Nano Server, do

--- a/src/Temporalio/Temporalio.csproj
+++ b/src/Temporalio/Temporalio.csproj
@@ -94,6 +94,9 @@
       <Content Include="$(BridgeLibraryRoot)/linux-musl-x64-bridge/libtemporalio_sdk_core_c_bridge.so">
         <PackagePath>runtimes/linux-musl-x64/native/libtemporalio_sdk_core_c_bridge.so</PackagePath>
       </Content>
+      <Content Include="$(BridgeLibraryRoot)/linux-musl-arm64-bridge/libtemporalio_sdk_core_c_bridge.so">
+        <PackagePath>runtimes/linux-musl-arm64/native/libtemporalio_sdk_core_c_bridge.so</PackagePath>
+      </Content>
       <Content Include="$(BridgeLibraryRoot)/osx-x64-bridge/libtemporalio_sdk_core_c_bridge.dylib">
         <PackagePath>runtimes/osx-x64/native/libtemporalio_sdk_core_c_bridge.dylib</PackagePath>
       </Content>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Added `linux-musl-arm64` runtime identifier support to the CI build pipeline
- Updated `.csproj` configuration to enable `linux-musl-arm64` compatibility

## Why?
<!-- Tell your future self why have you made these changes -->
.NET 10 officially supports only Ubuntu, Alpine Linux, and Azure Linux as target platforms. With Alpine Linux becoming increasingly popular for containerized deployments and ARM64 architecture gaining widespread adoption (especially in cloud environments), adding `linux-musl-arm64` support ensures compatibility with this growing ecosystem.

## Checklist
<!--- add/delete as needed --->

1. **Closes** #597 

2. **How was this tested:**
   - CI pipeline runs with smoke tests will validate the build
   - Manual testing suggestions welcome, as local validation of this platform combination is challenging

3. **Documentation updates:**
   - Updated README to include the new `linux-musl-arm64` runtime identifier in the supported platforms list