### PR TITLE
Avoid double Client SafeHandle implementation

### DIFF
--- a/src/Temporalio/Bridge/Client.cs
+++ b/src/Temporalio/Bridge/Client.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Google.Protobuf;
 
@@ -9,17 +8,15 @@ namespace Temporalio.Bridge
     /// <summary>
     /// Core-owned Temporal client.
     /// </summary>
-    internal class Client : SafeHandle
+    internal class Client : IDisposable
     {
+        private readonly SafeClientHandle handle;
+
         private unsafe Client(Runtime runtime, Interop.TemporalCoreClient* ptr)
-            : base((IntPtr)ptr, true)
         {
             Runtime = runtime;
-            Handle = new SafeClientHandle(ptr);
+            handle = new SafeClientHandle(ptr);
         }
-
-        /// <inheritdoc />
-        public override bool IsInvalid => Handle.IsInvalid;
 
         /// <summary>
         /// Gets the runtime associated with this client.
@@ -29,7 +26,7 @@ namespace Temporalio.Bridge
         /// <summary>
         /// Gets the safe handle for the client.
         /// </summary>
-        internal SafeClientHandle Handle { get; private init; }
+        internal SafeClientHandle Handle => handle;
 
         /// <summary>
         /// Connect to Temporal.
@@ -211,10 +208,9 @@ namespace Temporalio.Bridge
         }
 
         /// <inheritdoc />
-        protected override unsafe bool ReleaseHandle()
+        public void Dispose()
         {
-            Handle.Dispose();
-            return true;
+            handle.Dispose();
         }
     }
 }

--- a/src/Temporalio/Client/IBridgeClientProviderInternal.cs
+++ b/src/Temporalio/Client/IBridgeClientProviderInternal.cs
@@ -1,0 +1,18 @@
+namespace Temporalio.Client
+{
+    /// <summary>
+    /// Internal interface that provides access to bridge client and runtime.
+    /// </summary>
+    internal interface IBridgeClientProviderInternal : IBridgeClientProvider
+    {
+        /// <summary>
+        /// Gets the safe client handle for internal bridge use.
+        /// </summary>
+        Bridge.SafeClientHandle? ClientHandle { get; }
+
+        /// <summary>
+        /// Gets the runtime associated with the client.
+        /// </summary>
+        Bridge.Runtime? Runtime { get; }
+    }
+}

--- a/src/Temporalio/Client/TemporalConnection.cs
+++ b/src/Temporalio/Client/TemporalConnection.cs
@@ -18,7 +18,7 @@ namespace Temporalio.Client
     /// <remarks>
     /// Connections are thread-safe and are encouraged to be reused.
     /// </remarks>
-    public sealed class TemporalConnection : ITemporalConnection
+    public sealed class TemporalConnection : ITemporalConnection, IBridgeClientProviderInternal
     {
         // Not set if not lazy
         private readonly SemaphoreSlim? semaphoreForLazyClient;
@@ -177,7 +177,13 @@ namespace Temporalio.Client
         public bool IsConnected => client != null;
 
         /// <inheritdoc />
-        public SafeHandle? BridgeClient => client;
+        public SafeHandle? BridgeClient => client?.Handle;
+
+        /// <inheritdoc />
+        Bridge.SafeClientHandle? IBridgeClientProviderInternal.ClientHandle => client?.Handle;
+
+        /// <inheritdoc />
+        Bridge.Runtime? IBridgeClientProviderInternal.Runtime => client?.Runtime;
 
         /// <summary>
         /// Connect to Temporal.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Changed the bridge client to no longer implement `SafeHandle` and to only implement `IDisposable`. This required that more information is pass via a new `IBridgeClientProviderInternal` interface that exposes the `SafeClientHandle` and the `Runtime` instances from the `TemporalConnection`.

## Why?

Avoid the double creation of `SafeHandle` implementations for bridge clients.

## Checklist
1. Closes #587 
1. How was this tested: Unit tests
1. Any docs updates needed? No
