### PR TITLE
Add keep-original-workflow-id to schedule policy

### DIFF
--- a/src/Temporalio/Client/Schedules/SchedulePolicy.cs
+++ b/src/Temporalio/Client/Schedules/SchedulePolicy.cs
@@ -27,6 +27,12 @@ namespace Temporalio.Client.Schedules
         public bool PauseOnFailure { get; init; }
 
         /// <summary>
+        /// Gets a value indicating whether scheduled workflow IDs should be kept as-is without a
+        /// timestamp suffix.
+        /// </summary>
+        public bool KeepOriginalWorkflowId { get; init; }
+
+        /// <summary>
         /// Convert from proto.
         /// </summary>
         /// <param name="proto">Proto.</param>
@@ -36,6 +42,7 @@ namespace Temporalio.Client.Schedules
             Overlap = proto.OverlapPolicy,
             CatchupWindow = proto.CatchupWindow.ToTimeSpan(),
             PauseOnFailure = proto.PauseOnFailure,
+            KeepOriginalWorkflowId = proto.KeepOriginalWorkflowId,
         };
 
         /// <summary>
@@ -47,6 +54,7 @@ namespace Temporalio.Client.Schedules
             OverlapPolicy = Overlap,
             CatchupWindow = Duration.FromTimeSpan(CatchupWindow),
             PauseOnFailure = PauseOnFailure,
+            KeepOriginalWorkflowId = KeepOriginalWorkflowId,
         };
     }
 }

--- a/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
@@ -417,16 +417,6 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
             desc = await handle.DescribeAsync();
             Assert.True(desc.Schedule.Policy.KeepOriginalWorkflowId);
             Assert.True(desc.RawDescription.Schedule.Policies.KeepOriginalWorkflowId);
-
-            await handle.UpdateAsync(input =>
-            {
-                var sched = input.Description.Schedule;
-                return new(sched with { Policy = sched.Policy with { KeepOriginalWorkflowId = false } });
-            });
-
-            desc = await handle.DescribeAsync();
-            Assert.False(desc.Schedule.Policy.KeepOriginalWorkflowId);
-            Assert.False(desc.RawDescription.Schedule.Policies.KeepOriginalWorkflowId);
         }
         finally
         {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add field to allow keeping the original workflow id on a schedule.

1. Part of https://github.com/temporalio/features/issues/727

2. How was this tested:
integration test

3. Any docs updates needed?
no
