### PR TITLE
 💥 [BREAKING CHANGE] Rename Nexus Operation classes used in a workflow in preparation for Stand alone Nexus operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,12 +588,12 @@ Some things to note about the above code:
 
 #### Invoking Nexus Operations
 
-* Nexus operations are started by first obtaining a Nexus client for a service via `Workflow.CreateNexusClient`, then
+* Nexus operations are started by first obtaining a Nexus client for a service via `Workflow.CreateNexusWorkflowClient`, then
   invoking `StartNexusOperationAsync` on it which accepts a lambda expression for the call on the service.
-* Non-type-safe forms of `Workflow.CreateNexusClient` and `StartNexusOperationAsync` exist that just accept string
+* Non-type-safe forms of `Workflow.CreateNexusWorkflowClient` and `StartNexusOperationAsync` exist that just accept string
   service and operation names.
 * Nexus client and operation options are simple classes optionally provided as the last parameter.
-* Result of a Nexus operation starting is a `NexusOperationHandle` which has the operation token and `GetResultAsync`
+* Result of a Nexus operation starting is a `NexusWorkflowOperationHandle` which has the operation token and `GetResultAsync`
   for getting the result.
 * The task for starting a Nexus operation does not complete until the operation has actually started.
 * A shortcut of `ExecuteNexusOperationAsync` is available which is `StartNexusOperationAsync` + `GetResultAsync` for
@@ -1208,7 +1208,7 @@ using Temporalio.Nexus;
 [NexusServiceHandler(typeof(IGreetingService))]
 public class GreetingService
 {
-    [NexusOperationHandler]
+    [NexusWorkflowOperationHandler]
     public IOperationHandler<string, string> SayHello() =>
         // Creates an operation handler backed by a workflow handle factory
         WorkflowRunOperationHandler.FromHandleFactory<string, string>((context, name) =>

--- a/README.md
+++ b/README.md
@@ -1208,7 +1208,7 @@ using Temporalio.Nexus;
 [NexusServiceHandler(typeof(IGreetingService))]
 public class GreetingService
 {
-    [NexusWorkflowOperationHandler]
+    [NexusOperationHandler]
     public IOperationHandler<string, string> SayHello() =>
         // Creates an operation handler backed by a workflow handle factory
         WorkflowRunOperationHandler.FromHandleFactory<string, string>((context, name) =>

--- a/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
+++ b/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
@@ -798,7 +798,7 @@ namespace Temporalio.Extensions.OpenTelemetry
                 try
                 {
                     using (var activity = NexusSource.StartActivity(
-                        $"RunStartNexusWorkflowOperationHandler:{input.Context.Service}/{input.Context.Operation}",
+                        $"RunStartNexusOperationHandler:{input.Context.Service}/{input.Context.Operation}",
                         kind: ActivityKind.Server,
                         parentContext: parentContext))
                     {
@@ -832,7 +832,7 @@ namespace Temporalio.Extensions.OpenTelemetry
                 try
                 {
                     using (var activity = NexusSource.StartActivity(
-                        $"RunCancelNexusWorkflowOperationHandler:{input.Context.Service}/{input.Context.Operation}",
+                        $"RunCancelNexusOperationHandler:{input.Context.Service}/{input.Context.Operation}",
                         kind: ActivityKind.Server,
                         parentContext: parentContext))
                     {

--- a/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
+++ b/src/Temporalio.Extensions.OpenTelemetry/TracingInterceptor.cs
@@ -700,7 +700,7 @@ namespace Temporalio.Extensions.OpenTelemetry
                 return base.StartChildWorkflowAsync<TWorkflow, TResult>(input);
             }
 
-            public override Task<NexusOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
+            public override Task<NexusWorkflowOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
                 StartNexusOperationInput input)
             {
                 var headers = StartWorkflowActivityOnHeaders(
@@ -798,7 +798,7 @@ namespace Temporalio.Extensions.OpenTelemetry
                 try
                 {
                     using (var activity = NexusSource.StartActivity(
-                        $"RunStartNexusOperationHandler:{input.Context.Service}/{input.Context.Operation}",
+                        $"RunStartNexusWorkflowOperationHandler:{input.Context.Service}/{input.Context.Operation}",
                         kind: ActivityKind.Server,
                         parentContext: parentContext))
                     {
@@ -832,7 +832,7 @@ namespace Temporalio.Extensions.OpenTelemetry
                 try
                 {
                     using (var activity = NexusSource.StartActivity(
-                        $"RunCancelNexusOperationHandler:{input.Context.Service}/{input.Context.Operation}",
+                        $"RunCancelNexusWorkflowOperationHandler:{input.Context.Service}/{input.Context.Operation}",
                         kind: ActivityKind.Server,
                         parentContext: parentContext))
                     {

--- a/src/Temporalio/Worker/Interceptors/StartNexusOperationInput.cs
+++ b/src/Temporalio/Worker/Interceptors/StartNexusOperationInput.cs
@@ -20,9 +20,9 @@ namespace Temporalio.Worker.Interceptors
     /// <remarks>WARNING: Nexus support is experimental.</remarks>
     public record StartNexusOperationInput(
         string Service,
-        NexusClientOptions ClientOptions,
+        NexusWorkflowClientOptions ClientOptions,
         string OperationName,
         object? Arg,
-        NexusOperationOptions Options,
+        NexusWorkflowOperationOptions Options,
         IDictionary<string, string>? Headers);
 }

--- a/src/Temporalio/Worker/Interceptors/WorkflowOutboundInterceptor.cs
+++ b/src/Temporalio/Worker/Interceptors/WorkflowOutboundInterceptor.cs
@@ -109,7 +109,7 @@ namespace Temporalio.Worker.Interceptors
         /// <param name="input">Input details of the call.</param>
         /// <returns>Operation handle.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public virtual Task<NexusOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
+        public virtual Task<NexusWorkflowOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
             StartNexusOperationInput input) => Next.StartNexusOperationAsync<TResult>(input);
     }
 }

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -406,12 +406,12 @@ namespace Temporalio.Worker
                 Headers: null));
 
         /// <inheritdoc/>
-        public NexusClient CreateNexusClient(string service, NexusClientOptions options) =>
-            new NexusClientImpl(this, service, options);
+        public NexusWorkflowClient CreateNexusWorkflowClient(string service, NexusWorkflowClientOptions options) =>
+            new NexusWorkflowClientImpl(this, service, options);
 
         /// <inheritdoc/>
-        public NexusClient<TService> CreateNexusClient<TService>(NexusClientOptions options) =>
-            new NexusClientImpl<TService>(this, options);
+        public NexusWorkflowClient<TService> CreateNexusWorkflowClient<TService>(NexusWorkflowClientOptions options) =>
+            new NexusWorkflowClientImpl<TService>(this, options);
 
         /// <inheritdoc/>
         public Task DelayWithOptionsAsync(DelayOptions options) =>
@@ -2540,7 +2540,7 @@ namespace Temporalio.Worker
             }
 
             /// <inheritdoc/>
-            public override Task<NexusOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
+            public override Task<NexusWorkflowOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
                 StartNexusOperationInput input)
             {
                 var token = input.Options.CancellationToken ?? instance.CancellationToken;
@@ -2551,7 +2551,7 @@ namespace Temporalio.Worker
                 // TemporalException.IsCanceledException helper).
                 if (token.IsCancellationRequested)
                 {
-                    return Task.FromException<NexusOperationHandle<TResult>>(
+                    return Task.FromException<NexusWorkflowOperationHandle<TResult>>(
                         new CanceledFailureException("Nexus operation cancelled before scheduled"));
                 }
 
@@ -2591,7 +2591,7 @@ namespace Temporalio.Worker
                 }
                 instance.AddCommand(workflowCommand);
 
-                var handleSource = new TaskCompletionSource<NexusOperationHandle<TResult>>();
+                var handleSource = new TaskCompletionSource<NexusWorkflowOperationHandle<TResult>>();
                 var pending = new PendingNexusOperationInfo(
                     StartCompletionSource: new(),
                     ResultCompletionSource: new());
@@ -2619,7 +2619,7 @@ namespace Temporalio.Worker
 
                             // If there is a start sync fail, we have to fail the handle task and
                             // there's nothing more we can do here
-                            var handle = new NexusOperationHandleImpl<TResult>(
+                            var handle = new NexusWorkflowOperationHandleImpl<TResult>(
                                 payloadConverter,
                                 // TODO(cretz): Support Nexus serialization context, ideally not
                                 // creating failure converter with context until actually needed
@@ -2925,11 +2925,11 @@ namespace Temporalio.Worker
                 instance.outbound.Value.CancelExternalWorkflowAsync(new(Id: Id, RunId: RunId));
         }
 
-        private class NexusClientImpl : NexusClient
+        private class NexusWorkflowClientImpl : NexusWorkflowClient
         {
             private readonly WorkflowInstance instance;
 
-            public NexusClientImpl(WorkflowInstance instance, string service, NexusClientOptions options)
+            public NexusWorkflowClientImpl(WorkflowInstance instance, string service, NexusWorkflowClientOptions options)
             {
                 this.instance = instance;
                 Service = service;
@@ -2938,10 +2938,10 @@ namespace Temporalio.Worker
 
             public override string Service { get; }
 
-            public override NexusClientOptions Options { get; }
+            public override NexusWorkflowClientOptions Options { get; }
 
-            public override Task<NexusOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
-                string operationName, object? arg, NexusOperationOptions? options = null) =>
+            public override Task<NexusWorkflowOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
+                string operationName, object? arg, NexusWorkflowOperationOptions? options = null) =>
                 instance.outbound.Value.StartNexusOperationAsync<TResult>(new(
                     Service: Service,
                     ClientOptions: Options,
@@ -2951,11 +2951,11 @@ namespace Temporalio.Worker
                     Headers: null));
         }
 
-        private class NexusClientImpl<TService> : NexusClient<TService>
+        private class NexusWorkflowClientImpl<TService> : NexusWorkflowClient<TService>
         {
             private readonly WorkflowInstance instance;
 
-            public NexusClientImpl(WorkflowInstance instance, NexusClientOptions options)
+            public NexusWorkflowClientImpl(WorkflowInstance instance, NexusWorkflowClientOptions options)
             {
                 this.instance = instance;
                 ServiceDefinition = ServiceDefinition.FromType<TService>();
@@ -2964,10 +2964,10 @@ namespace Temporalio.Worker
 
             public override ServiceDefinition ServiceDefinition { get; }
 
-            public override NexusClientOptions Options { get; }
+            public override NexusWorkflowClientOptions Options { get; }
 
-            public override Task<NexusOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
-                string operationName, object? arg, NexusOperationOptions? options = null) =>
+            public override Task<NexusWorkflowOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
+                string operationName, object? arg, NexusWorkflowOperationOptions? options = null) =>
                 instance.outbound.Value.StartNexusOperationAsync<TResult>(new(
                     Service: Service,
                     ClientOptions: Options,
@@ -2977,12 +2977,12 @@ namespace Temporalio.Worker
                     Headers: null));
         }
 
-        private class NexusOperationHandleImpl<TResult> : NexusOperationHandle<TResult>
+        private class NexusWorkflowOperationHandleImpl<TResult> : NexusWorkflowOperationHandle<TResult>
         {
             private readonly IPayloadConverter payloadConverter;
             private readonly IFailureConverter failureConverter;
 
-            public NexusOperationHandleImpl(
+            public NexusWorkflowOperationHandleImpl(
                 IPayloadConverter payloadConverter,
                 IFailureConverter failureConverter,
                 string? operationToken)

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -155,20 +155,20 @@ namespace Temporalio.Workflows
             string workflow, IReadOnlyCollection<object?> args, ContinueAsNewOptions? options);
 
         /// <summary>
-        /// Backing call for <see cref="Workflow.CreateNexusClient(string, NexusClientOptions)"/>.
+        /// Backing call for <see cref="Workflow.CreateNexusWorkflowClient(string, NexusWorkflowClientOptions)"/>.
         /// </summary>
         /// <param name="service">Service name.</param>
         /// <param name="options">Options.</param>
         /// <returns>Nexus client.</returns>
-        NexusClient CreateNexusClient(string service, NexusClientOptions options);
+        NexusWorkflowClient CreateNexusWorkflowClient(string service, NexusWorkflowClientOptions options);
 
         /// <summary>
-        /// Backing call for <see cref="Workflow.CreateNexusClient{TService}(NexusClientOptions)"/>.
+        /// Backing call for <see cref="Workflow.CreateNexusWorkflowClient{TService}(NexusWorkflowClientOptions)"/>.
         /// </summary>
         /// <typeparam name="TService">Service type.</typeparam>
         /// <param name="options">Options.</param>
         /// <returns>Nexus client.</returns>
-        NexusClient<TService> CreateNexusClient<TService>(NexusClientOptions options);
+        NexusWorkflowClient<TService> CreateNexusWorkflowClient<TService>(NexusWorkflowClientOptions options);
 
         /// <summary>
         /// Backing call for <see cref="Workflow.DelayWithOptionsAsync(DelayOptions)" /> and

--- a/src/Temporalio/Workflows/NexusWorkflowClient.cs
+++ b/src/Temporalio/Workflows/NexusWorkflowClient.cs
@@ -13,7 +13,7 @@ namespace Temporalio.Workflows
     /// Client for making Nexus service calls from a workflow.
     /// </summary>
     /// <remarks>WARNING: Nexus support is experimental.</remarks>
-    public abstract class NexusClient
+    public abstract class NexusWorkflowClient
     {
         /// <summary>
         /// Gets the service name.
@@ -23,20 +23,20 @@ namespace Temporalio.Workflows
         /// <summary>
         /// Gets the client options. Should not be mutated.
         /// </summary>
-        public abstract NexusClientOptions Options { get; }
+        public abstract NexusWorkflowClientOptions Options { get; }
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="StartNexusOperationAsync(string, object?, NexusOperationOptions?)"/>
+        /// <see cref="StartNexusOperationAsync(string, object?, NexusWorkflowOperationOptions?)"/>
         /// +
-        /// <see cref="NexusOperationHandle.GetResultAsync"/>.
+        /// <see cref="NexusWorkflowOperationHandle.GetResultAsync"/>.
         /// </summary>
         /// <param name="operationName">Operation name to start.</param>
         /// <param name="arg">Operation argument.</param>
         /// <param name="options">Operation options.</param>
         /// <returns>Task representing completion of the Nexus operation.</returns>
         public async Task ExecuteNexusOperationAsync(
-            string operationName, object? arg, NexusOperationOptions? options = null)
+            string operationName, object? arg, NexusWorkflowOperationOptions? options = null)
         {
             var handle = await StartNexusOperationAsync(operationName, arg, options).ConfigureAwait(true);
             await handle.GetResultAsync().ConfigureAwait(true);
@@ -44,9 +44,9 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="StartNexusOperationAsync{TResult}(string, object?, NexusOperationOptions?)"/>
+        /// <see cref="StartNexusOperationAsync{TResult}(string, object?, NexusWorkflowOperationOptions?)"/>
         /// +
-        /// <see cref="NexusOperationHandle{TResult}.GetResultAsync"/>.
+        /// <see cref="NexusWorkflowOperationHandle{TResult}.GetResultAsync"/>.
         /// </summary>
         /// <typeparam name="TResult">Operation result type.</typeparam>
         /// <param name="operationName">Operation name to start.</param>
@@ -54,7 +54,7 @@ namespace Temporalio.Workflows
         /// <param name="options">Operation options.</param>
         /// <returns>Task with the result of the Nexus operation.</returns>
         public async Task<TResult> ExecuteNexusOperationAsync<TResult>(
-            string operationName, object? arg, NexusOperationOptions? options = null)
+            string operationName, object? arg, NexusWorkflowOperationOptions? options = null)
         {
             var handle = await StartNexusOperationAsync<TResult>(operationName, arg, options).ConfigureAwait(true);
             return await handle.GetResultAsync().ConfigureAwait(true);
@@ -67,8 +67,8 @@ namespace Temporalio.Workflows
         /// <param name="arg">Operation argument.</param>
         /// <param name="options">Operation options.</param>
         /// <returns>Handle to the started operation once started.</returns>
-        public async Task<NexusOperationHandle> StartNexusOperationAsync(
-            string operationName, object? arg, NexusOperationOptions? options = null) =>
+        public async Task<NexusWorkflowOperationHandle> StartNexusOperationAsync(
+            string operationName, object? arg, NexusWorkflowOperationOptions? options = null) =>
             await StartNexusOperationAsync<ValueTuple>(operationName, arg, options).ConfigureAwait(true);
 
         /// <summary>
@@ -79,12 +79,12 @@ namespace Temporalio.Workflows
         /// <param name="arg">Operation argument.</param>
         /// <param name="options">Operation options.</param>
         /// <returns>Handle to the started operation once started.</returns>
-        public abstract Task<NexusOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
-            string operationName, object? arg, NexusOperationOptions? options = null);
+        public abstract Task<NexusWorkflowOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
+            string operationName, object? arg, NexusWorkflowOperationOptions? options = null);
     }
 
     /// <inheritdoc />
-    public abstract class NexusClient<TService> : NexusClient
+    public abstract class NexusWorkflowClient<TService> : NexusWorkflowClient
     {
         /// <summary>
         /// Gets the service name.
@@ -98,16 +98,16 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="StartNexusOperationAsync(Expression{Action{TService}}, NexusOperationOptions?)"/>
+        /// <see cref="StartNexusOperationAsync(Expression{Action{TService}}, NexusWorkflowOperationOptions?)"/>
         /// +
-        /// <see cref="NexusOperationHandle.GetResultAsync"/>.
+        /// <see cref="NexusWorkflowOperationHandle.GetResultAsync"/>.
         /// </summary>
         /// <param name="operationStartCall">Invocation of operation without a result.</param>
         /// <param name="options">Operation options.</param>
         /// <returns>Task with the result of the Nexus operation.</returns>
         public async Task ExecuteNexusOperationAsync(
             Expression<Action<TService>> operationStartCall,
-            NexusOperationOptions? options = null)
+            NexusWorkflowOperationOptions? options = null)
         {
             var handle = await StartNexusOperationAsync(operationStartCall, options).ConfigureAwait(true);
             await handle.GetResultAsync().ConfigureAwait(true);
@@ -115,9 +115,9 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Shortcut for
-        /// <see cref="StartNexusOperationAsync{TResult}(Expression{Func{TService, TResult}}, NexusOperationOptions?)"/>
+        /// <see cref="StartNexusOperationAsync{TResult}(Expression{Func{TService, TResult}}, NexusWorkflowOperationOptions?)"/>
         /// +
-        /// <see cref="NexusOperationHandle{TResult}.GetResultAsync"/>.
+        /// <see cref="NexusWorkflowOperationHandle{TResult}.GetResultAsync"/>.
         /// </summary>
         /// <typeparam name="TResult">Operation result type.</typeparam>
         /// <param name="operationStartCall">Invocation of operation with a result.</param>
@@ -125,7 +125,7 @@ namespace Temporalio.Workflows
         /// <returns>Task with the result of the Nexus operation.</returns>
         public async Task<TResult> ExecuteNexusOperationAsync<TResult>(
             Expression<Func<TService, TResult>> operationStartCall,
-            NexusOperationOptions? options = null)
+            NexusWorkflowOperationOptions? options = null)
         {
             var handle = await StartNexusOperationAsync(operationStartCall, options).ConfigureAwait(true);
             return await handle.GetResultAsync().ConfigureAwait(true);
@@ -137,9 +137,9 @@ namespace Temporalio.Workflows
         /// <param name="operationStartCall">Invocation of operation without a result.</param>
         /// <param name="options">Operation options.</param>
         /// <returns>Handle to the started operation once started.</returns>
-        public Task<NexusOperationHandle> StartNexusOperationAsync(
+        public Task<NexusWorkflowOperationHandle> StartNexusOperationAsync(
             Expression<Action<TService>> operationStartCall,
-            NexusOperationOptions? options = null)
+            NexusWorkflowOperationOptions? options = null)
         {
             var (method, args) = ExpressionUtil.ExtractCall(operationStartCall);
             // Find name from method
@@ -163,9 +163,9 @@ namespace Temporalio.Workflows
         /// <param name="operationStartCall">Invocation of operation with a result.</param>
         /// <param name="options">Operation options.</param>
         /// <returns>Handle to the started operation once started.</returns>
-        public Task<NexusOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
+        public Task<NexusWorkflowOperationHandle<TResult>> StartNexusOperationAsync<TResult>(
             Expression<Func<TService, TResult>> operationStartCall,
-            NexusOperationOptions? options = null)
+            NexusWorkflowOperationOptions? options = null)
         {
             var (method, args) = ExpressionUtil.ExtractCall(operationStartCall);
             // Find name from method

--- a/src/Temporalio/Workflows/NexusWorkflowClientOptions.cs
+++ b/src/Temporalio/Workflows/NexusWorkflowClientOptions.cs
@@ -6,20 +6,20 @@ namespace Temporalio.Workflows
     /// Options for creating a Nexus client.
     /// </summary>
     /// <remarks>WARNING: Nexus support is experimental.</remarks>
-    public class NexusClientOptions : ICloneable
+    public class NexusWorkflowClientOptions : ICloneable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="NexusClientOptions"/> class.
+        /// Initializes a new instance of the <see cref="NexusWorkflowClientOptions"/> class.
         /// </summary>
-        public NexusClientOptions()
+        public NexusWorkflowClientOptions()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NexusClientOptions"/> class.
+        /// Initializes a new instance of the <see cref="NexusWorkflowClientOptions"/> class.
         /// </summary>
         /// <param name="endpoint">Endpoint.</param>
-        public NexusClientOptions(string endpoint) => Endpoint = endpoint;
+        public NexusWorkflowClientOptions(string endpoint) => Endpoint = endpoint;
 
         /// <summary>
         /// Gets or sets the endpoint.

--- a/src/Temporalio/Workflows/NexusWorkflowOperationHandle.cs
+++ b/src/Temporalio/Workflows/NexusWorkflowOperationHandle.cs
@@ -9,7 +9,7 @@ namespace Temporalio.Workflows
     /// Handle representing a started Nexus operation.
     /// </summary>
     /// <remarks>WARNING: Nexus support is experimental.</remarks>
-    public abstract class NexusOperationHandle
+    public abstract class NexusWorkflowOperationHandle
     {
         /// <summary>
         /// Gets the operation token.
@@ -35,7 +35,7 @@ namespace Temporalio.Workflows
     }
 
     /// <inheritdoc />
-    public abstract class NexusOperationHandle<TResult> : NexusOperationHandle
+    public abstract class NexusWorkflowOperationHandle<TResult> : NexusWorkflowOperationHandle
     {
         /// <summary>
         /// Wait for result of the operation.

--- a/src/Temporalio/Workflows/NexusWorkflowOperationOptions.cs
+++ b/src/Temporalio/Workflows/NexusWorkflowOperationOptions.cs
@@ -7,7 +7,7 @@ namespace Temporalio.Workflows
     /// Options for starting a Nexus operation.
     /// </summary>
     /// <remarks>WARNING: Nexus support is experimental.</remarks>
-    public class NexusOperationOptions : ICloneable
+    public class NexusWorkflowOperationOptions : ICloneable
     {
         /// <summary>
         /// Gets or sets the schedule to close timeout.

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -317,14 +317,14 @@ namespace Temporalio.Workflows
 
         /// <summary>
         /// Create an untyped Nexus client with a string service name and endpoint. This is a
-        /// shortcut for <see cref="CreateNexusClient(string, NexusClientOptions)"/>.
+        /// shortcut for <see cref="CreateNexusWorkflowClient(string, NexusWorkflowClientOptions)"/>.
         /// </summary>
         /// <param name="service">Service name.</param>
         /// <param name="endpoint">Endpoint.</param>
         /// <returns>Nexus client.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static NexusClient CreateNexusClient(string service, string endpoint) =>
-            CreateNexusClient(service, new NexusClientOptions(endpoint));
+        public static NexusWorkflowClient CreateNexusWorkflowClient(string service, string endpoint) =>
+            CreateNexusWorkflowClient(service, new NexusWorkflowClientOptions(endpoint));
 
         /// <summary>
         /// Create an untyped Nexus client with a string service name and client options.
@@ -333,20 +333,20 @@ namespace Temporalio.Workflows
         /// <param name="options">Client options.</param>
         /// <returns>Nexus client.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static NexusClient CreateNexusClient(string service, NexusClientOptions options) =>
-            Context.CreateNexusClient(service, options);
+        public static NexusWorkflowClient CreateNexusWorkflowClient(string service, NexusWorkflowClientOptions options) =>
+            Context.CreateNexusWorkflowClient(service, options);
 
         /// <summary>
         /// Create a typed Nexus client from a service interface and endpoint. This is a shortcut
-        /// for <see cref="CreateNexusClient{TService}(NexusClientOptions)"/>.
+        /// for <see cref="CreateNexusWorkflowClient{TService}(NexusWorkflowClientOptions)"/>.
         /// </summary>
         /// <typeparam name="TService">Service interface type with the
         /// <see cref="NexusRpc.NexusServiceAttribute"/> attribute.</typeparam>
         /// <param name="endpoint">Endpoint.</param>
         /// <returns>Nexus client.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static NexusClient<TService> CreateNexusClient<TService>(string endpoint) =>
-            CreateNexusClient<TService>(new NexusClientOptions(endpoint));
+        public static NexusWorkflowClient<TService> CreateNexusWorkflowClient<TService>(string endpoint) =>
+            CreateNexusWorkflowClient<TService>(new NexusWorkflowClientOptions(endpoint));
 
         /// <summary>
         /// Create a typed Nexus client from a service interface and endpoint.
@@ -356,8 +356,8 @@ namespace Temporalio.Workflows
         /// <param name="options">Client options.</param>
         /// <returns>Nexus client.</returns>
         /// <remarks>WARNING: Nexus support is experimental.</remarks>
-        public static NexusClient<TService> CreateNexusClient<TService>(NexusClientOptions options) =>
-            Context.CreateNexusClient<TService>(options);
+        public static NexusWorkflowClient<TService> CreateNexusWorkflowClient<TService>(NexusWorkflowClientOptions options) =>
+            Context.CreateNexusWorkflowClient<TService>(options);
 
         /// <summary>
         /// Sleep in a workflow for the given time. See documentation of

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -234,14 +234,14 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     private async Task<int> ExecuteHostedNexusWithWorkflow(
         Action<IServiceCollection> configureServices,
         Action<ITemporalWorkerServiceOptionsBuilder> configureBuilder,
-        Func<NexusClient<ITestNexusService>, Task<int>> workflowFunc)
+        Func<NexusWorkflowClient<ITestNexusService>, Task<int>> workflowFunc)
     {
         var taskQueue = $"tq-{Guid.NewGuid()}";
         var endpointName = $"nexus-endpoint-{taskQueue}";
 
         Func<Task<int>> outerWorkflowFunc = async () =>
         {
-            var client = Workflow.CreateNexusClient<ITestNexusService>(endpointName);
+            var client = Workflow.CreateNexusWorkflowClient<ITestNexusService>(endpointName);
 
             return await workflowFunc(client);
         };

--- a/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
+++ b/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
@@ -1060,7 +1060,7 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
                 }
                 if (action.CallNexusEndpoint is { } nexusEndpoint)
                 {
-                    await Workflow.CreateNexusClient<INexusTracingService>(nexusEndpoint).
+                    await Workflow.CreateNexusWorkflowClient<INexusTracingService>(nexusEndpoint).
                         ExecuteNexusOperationAsync(svc => svc.DoSomething());
                 }
             }

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -94,7 +94,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         {
             await RunInWorkflowAsync(workerOptions, async () =>
             {
-                var result = await Workflow.CreateNexusClient<IStringService>(endpointName).
+                var result = await Workflow.CreateNexusWorkflowClient<IStringService>(endpointName).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
                 Assert.Equal("Hello, some-name", result);
             });
@@ -136,7 +136,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         // Run the Nexus client code in workflow
         var handle = await RunInWorkflowAsync(workerOptions, async () =>
         {
-            var result = await Workflow.CreateNexusClient<IStringService>(endpoint).
+            var result = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                 ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
             Assert.Equal("Hello from workflow, some-name", result);
         });
@@ -192,7 +192,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             workerOptions,
             async () =>
             {
-                var result = await Workflow.CreateNexusClient<IStringService>(endpoint).
+                var result = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
                 Assert.Equal("Hello from workflow, some-name", result);
             },
@@ -214,7 +214,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             {
                 // Start with cancel token
                 using var cancelSource = new CancellationTokenSource();
-                var handle = await Workflow.CreateNexusClient<IStringService>(endpoint).
+                var handle = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     StartNexusOperationAsync(
                         svc => svc.DoSomething("some-name"),
                         new() { CancellationToken = cancelSource.Token });
@@ -292,7 +292,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, async () =>
             {
-                await Workflow.CreateNexusClient<IStringService>(endpoint).
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(
                         svc => svc.DoSomething("some-name"),
                         new() { ScheduleToCloseTimeout = TimeSpan.FromSeconds(2) });
@@ -318,7 +318,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
 
         var handle = await RunInWorkflowAsync(workerOptions, async () =>
             {
-                await Workflow.CreateNexusClient<IStringService>(endpoint).
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(
                         svc => svc.DoSomething("some-name"),
                         new() { Summary = expectedSummary });
@@ -363,7 +363,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, async () =>
             {
-                await Workflow.CreateNexusClient<IStringService>(endpoint).
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(
                         svc => svc.DoSomething("some-name"),
                         new() { ScheduleToStartTimeout = TimeSpan.FromSeconds(2) });
@@ -394,7 +394,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, async () =>
             {
-                await Workflow.CreateNexusClient<IStringService>(endpoint).
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(
                         svc => svc.DoSomething("some-name"),
                         new()
@@ -446,7 +446,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             {
                 // Start one Nexus operation which will succeed and another which will fail because
                 // the second tries to start with the same ID
-                var client = Workflow.CreateNexusClient<IStringService>(endpoint);
+                var client = Workflow.CreateNexusWorkflowClient<IStringService>(endpoint);
                 await client.StartNexusOperationAsync(svc => svc.DoSomething("some-name1"));
                 await client.StartNexusOperationAsync(svc => svc.DoSomething("some-name2"));
             }));
@@ -481,7 +481,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             {
                 // Start both Nexus operations which will both succeed and be backed by the same
                 // operation
-                var client = Workflow.CreateNexusClient<IStringService>(endpoint);
+                var client = Workflow.CreateNexusWorkflowClient<IStringService>(endpoint);
                 var handle1 = await client.StartNexusOperationAsync(svc => svc.DoSomething("some-name1"));
                 var handle2 = await client.StartNexusOperationAsync(svc => svc.DoSomething("some-name2"));
 
@@ -507,7 +507,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         await RunInWorkflowAsync(
             workerOptions,
             // Use int as arg
-            async () => await Workflow.CreateNexusClient("StringService", endpoint).
+            async () => await Workflow.CreateNexusWorkflowClient("StringService", endpoint).
                 ExecuteNexusOperationAsync<string>("DoSomething", 1234),
             // Wait for one Nexus op to be failing
             checkResultFunc: async handle =>
@@ -526,7 +526,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
         await RunInWorkflowAsync(
             workerOptions,
-            async () => await Workflow.CreateNexusClient("StringService", endpoint).
+            async () => await Workflow.CreateNexusWorkflowClient("StringService", endpoint).
                 ExecuteNexusOperationAsync<string>("DoSomething", "some-name"),
             checkResultFunc: async handle =>
                 Assert.Equal("Hello, some-name", await handle.GetResultAsync()));
@@ -546,7 +546,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
         await RunInWorkflowAsync(workerOptions, async () =>
         {
-            var result = await Workflow.CreateNexusClient<IStringService>(endpoint).
+            var result = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                 ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
             Assert.Equal("Hello from workflow, some-name-suffixed", result);
         });
@@ -569,7 +569,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         // ---------------- Temporalio.Exceptions.ApplicationFailureException : Intentional failure
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
-                Workflow.CreateNexusClient<IStringService>(endpoint).
+                Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"))));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
         var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
@@ -594,7 +594,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         // -------- Temporalio.Exceptions.ApplicationFailureException : Intentional failure
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
-                Workflow.CreateNexusClient<IStringService>(endpoint).
+                Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"))));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
         var exc3 = Assert.IsType<ApplicationFailureException>(exc2.InnerException);
@@ -618,7 +618,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         // ------------ Temporalio.Exceptions.ApplicationFailureException : Intentional failure
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
-                Workflow.CreateNexusClient<IStringService>(endpoint).
+                Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"))));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
         var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
@@ -653,7 +653,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
         await RunInWorkflowAsync(workerOptions, async () =>
         {
-            var result = await Workflow.CreateNexusClient("my-service", endpoint).
+            var result = await Workflow.CreateNexusWorkflowClient("my-service", endpoint).
                 ExecuteNexusOperationAsync<string>("my-operation", "some-param");
             Assert.Equal("manual-handler, param: some-param", result);
         });
@@ -707,7 +707,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(
                 workerOptions,
-                () => Workflow.CreateNexusClient<IStringService>(endpoint).
+                () => Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name")),
                 beforeGetResultFunc: async handle =>
                 {
@@ -738,7 +738,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         // ------------ Temporalio.Exceptions.ApplicationFailureException : Unrecognized service missing-service or operation unknown-operation
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
-                Workflow.CreateNexusClient("missing-service", endpoint).
+                Workflow.CreateNexusWorkflowClient("missing-service", endpoint).
                     ExecuteNexusOperationAsync("unknown-operation", "some-param")));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
         var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
@@ -760,7 +760,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         // ------------ Temporalio.Exceptions.ApplicationFailureException : Unrecognized service StringService or operation unknown-operation
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
-                Workflow.CreateNexusClient("StringService", endpoint).
+                Workflow.CreateNexusWorkflowClient("StringService", endpoint).
                     ExecuteNexusOperationAsync("unknown-operation", "some-param")));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
         var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
@@ -844,7 +844,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
 
         var handle = await RunInWorkflowAsync(workerOptions, async () =>
         {
-            var client = Workflow.CreateNexusClient<IVoidService>(endpoint);
+            var client = Workflow.CreateNexusWorkflowClient<IVoidService>(endpoint);
             await client.ExecuteNexusOperationAsync(svc => svc.NoReturn("some-param"));
             var result = await client.ExecuteNexusOperationAsync(svc => svc.NoParam());
             Assert.Equal("done", result);
@@ -1047,7 +1047,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             workerOptions,
             inWorkflowFunc: async () =>
             {
-                var client = Workflow.CreateNexusClient<ICancelTypeService>(endpoint);
+                var client = Workflow.CreateNexusWorkflowClient<ICancelTypeService>(endpoint);
                 try
                 {
                     await client.ExecuteNexusOperationAsync(

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -510,7 +510,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             RunInWorkflowAsync(
                 workerOptions,
                 // Use int as arg
-                async () => await Workflow.CreateNexusClient("StringService", endpoint).
+                async () => await Workflow.CreateNexusWorkflowClient("StringService", endpoint).
                     ExecuteNexusOperationAsync<string>("DoSomething", 1234)));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
         var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
@@ -1135,7 +1135,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             null,
             _args => new CustomFuncWorkflow(async () =>
             {
-                var result = await Workflow.CreateNexusClient<IStringService>(endpoint).
+                var result = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
                 Assert.Equal("Hello, some-name", result);
                 return null;
@@ -1189,7 +1189,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             null,
             _args => new CustomFuncWorkflow(async () =>
             {
-                await Workflow.CreateNexusClient<IStringService>(endpoint).
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
                 return null;
             })));

--- a/tests/Temporalio.Tests/Worker/WorkerTuningTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkerTuningTests.cs
@@ -277,7 +277,7 @@ public class WorkerTuningTests : WorkflowEnvironmentTestBase
         [WorkflowRun]
         public async Task<string> RunAsync(NexusCallingWorkflowInput input)
         {
-            return await Workflow.CreateNexusClient<ISimpleService>(input.EndpointName).
+            return await Workflow.CreateNexusWorkflowClient<ISimpleService>(input.EndpointName).
                 ExecuteNexusOperationAsync(svc => svc.Simple(input.Name));
         }
     }

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -7272,7 +7272,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         {
             // Call Nexus and confirm no events are on the value because Nexus doesn't go through
             // context converters at this time
-            var res = await Workflow.CreateNexusClient<INexusService>(endpoint).
+            var res = await Workflow.CreateNexusWorkflowClient<INexusService>(endpoint).
                 ExecuteNexusOperationAsync(svc => svc.DoSomething(new("nexus-input", new())));
             Assert.Equal("nexus-result", res.Name);
             Assert.Empty(res.Events);


### PR DESCRIPTION
 Rename Nexus Operation classes used in a workflow. I went with inserting `Workflow` into the name, but am open to other suggestions.

closes https://github.com/temporalio/sdk-dotnet/issues/618

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API rename across workflow Nexus client/handle/options and related interceptor signatures; functional behavior appears unchanged but downstream projects will require code updates and any missed rename could surface as runtime/compile failures.
> 
> **Overview**
> Renames the workflow-scoped Nexus API surface to explicitly include `Workflow` in the type names, updating `Workflow.CreateNexusClient` to `Workflow.CreateNexusWorkflowClient` and renaming `NexusClient*`, `NexusOperationHandle*`, and related options to `NexusWorkflowClient*`, `NexusWorkflowOperationHandle*`, and `NexusWorkflow*Options`.
> 
> Updates all internal plumbing and interception points (workflow outbound interceptors, OpenTelemetry `TracingInterceptor`, and `WorkflowInstance` implementations) plus tests and README references to use the new names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e01b7bdfe447738eda646a6c3428f4d72e752d2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->