### PR TITLE
Make search attribute type more lenient when parsing

### DIFF
--- a/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
@@ -218,8 +218,7 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
                     Set(AttrDateTime, dateTime).
                     Set(AttrDouble, 123.45).
                     Set(AttrKeyword, "SomeKeyword").
-                    // TODO(cretz): Fix after Temporal dev server upgraded
-                    // Set(AttrKeywordList, new[] { "SomeKeyword1", "SomeKeyword2" }).
+                    Set(AttrKeywordList, new[] { "SomeKeyword1", "SomeKeyword2" }).
                     Set(AttrLong, 678).
                     Set(AttrText, "SomeText").
                     ToSearchAttributeCollection(),
@@ -236,8 +235,7 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
         Assert.Equal(dateTime, desc.TypedSearchAttributes.Get(AttrDateTime));
         Assert.Equal(123.45, desc.TypedSearchAttributes.Get(AttrDouble));
         Assert.Equal("SomeKeyword", desc.TypedSearchAttributes.Get(AttrKeyword));
-        // TODO(cretz): Fix after Temporal dev server upgraded
-        // Assert.Equal(new[] { "SomeKeyword1", "SomeKeyword2" }, desc.TypedSearchAttributes.Get(AttrKeywordList));
+        Assert.Equal(new[] { "SomeKeyword1", "SomeKeyword2" }, desc.TypedSearchAttributes.Get(AttrKeywordList));
         Assert.Equal(678, desc.TypedSearchAttributes.Get(AttrLong));
         Assert.Equal("SomeText", desc.TypedSearchAttributes.Get(AttrText));
         Assert.Equal(memoVals, await desc.Memo["MemoKey"].ToValueAsync<List<string>>());

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -2733,6 +2733,48 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Workflow]
+    public class PatchSearchAttributeWorkflow
+    {
+        [Activity]
+        public static string SomeActivity() => "done";
+
+        [WorkflowRun]
+        public async Task RunAsync()
+        {
+            if (Workflow.Patched("my-patch"))
+            {
+                await Workflow.ExecuteActivityAsync(
+                    () => SomeActivity(),
+                    new() { ScheduleToCloseTimeout = TimeSpan.FromMinutes(5) });
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_PatchSearchAttribute_ReturnsProperly()
+    {
+        await EnsureSearchAttributesPresentAsync();
+        await ExecuteWorkerAsync<PatchSearchAttributeWorkflow>(
+            async worker =>
+            {
+                var handle = await Env.Client.StartWorkflowAsync(
+                    (PatchSearchAttributeWorkflow wf) => wf.RunAsync(),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!)
+                {
+                    TypedSearchAttributes = new SearchAttributeCollection.Builder().
+                        Set(AttrKeywordList, new[] { "SomeKeywordA", "SomeKeywordB" }).
+                        ToSearchAttributeCollection(),
+                });
+                await handle.GetResultAsync();
+                var desc = await handle.DescribeAsync();
+                Assert.Equal(
+                    ["my-patch"],
+                    desc.TypedSearchAttributes.Get(SearchAttributeKey.CreateKeywordList("TemporalChangeVersion")));
+            },
+            new TemporalWorkerOptions().AddActivity(PatchSearchAttributeWorkflow.SomeActivity));
+    }
+
+    [Workflow]
     public class HeadersWithCodecWorkflow
     {
         public enum Kind

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -2760,11 +2760,11 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 var handle = await Env.Client.StartWorkflowAsync(
                     (PatchSearchAttributeWorkflow wf) => wf.RunAsync(),
                     new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!)
-                {
-                    TypedSearchAttributes = new SearchAttributeCollection.Builder().
+                    {
+                        TypedSearchAttributes = new SearchAttributeCollection.Builder().
                         Set(AttrKeywordList, new[] { "SomeKeywordA", "SomeKeywordB" }).
                         ToSearchAttributeCollection(),
-                });
+                    });
                 await handle.GetResultAsync();
                 var desc = await handle.DescribeAsync();
                 Assert.Equal(


### PR DESCRIPTION
## What was changed

Allowed the `UNQUALIFIED_SCREAMING_CASE` to be in the metadata `type` of search attributes since it was the type used in Core as part of https://github.com/temporalio/sdk-core/pull/1032 and server has no validation of this value to have prevented that one.

## Checklist

1. Closes #603