### PR TITLE
Fix local activity backoff double-encoding headers when codec is used

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -2229,7 +2229,14 @@ namespace Temporalio.Worker
                         };
                         if (input.Headers is IDictionary<string, Payload> headers)
                         {
-                            cmd.Headers.Add(headers);
+                            // Clone each header payload to avoid in-place codec
+                            // encoding from mutating the originals, which would
+                            // cause double-encoding on local activity backoff
+                            // retries.
+                            foreach (var kvp in headers)
+                            {
+                                cmd.Headers.Add(kvp.Key, kvp.Value.Clone());
+                            }
                         }
                         if (input.Options.ScheduleToCloseTimeout is TimeSpan schedToClose)
                         {


### PR DESCRIPTION
## What was changed

Clone headers for local activities so codec mutating them doesn't cause problems with repeat use

## Checklist

1. Closes #610