### PR TITLE
Remove experimental warning for worker deployment versioning and envconfig

### DIFF
--- a/src/Temporalio/Client/BuildIdOp.cs
+++ b/src/Temporalio/Client/BuildIdOp.cs
@@ -1,8 +1,11 @@
+using System;
+
 namespace Temporalio.Client
 {
     /// <summary>
     /// A supertype for all operations that may be performed by <see cref="ITemporalClient.UpdateWorkerBuildIdCompatibilityAsync"/>.
     /// </summary>
+    [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
     public abstract record BuildIdOp
     {
         private BuildIdOp()

--- a/src/Temporalio/Client/BuildIdReachability.cs
+++ b/src/Temporalio/Client/BuildIdReachability.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Temporalio.Api.Enums.V1;
@@ -11,6 +12,7 @@ namespace Temporalio.Client
     /// queue. If the value is an empty list, the Build ID is not reachable on that queue.</param>
     /// <param name="UnretrievedTaskQueues">If any Task Queues could not be retrieved because the server limits the
     /// number that can be queried at once, they will be listed here.</param>
+    [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
     public record BuildIdReachability(
         IReadOnlyDictionary<string, IReadOnlyCollection<TaskReachability>> TaskQueueReachability,
         IReadOnlyCollection<string> UnretrievedTaskQueues)

--- a/src/Temporalio/Client/ITemporalClient.TaskQueue.cs
+++ b/src/Temporalio/Client/ITemporalClient.TaskQueue.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Temporalio.Api.Enums.V1;
@@ -15,6 +16,7 @@ namespace Temporalio.Client
         /// <param name="buildIdOp">The operation to perform.</param>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>Completion task.</returns>
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
         Task UpdateWorkerBuildIdCompatibilityAsync(
             string taskQueue,
             BuildIdOp buildIdOp,
@@ -29,6 +31,7 @@ namespace Temporalio.Client
         ///     returned.</param>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>The sets, if the Task Queue is versioned, otherwise null.</returns>
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
         Task<WorkerBuildIdVersionSets?> GetWorkerBuildIdCompatibilityAsync(
             string taskQueue,
             int maxSets = 0,
@@ -50,6 +53,7 @@ namespace Temporalio.Client
         /// <param name="reachability">The kind of reachability this request is concerned with.</param>
         /// <param name="rpcOptions">RPC options.</param>
         /// <returns>The reachability information.</returns>
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
         Task<WorkerTaskReachability> GetWorkerTaskReachabilityAsync(
             IReadOnlyCollection<string> buildIds,
             IReadOnlyCollection<string> taskQueues,

--- a/src/Temporalio/Client/Interceptors/ClientOutboundInterceptor.TaskQueue.cs
+++ b/src/Temporalio/Client/Interceptors/ClientOutboundInterceptor.TaskQueue.cs
@@ -1,14 +1,17 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Temporalio.Client.Interceptors
 {
     public partial class ClientOutboundInterceptor
     {
+#pragma warning disable CS0618 // Using obsolete types internally
         /// <summary>
         /// Intercept update worker build id compatability calls.
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>Completion task.</returns>
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
         public virtual Task UpdateWorkerBuildIdCompatibilityAsync(
             UpdateWorkerBuildIdCompatibilityInput input) =>
             Next.UpdateWorkerBuildIdCompatibilityAsync(input);
@@ -18,6 +21,7 @@ namespace Temporalio.Client.Interceptors
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>The sets, if the Task Queue is versioned, otherwise null.</returns>
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
         public virtual Task<WorkerBuildIdVersionSets?> GetWorkerBuildIdCompatibilityAsync(
             GetWorkerBuildIdCompatibilityInput input) =>
             Next.GetWorkerBuildIdCompatibilityAsync(input);
@@ -27,8 +31,10 @@ namespace Temporalio.Client.Interceptors
         /// </summary>
         /// <param name="input">Input details of the call.</param>
         /// <returns>The reachability information.</returns>
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
         public virtual Task<WorkerTaskReachability> GetWorkerTaskReachabilityAsync(
             GetWorkerTaskReachabilityInput input) =>
             Next.GetWorkerTaskReachabilityAsync(input);
+#pragma warning restore CS0618
     }
 }

--- a/src/Temporalio/Client/Interceptors/GetWorkerBuildIdCompatibilityInput.cs
+++ b/src/Temporalio/Client/Interceptors/GetWorkerBuildIdCompatibilityInput.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Temporalio.Client.Interceptors
 {
     /// <summary>
@@ -11,6 +13,7 @@ namespace Temporalio.Client.Interceptors
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
+    [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
     public record GetWorkerBuildIdCompatibilityInput(
         string TaskQueue,
         int MaxSets,

--- a/src/Temporalio/Client/Interceptors/GetWorkerTaskReachabilityInput.cs
+++ b/src/Temporalio/Client/Interceptors/GetWorkerTaskReachabilityInput.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Temporalio.Api.Enums.V1;
 
@@ -21,6 +22,7 @@ namespace Temporalio.Client.Interceptors
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
+    [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
     public record GetWorkerTaskReachabilityInput(
         IReadOnlyCollection<string> BuildIds,
         IReadOnlyCollection<string> TaskQueues,

--- a/src/Temporalio/Client/Interceptors/UpdateWorkerBuildIdCompatibilityInput.cs
+++ b/src/Temporalio/Client/Interceptors/UpdateWorkerBuildIdCompatibilityInput.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Temporalio.Client.Interceptors
 {
     /// <summary>
@@ -10,6 +12,7 @@ namespace Temporalio.Client.Interceptors
     /// WARNING: This constructor may have required properties added. Do not rely on the exact
     /// constructor, only use "with" clauses.
     /// </remarks>
+    [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
     public record UpdateWorkerBuildIdCompatibilityInput(
         string TaskQueue,
         BuildIdOp BuildIdOp,

--- a/src/Temporalio/Client/TemporalClient.TaskQueue.cs
+++ b/src/Temporalio/Client/TemporalClient.TaskQueue.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Temporalio.Api.Enums.V1;
@@ -9,6 +10,8 @@ namespace Temporalio.Client
     public partial class TemporalClient
     {
         /// <inheritdoc />
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
+#pragma warning disable CS0618 // Using obsolete types internally
         public Task UpdateWorkerBuildIdCompatibilityAsync(
             string taskQueue,
             BuildIdOp buildIdOp,
@@ -17,8 +20,11 @@ namespace Temporalio.Client
                 TaskQueue: taskQueue,
                 BuildIdOp: buildIdOp,
                 RpcOptions: rpcOptions));
+#pragma warning restore CS0618
 
         /// <inheritdoc />
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
+#pragma warning disable CS0618 // Using obsolete types internally
         public Task<WorkerBuildIdVersionSets?> GetWorkerBuildIdCompatibilityAsync(
             string taskQueue,
             int maxSets,
@@ -27,8 +33,11 @@ namespace Temporalio.Client
                 TaskQueue: taskQueue,
                 MaxSets: maxSets,
                 RpcOptions: rpcOptions));
+#pragma warning restore CS0618
 
         /// <inheritdoc />
+        [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
+#pragma warning disable CS0618 // Using obsolete types internally
         public Task<WorkerTaskReachability> GetWorkerTaskReachabilityAsync(
             IReadOnlyCollection<string> buildIds,
             IReadOnlyCollection<string> taskQueues,
@@ -39,10 +48,13 @@ namespace Temporalio.Client
                 TaskQueues: taskQueues,
                 Reachability: reachability,
                 RpcOptions: rpcOptions));
+#pragma warning restore CS0618
 
         internal partial class Impl
         {
+#pragma warning disable CS0618, CS0672 // Using obsolete types internally
             /// <inheritdoc />
+            [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
             public override async Task UpdateWorkerBuildIdCompatibilityAsync(
                 UpdateWorkerBuildIdCompatibilityInput input)
             {
@@ -86,6 +98,7 @@ namespace Temporalio.Client
             }
 
             /// <inheritdoc />
+            [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
             public override async Task<WorkerBuildIdVersionSets?> GetWorkerBuildIdCompatibilityAsync(
                 GetWorkerBuildIdCompatibilityInput input)
             {
@@ -102,6 +115,7 @@ namespace Temporalio.Client
             }
 
             /// <inheritdoc />
+            [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
             public override async Task<WorkerTaskReachability> GetWorkerTaskReachabilityAsync(
                 GetWorkerTaskReachabilityInput input)
             {
@@ -117,6 +131,7 @@ namespace Temporalio.Client
                     .ConfigureAwait(false);
                 return WorkerTaskReachability.FromProto(resp);
             }
+#pragma warning restore CS0618, CS0672
         }
     }
 }

--- a/src/Temporalio/Client/WorkerBuildIdVersionSets.cs
+++ b/src/Temporalio/Client/WorkerBuildIdVersionSets.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,6 +9,7 @@ namespace Temporalio.Client
     /// fetched by <see cref="ITemporalClient.GetWorkerBuildIdCompatibilityAsync"/>.
     /// </summary>
     /// <param name="VersionSets">The sets of compatible versions in the Task Queue.</param>
+    [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
     public record WorkerBuildIdVersionSets(IReadOnlyCollection<BuildIdVersionSet> VersionSets)
     {
         /// <summary>
@@ -44,6 +46,7 @@ namespace Temporalio.Client
     /// A set of Build IDs which are compatible with each other.
     /// </summary>
     /// <param name="BuildIds">The Build IDs.</param>
+    [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
     public record BuildIdVersionSet(IReadOnlyCollection<string> BuildIds)
     {
         /// <summary>Gets the default Build ID for this set.</summary>

--- a/src/Temporalio/Client/WorkerTaskReachability.cs
+++ b/src/Temporalio/Client/WorkerTaskReachability.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,7 @@ namespace Temporalio.Client
     /// Contains information about the reachability of some Build IDs.
     /// </summary>
     /// <param name="BuildIdReachability">Maps Build IDs to information about their reachability.</param>
+    [Obsolete("Use the Worker Deployment API instead. See https://docs.temporal.io/worker-deployments")]
     public record WorkerTaskReachability(IReadOnlyDictionary<string, BuildIdReachability> BuildIdReachability)
     {
         /// <summary>

--- a/src/Temporalio/Common/VersioningBehavior.cs
+++ b/src/Temporalio/Common/VersioningBehavior.cs
@@ -3,7 +3,6 @@ namespace Temporalio.Common
     /// <summary>
     /// Specifies when a workflow might move from a worker of one Build ID to another.
     /// </summary>
-    /// <remarks>WARNING: Deployment-based versioning is experimental and APIs may change.</remarks>
     public enum VersioningBehavior
     {
         /// <summary>

--- a/src/Temporalio/Common/WorkerDeploymentVersion.cs
+++ b/src/Temporalio/Common/WorkerDeploymentVersion.cs
@@ -5,7 +5,6 @@ namespace Temporalio.Common
     /// <summary>
     /// Represents the version of a specific worker deployment.
     /// </summary>
-    /// <remarks>WARNING: Deployment-based versioning is experimental and APIs may change.</remarks>
     public sealed record WorkerDeploymentVersion(string DeploymentName, string BuildId)
     {
         private static readonly char[] Separator = new char[] { '.' };

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -140,9 +140,7 @@ namespace Temporalio.Worker
         /// <summary>
         /// Gets or sets the deployment options for this worker.
         /// </summary>
-        /// <remarks>Exclusive with <see cref="DeploymentOptions"/> and <see cref="UseWorkerVersioning"/>.</remarks>
-        /// <remarks>WARNING: Deployment-based versioning is experimental and APIs may
-        /// change.</remarks>
+        /// <remarks>Exclusive with <see cref="BuildId"/> and <see cref="UseWorkerVersioning"/>.</remarks>
         public WorkerDeploymentOptions? DeploymentOptions { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Worker/WorkerDeploymentOptions.cs
+++ b/src/Temporalio/Worker/WorkerDeploymentOptions.cs
@@ -8,7 +8,6 @@ namespace Temporalio.Worker
     ///
     /// <see cref="Version"/> must be set.
     /// </summary>
-    /// <remarks>WARNING: Deployment-based versioning is experimental and APIs may change.</remarks>
     public class WorkerDeploymentOptions : ICloneable
     {
         /// <summary>

--- a/src/Temporalio/Workflows/WorkflowAttribute.cs
+++ b/src/Temporalio/Workflows/WorkflowAttribute.cs
@@ -66,8 +66,6 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Gets or sets the versioning behavior to use for this workflow.
         /// </summary>
-        /// <remarks>WARNING: Deployment-based versioning is experimental and APIs may
-        /// change.</remarks>
         public VersioningBehavior VersioningBehavior { get; set; }
     }
 }

--- a/src/Temporalio/Workflows/WorkflowDefinitionOptions.cs
+++ b/src/Temporalio/Workflows/WorkflowDefinitionOptions.cs
@@ -35,8 +35,6 @@ namespace Temporalio.Workflows
         /// If set to a non-unspecified value, overrides any value set on
         /// <see cref="WorkflowAttribute.VersioningBehavior"/>.
         /// </remarks>
-        /// <remarks>WARNING: Deployment-based versioning is experimental and APIs may
-        /// change.</remarks>
         public VersioningBehavior VersioningBehavior { get; set; }
 
         /// <summary>

--- a/tests/Temporalio.Tests/Client/TemporalClientTaskQueueTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientTaskQueueTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Testing obsolete APIs
 using Temporalio.Client;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
@@ -312,14 +312,13 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
         // Build with two workers on same queue but different versions
         var bld = Host.CreateApplicationBuilder();
         bld.Services.AddSingleton(Client);
-#pragma warning disable 0618
+#pragma warning disable CS0618 // Testing obsolete APIs
         bld.Services.
             AddHostedTemporalWorker(taskQueue, "1.0").
             AddWorkflow<WorkflowV1>();
         bld.Services.
             AddHostedTemporalWorker(taskQueue, "2.0").
             AddWorkflow<WorkflowV2>();
-#pragma warning restore 0618
 
         // Start the host
         using var tokenSource = new CancellationTokenSource();
@@ -341,6 +340,7 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
             (WorkflowV1 wf) => wf.RunAsync(),
             new($"wf-{Guid.NewGuid()}", taskQueue));
         Assert.Equal("done-v2", res);
+#pragma warning restore CS0618
     }
 
     [Fact]

--- a/tests/Temporalio.Tests/WorkflowEnvironmentTestBase.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironmentTestBase.cs
@@ -53,7 +53,9 @@ public abstract class WorkflowEnvironmentTestBase : TestBase
         var tq = $"tq-test-worker-ver-{Guid.NewGuid()}";
         try
         {
+#pragma warning disable CS0618 // Testing obsolete APIs
             await Client.UpdateWorkerBuildIdCompatibilityAsync(tq, new BuildIdOp.AddNewDefault("yoyoyo"));
+#pragma warning restore CS0618
         }
         catch (RpcException e) when (e.Code == RpcException.StatusCode.PermissionDenied ||
                                      e.Code == RpcException.StatusCode.Unimplemented)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
DWISOTT:
- remove experimental warnings for worker deployment API
- remove experimental warnings for (client) environment configuration
- add deprecated warnings/markings to old worker deployment APIs

## Why?
Worker deployment versioning and envconfig are GA

1. Part of https://github.com/temporalio/features/issues/744

3. Any docs updates needed?
Yes?
