### PR TITLE
💥 Standardize Nexus Operation Input Arg. Deserialization Failure

### DIFF
--- a/src/Temporalio/Worker/NexusPayloadSerializer.cs
+++ b/src/Temporalio/Worker/NexusPayloadSerializer.cs
@@ -61,13 +61,13 @@ namespace Temporalio.Worker
                 {
                     var decoded = await dataConverter.PayloadCodec.DecodeAsync(
                         new Payload[] { payload }).ConfigureAwait(false);
+                    if (decoded.Count != 1)
+                    {
+                        throw new ArgumentException($"Expected 1 payload, found {decoded.Count}");
+                    }
                     payload = decoded.First();
                 }
-                catch (ApplicationFailureException)
-                {
-                    throw;
-                }
-                catch (Exception e)
+                catch (Exception e) when (e is not ApplicationFailureException)
                 {
                     throw new HandlerException(
                         HandlerErrorType.Internal,
@@ -84,11 +84,7 @@ namespace Temporalio.Worker
             {
                 result = dataConverter.PayloadConverter.ToValue(payload, type);
             }
-            catch (ApplicationFailureException)
-            {
-                throw;
-            }
-            catch (Exception e)
+            catch (Exception e) when (e is not ApplicationFailureException)
             {
                 throw new HandlerException(
                     HandlerErrorType.BadRequest,

--- a/src/Temporalio/Worker/NexusPayloadSerializer.cs
+++ b/src/Temporalio/Worker/NexusPayloadSerializer.cs
@@ -6,6 +6,7 @@ using NexusRpc;
 using NexusRpc.Handlers;
 using Temporalio.Api.Common.V1;
 using Temporalio.Converters;
+using Temporalio.Exceptions;
 
 namespace Temporalio.Worker
 {
@@ -62,6 +63,10 @@ namespace Temporalio.Worker
                         new Payload[] { payload }).ConfigureAwait(false);
                     payload = decoded.First();
                 }
+                catch (ApplicationFailureException)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
                     throw new HandlerException(
@@ -78,6 +83,10 @@ namespace Temporalio.Worker
             try
             {
                 result = dataConverter.PayloadConverter.ToValue(payload, type);
+            }
+            catch (ApplicationFailureException)
+            {
+                throw;
             }
             catch (Exception e)
             {

--- a/src/Temporalio/Worker/NexusPayloadSerializer.cs
+++ b/src/Temporalio/Worker/NexusPayloadSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using NexusRpc;
@@ -49,7 +50,43 @@ namespace Temporalio.Worker
             }
 
             var payload = Payload.Parser.ParseFrom(content.Data);
-            var result = await dataConverter.ToValueAsync(payload, type).ConfigureAwait(false);
+
+            // Decode with payload codec if configured. Codec failures are treated as
+            // retryable INTERNAL errors since they are typically transient (e.g. a remote
+            // decryption service is temporarily down).
+            if (dataConverter.PayloadCodec != null)
+            {
+                try
+                {
+                    var decoded = await dataConverter.PayloadCodec.DecodeAsync(
+                        new Payload[] { payload }).ConfigureAwait(false);
+                    payload = decoded.First();
+                }
+                catch (Exception e)
+                {
+                    throw new HandlerException(
+                        HandlerErrorType.Internal,
+                        "Payload codec failed to decode Nexus operation input",
+                        e);
+                }
+            }
+
+            // Convert with payload converter. Converter failures are non-retryable
+            // BAD_REQUEST errors since the payload data doesn't match the expected type/format
+            // and retrying with the same input will never succeed.
+            object? result;
+            try
+            {
+                result = dataConverter.PayloadConverter.ToValue(payload, type);
+            }
+            catch (Exception e)
+            {
+                throw new HandlerException(
+                    HandlerErrorType.BadRequest,
+                    "Payload converter failed to decode Nexus operation input",
+                    e,
+                    HandlerErrorRetryBehavior.NonRetryable);
+            }
 
             // Ignore result if type is NoValue. We choose to still go through the data converter
             // machinations (it will be for null value) in case user has expectations of _all_

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1212,7 +1212,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             NexusHandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
         Assert.Contains(
             "Payload converter failed to decode Nexus operation input",
-            exc3.Failure.Message);
+            exc3.Failure.Cause.Message);
     }
 
     private async Task<string> CreateNexusEndpointAsync(string taskQueue)

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -2,6 +2,7 @@ namespace Temporalio.Tests.Worker;
 
 using NexusRpc;
 using NexusRpc.Handlers;
+using Temporalio.Api.Common.V1;
 using Temporalio.Api.Enums.V1;
 using Temporalio.Api.History.V1;
 using Temporalio.Client;
@@ -504,17 +505,18 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             AddNexusService(new HandlerFactoryStringService(() =>
                 OperationHandler.Sync<string, string>(async (ctx, name) => "never reached")));
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
-        await RunInWorkflowAsync(
-            workerOptions,
-            // Use int as arg
-            async () => await Workflow.CreateNexusClient("StringService", endpoint).
-                ExecuteNexusOperationAsync<string>("DoSomething", 1234),
-            // Wait for one Nexus op to be failing
-            checkResultFunc: async handle =>
-                await AssertMore.EventuallyAsync(async () => Assert.Equal(
-                    1,
-                    (await handle.DescribeAsync()).RawDescription.
-                        PendingNexusOperations.Count(op => op.LastAttemptFailure != null))));
+        // Converter failure is non-retryable BAD_REQUEST, so workflow should fail
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
+            RunInWorkflowAsync(
+                workerOptions,
+                // Use int as arg
+                async () => await Workflow.CreateNexusClient("StringService", endpoint).
+                    ExecuteNexusOperationAsync<string>("DoSomething", 1234)));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        Assert.Equal(HandlerErrorType.BadRequest, exc3.ErrorType);
+        Assert.Equal(
+            NexusHandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
     }
 
     [Fact]
@@ -1092,6 +1094,125 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         return (
             CallerHistory: callerHistory,
             TargetHandle: Client.GetWorkflowHandle(nexusStartEvent.Links.Single().WorkflowEvent.WorkflowId));
+    }
+
+    private class FailOnceCodec : IPayloadCodec
+    {
+        private int decodeCallCount;
+
+        public int DecodeCallCount => decodeCallCount;
+
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult(payloads);
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads)
+        {
+            if (Interlocked.Increment(ref decodeCallCount) == 1)
+            {
+                throw new InvalidOperationException("Simulated codec failure");
+            }
+            return Task.FromResult(payloads);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_CodecFailure_IsRetried()
+    {
+        var codec = new FailOnceCodec();
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with { PayloadCodec = codec };
+        var codecClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) => $"Hello, {name}")));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                var result = await Workflow.CreateNexusClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
+                Assert.Equal("Hello, some-name", result);
+                return null;
+            })));
+
+        using var worker = new TemporalWorker(codecClient, workerOptions);
+        await worker.ExecuteAsync(async () =>
+        {
+            var handle = await codecClient.StartWorkflowAsync(
+                (CustomFuncWorkflow wf) => wf.RunAsync(),
+                new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+            await handle.GetResultAsync();
+        });
+
+        // Decode is called once for the Nexus input (fails), once for the retry (succeeds),
+        // and once for the Nexus result on the workflow side.
+        Assert.True(
+            codec.DecodeCallCount >= 2,
+            $"Expected at least 2 decode calls (confirming retry), got {codec.DecodeCallCount}");
+    }
+
+    private class AlwaysFailPayloadConverter : IPayloadConverter
+    {
+        private readonly IPayloadConverter inner = DataConverter.Default.PayloadConverter;
+
+        public Payload ToPayload(object? value) => inner.ToPayload(value);
+
+        public object? ToValue(Payload payload, Type type) =>
+            throw new InvalidOperationException("Simulated converter failure");
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_ConverterFailure_IsNotRetried()
+    {
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadConverter = new AlwaysFailPayloadConverter(),
+        };
+        var converterClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) => $"Hello, {name}")));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                await Workflow.CreateNexusClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
+                return null;
+            })));
+
+        // Use converterClient for the worker (Nexus handler uses failing converter)
+        // but regular Client for starting the workflow (args serialize correctly)
+        using var worker = new TemporalWorker(converterClient, workerOptions);
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(
+            () => worker.ExecuteAsync(async () =>
+            {
+                var handle = await Client.StartWorkflowAsync(
+                    (CustomFuncWorkflow wf) => wf.RunAsync(),
+                    new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+                await handle.GetResultAsync();
+            }));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        Assert.Equal(HandlerErrorType.BadRequest, exc3.ErrorType);
+        Assert.Equal(
+            NexusHandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
+        Assert.Contains(
+            "Payload converter failed to decode Nexus operation input",
+            exc3.Failure.Message);
     }
 
     private async Task<string> CreateNexusEndpointAsync(string taskQueue)


### PR DESCRIPTION
Standardize Nexus Operation Input Arg. Deserialization Failure. Previously dotnet was treating all failures as retryable which is different then all other core based SDKs. After consolation with the SDK team, the agreed behaviour is in core based SDKs failures from the payload converter are non retry able (BAD_REQUEST), and failures in the codec are retry able (INTERNAL) and `ApplicationFailureException` should be respected.

see also: https://github.com/temporalio/features/issues/762

closes https://github.com/temporalio/sdk-dotnet/issues/614

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Nexus handler error classification and retry behavior, which can alter production failure/retry semantics for Nexus operations; scope is contained and backed by targeted tests.
> 
> **Overview**
> Nexus operation input deserialization now explicitly runs `PayloadCodec.DecodeAsync` (when configured) before `PayloadConverter.ToValue`, and maps failures to standardized `HandlerException`s: codec/decode errors become retryable `INTERNAL`, while converter/type/format errors become non-retryable `BAD_REQUEST`; `ApplicationFailureException` is allowed to propagate unchanged.
> 
> Tests were updated to assert workflows fail immediately for bad argument types (non-retryable), and new coverage was added to verify codec failures trigger retries while converter failures do not.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 296cc1e13804a1a472f5245a3598e49de100300b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->