### PR TITLE
Nexus - Align Metric Meter

### DIFF
--- a/src/Temporalio/Nexus/NexusOperationExecutionContext.cs
+++ b/src/Temporalio/Nexus/NexusOperationExecutionContext.cs
@@ -40,6 +40,7 @@ namespace Temporalio.Nexus
             {
                 return runtimeMetricMeter.Value.WithTags(new Dictionary<string, object>()
                 {
+                    { "namespace", info.Namespace },
                     { "nexus_service", handlerContext.Service },
                     { "nexus_operation", handlerContext.Operation },
                     { "task_queue", info.TaskQueue },

--- a/src/Temporalio/Nexus/NexusOperationExecutionContext.cs
+++ b/src/Temporalio/Nexus/NexusOperationExecutionContext.cs
@@ -40,10 +40,9 @@ namespace Temporalio.Nexus
             {
                 return runtimeMetricMeter.Value.WithTags(new Dictionary<string, object>()
                 {
-                    { "namespace", info.Namespace },
+                    { "nexus_service", handlerContext.Service },
+                    { "nexus_operation", handlerContext.Operation },
                     { "task_queue", info.TaskQueue },
-                    { "service", handlerContext.Service },
-                    { "operation", handlerContext.Operation },
                 });
             });
             this.temporalClient = temporalClient;


### PR DESCRIPTION
Align the metric meter tags with Python SDK https://github.com/temporalio/sdk-python/blob/8f003b4f842462a643be23743d5c4a3c4d8249a2/temporalio/nexus/_operation_context.py#L199

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes metric tag keys for Nexus operation meters, which may affect dashboards/alerts that rely on the previous tag names.
> 
> **Overview**
> Aligns Nexus operation `MetricMeter` tag keys to the `nexus_service` / `nexus_operation` naming convention (replacing the prior `service` / `operation` tags) while keeping `namespace` and `task_queue` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 540723bbd785584dc52f08aff691c7d620c96306. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->