### PR TITLE
Nexus Error Serialization Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ obj/
 /.vscode
 /.idea
 /.zed
+/.omc
 Temporalio.sln.DotSettings.user

--- a/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
+++ b/src/Temporalio.Extensions.Hosting/ServiceProviderExtensions.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using NexusRpc;
 using NexusRpc.Handlers;
 using Temporalio.Activities;
 
@@ -192,12 +191,6 @@ namespace Temporalio.Extensions.Hosting
                     default,
                     TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion,
                     TaskScheduler.Current)).ConfigureAwait(false);
-
-            public async Task<OperationInfo> FetchInfoAsync(OperationFetchInfoContext context) =>
-                await InvokeWithScopeAsync(handler => handler.FetchInfoAsync(context)).ConfigureAwait(false);
-
-            public async Task<object?> FetchResultAsync(OperationFetchResultContext context) =>
-                await InvokeWithScopeAsync(handler => handler.FetchResultAsync(context)).ConfigureAwait(false);
 
             private async Task<T> InvokeWithScopeAsync<T>(Func<IOperationHandler<object?, object?>, Task<T>> handlerInvoker)
             {

--- a/src/Temporalio/Converters/DefaultFailureConverter.cs
+++ b/src/Temporalio/Converters/DefaultFailureConverter.cs
@@ -1,7 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using NexusRpc.Handlers;
+using Temporalio.Api.Common.V1;
+using Temporalio.Api.Enums.V1;
 using Temporalio.Api.Failure.V1;
 using Temporalio.Exceptions;
 
@@ -43,24 +48,40 @@ namespace Temporalio.Converters
         /// <inheritdoc />
         public virtual Failure ToFailure(Exception exception, IPayloadConverter payloadConverter)
         {
-            // If the exception is not already a failure exception, make it an application exception
-            var failureEx =
-                exception as FailureException
-                ?? new ApplicationFailureException(
-                    exception.Message,
-                    exception.InnerException,
-                    exception.GetType().Name);
+            Failure failure;
 
-            // Create new failure object. This means if it's already set we copy it. This is costly,
-            // but we prefer it over potentially mutating the failure on the existing exception. We
-            // pass in the stack trace from the original exception always just in case it was
-            // converted to an application failure which won't have the original stack trace.
-            var failure = CreateFailureFromException(
-                failureEx,
-                exception.StackTrace,
-                payloadConverter);
+            // Handle Nexus HandlerException before FailureException check, since
+            // HandlerException extends Exception not FailureException
+            if (exception is HandlerException handlerException)
+            {
+                failure = CreateFailureFromHandlerException(
+                    handlerException, payloadConverter);
+            }
+            else
+            {
+                // If the exception is not already a failure exception, make it an application
+                // exception
+                var failureEx =
+                    exception as FailureException
+                    ?? new ApplicationFailureException(
+                        exception.Message,
+                        exception.InnerException,
+                        exception.GetType().Name);
 
-            // If requested, move message and stack trace to encoded attributes
+                // Create new failure object. This means if it's already set we copy it. This is
+                // costly, but we prefer it over potentially mutating the failure on the existing
+                // exception. We pass in the stack trace from the original exception always just
+                // in case it was converted to an application failure which won't have the original
+                // stack trace.
+                failure = CreateFailureFromException(
+                    failureEx,
+                    exception.StackTrace,
+                    payloadConverter);
+            }
+
+            // If requested, move message and stack trace to encoded attributes.
+            // Skip for round-trip failures since the message/stack_trace are already
+            // part of the restored proto from the serialized details.
             if (Options.EncodeCommonAttributes)
             {
                 failure.EncodedAttributes = payloadConverter.ToPayload(
@@ -122,10 +143,119 @@ namespace Temporalio.Converters
                 case Failure.FailureInfoOneofCase.NexusOperationExecutionFailureInfo:
                     return new NexusOperationFailureException(failure, inner);
                 case Failure.FailureInfoOneofCase.NexusHandlerFailureInfo:
-                    return new NexusHandlerFailureException(failure, inner);
+                    var handlerInfo = failure.NexusHandlerFailureInfo;
+                    HandlerErrorRetryBehavior retryBehavior = handlerInfo.RetryBehavior switch
+                    {
+                        NexusHandlerErrorRetryBehavior.Retryable => HandlerErrorRetryBehavior.Retryable,
+                        NexusHandlerErrorRetryBehavior.NonRetryable => HandlerErrorRetryBehavior.NonRetryable,
+                        _ => HandlerErrorRetryBehavior.Unspecified,
+                    };
+                    return new HandlerException(
+                        handlerInfo.Type,
+                        failure.Message,
+                        inner,
+                        retryBehavior,
+                        string.IsNullOrEmpty(failure.StackTrace) ? null : failure.StackTrace,
+                        TemporalFailureToNexusFailure(failure));
                 default:
                     return new FailureException(failure, inner);
             }
+        }
+
+        /// <summary>
+        /// Convert a NexusRpc.Failure back to a Temporal Failure proto. This handles
+        /// round-tripping failures that were originally Temporal Failure protos serialized
+        /// as NexusRpc Failures.
+        /// </summary>
+        /// <param name="nexusFailure">The NexusRpc failure to convert.</param>
+        /// <param name="nonRetryable">Whether the failure is non-retryable (used for
+        /// non-Temporal fallback path).</param>
+        /// <returns>The reconstructed Temporal Failure proto.</returns>
+        internal static Failure NexusFailureToTemporalFailure(
+            NexusRpc.Failure nexusFailure, bool nonRetryable = true)
+        {
+            Failure failure;
+
+            // Check if this was originally a Temporal Failure proto
+            if (nexusFailure.Metadata != null &&
+                nexusFailure.Metadata.TryGetValue("type", out var metadataType) &&
+                metadataType == Failure.Descriptor.FullName)
+            {
+                // Round-trip: details contain the serialized proto fields as JSON-compatible dict
+                if (nexusFailure.Details != null)
+                {
+                    var json = JsonSerializer.Serialize(nexusFailure.Details);
+                    failure = JsonParser.Default.Parse<Failure>(json);
+                }
+                else
+                {
+                    failure = new Failure();
+                }
+            }
+            else
+            {
+                // Non-Temporal Nexus failure: wrap as ApplicationFailureInfo with type
+                // "NexusFailure" and serialize the remaining failure fields as a JSON payload
+                // in the details, matching Python's _nexus_failure_to_temporal_failure.
+                var detailsPayload = new Payload()
+                {
+                    Metadata = { ["encoding"] = ByteString.CopyFromUtf8("json/plain") },
+                };
+                // Serialize the NexusRpc Failure (with message cleared) as JSON
+                var failureForDetails = new NexusRpc.Failure(
+                    string.Empty,
+                    nexusFailure.Metadata,
+                    nexusFailure.Details,
+                    nexusFailure.StackTrace,
+                    nexusFailure.Cause);
+                detailsPayload.Data = ByteString.CopyFromUtf8(
+                    JsonSerializer.Serialize(failureForDetails));
+                failure = new Failure()
+                {
+                    ApplicationFailureInfo = new()
+                    {
+                        Type = "NexusFailure",
+                        NonRetryable = nonRetryable,
+                        Details = new() { Payloads_ = { detailsPayload } },
+                    },
+                };
+            }
+
+            // Restore message and stack trace from the NexusRpc Failure
+            failure.Message = nexusFailure.Message;
+            failure.StackTrace = nexusFailure.StackTrace ?? string.Empty;
+
+            return failure;
+        }
+
+        /// <summary>
+        /// Convert a Temporal Failure proto to a NexusRpc.Failure. This is the reverse of
+        /// <see cref="NexusFailureToTemporalFailure"/>. Used when deserializing
+        /// NexusHandlerFailureInfo to set OriginalFailure on HandlerException for
+        /// round-tripping. Mirrors Python's _temporal_failure_to_nexus_failure.
+        /// </summary>
+        /// <param name="failure">The Temporal Failure proto to convert.</param>
+        /// <returns>The NexusRpc Failure for round-tripping.</returns>
+        internal static NexusRpc.Failure TemporalFailureToNexusFailure(Failure failure)
+        {
+            // Temporarily zero out message and stack trace, serialize the rest as a
+            // JSON dict, then restore. This matches Python's approach.
+            var message = failure.Message;
+            var stackTrace = failure.StackTrace;
+            failure.Message = string.Empty;
+            failure.StackTrace = string.Empty;
+            var failureDict = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                JsonFormatter.Default.Format(failure));
+            failure.Message = message;
+            failure.StackTrace = stackTrace;
+            return new NexusRpc.Failure(
+                message: message,
+                metadata: new Dictionary<string, string>
+                {
+                    ["type"] = Failure.Descriptor.FullName,
+                },
+                details: failureDict,
+                stackTrace: string.IsNullOrEmpty(stackTrace) ? null : stackTrace);
         }
 
         private Failure CreateFailureFromException(
@@ -189,6 +319,36 @@ namespace Temporalio.Converters
                         $"Unexpected failure type {exc.GetType()} without failure proto");
             }
             return failure;
+        }
+
+        private Failure CreateFailureFromHandlerException(
+            HandlerException exc,
+            IPayloadConverter conv)
+        {
+            // If OriginalFailure is set, this is a round-trip case where an upstream
+            // Temporal failure was converted to a NexusRpc Failure and needs to be restored.
+            // This mirrors Python's _nexus_failure_to_temporal_failure.
+            // IMPORTANT: Do NOT set NexusHandlerFailureInfo here — the restored proto already
+            // has the correct failure_info type (e.g. ApplicationFailureInfo). Setting
+            // NexusHandlerFailureInfo would clear it (protobuf oneof). Python also does not
+            // set nexus_handler_failure_info in this path.
+            if (exc.OriginalFailure is { } originalFailure)
+            {
+                return NexusFailureToTemporalFailure(originalFailure, !exc.IsRetryable);
+            }
+
+            // Fresh error: create a new Failure proto with NexusHandlerFailureInfo
+            return new Failure()
+            {
+                Message = exc.Message,
+                StackTrace = exc.StackTrace ?? string.Empty,
+                Cause = exc.InnerException == null ? null : ToFailure(exc.InnerException, conv),
+                NexusHandlerFailureInfo = new()
+                {
+                    Type = exc.RawErrorType,
+                    RetryBehavior = (NexusHandlerErrorRetryBehavior)(int)exc.ErrorRetryBehavior,
+                },
+            };
         }
 
         /// <summary>

--- a/src/Temporalio/Converters/DefaultFailureConverter.cs
+++ b/src/Temporalio/Converters/DefaultFailureConverter.cs
@@ -196,7 +196,7 @@ namespace Temporalio.Converters
             {
                 // Non-Temporal Nexus failure: wrap as ApplicationFailureInfo with type
                 // "NexusFailure" and serialize the remaining failure fields as a JSON payload
-                // in the details, matching Python's _nexus_failure_to_temporal_failure.
+                // in the details.
                 var detailsPayload = new Payload()
                 {
                     Metadata = { ["encoding"] = ByteString.CopyFromUtf8("json/plain") },
@@ -232,14 +232,14 @@ namespace Temporalio.Converters
         /// Convert a Temporal Failure proto to a NexusRpc.Failure. This is the reverse of
         /// <see cref="NexusFailureToTemporalFailure"/>. Used when deserializing
         /// NexusHandlerFailureInfo to set OriginalFailure on HandlerException for
-        /// round-tripping. Mirrors Python's _temporal_failure_to_nexus_failure.
+        /// round-tripping.
         /// </summary>
         /// <param name="failure">The Temporal Failure proto to convert.</param>
         /// <returns>The NexusRpc Failure for round-tripping.</returns>
         internal static NexusRpc.Failure TemporalFailureToNexusFailure(Failure failure)
         {
             // Temporarily zero out message and stack trace, serialize the rest as a
-            // JSON dict, then restore. This matches Python's approach.
+            // JSON dict, then restore.
             var message = failure.Message;
             var stackTrace = failure.StackTrace;
             failure.Message = string.Empty;
@@ -327,11 +327,9 @@ namespace Temporalio.Converters
         {
             // If OriginalFailure is set, this is a round-trip case where an upstream
             // Temporal failure was converted to a NexusRpc Failure and needs to be restored.
-            // This mirrors Python's _nexus_failure_to_temporal_failure.
             // IMPORTANT: Do NOT set NexusHandlerFailureInfo here — the restored proto already
             // has the correct failure_info type (e.g. ApplicationFailureInfo). Setting
-            // NexusHandlerFailureInfo would clear it (protobuf oneof). Python also does not
-            // set nexus_handler_failure_info in this path.
+            // NexusHandlerFailureInfo would clear it (protobuf oneof).
             if (exc.OriginalFailure is { } originalFailure)
             {
                 return NexusFailureToTemporalFailure(originalFailure, !exc.IsRetryable);
@@ -346,7 +344,12 @@ namespace Temporalio.Converters
                 NexusHandlerFailureInfo = new()
                 {
                     Type = exc.RawErrorType,
-                    RetryBehavior = (NexusHandlerErrorRetryBehavior)(int)exc.ErrorRetryBehavior,
+                    RetryBehavior = exc.ErrorRetryBehavior switch
+                    {
+                        HandlerErrorRetryBehavior.Retryable => NexusHandlerErrorRetryBehavior.Retryable,
+                        HandlerErrorRetryBehavior.NonRetryable => NexusHandlerErrorRetryBehavior.NonRetryable,
+                        _ => NexusHandlerErrorRetryBehavior.Unspecified,
+                    },
                 },
             };
         }

--- a/src/Temporalio/Converters/DefaultFailureConverter.cs
+++ b/src/Temporalio/Converters/DefaultFailureConverter.cs
@@ -17,6 +17,9 @@ namespace Temporalio.Converters
     /// </summary>
     public class DefaultFailureConverter : IFailureConverter
     {
+        private static readonly JsonParser ProtoJsonParser =
+            new(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultFailureConverter"/> class.
         /// </summary>
@@ -163,99 +166,123 @@ namespace Temporalio.Converters
         }
 
         /// <summary>
-        /// Convert a NexusRpc.Failure back to a Temporal Failure proto. This handles
+        /// Convert a NexusRpc.FailureInfo back to a Temporal Failure proto. This handles
         /// round-tripping failures that were originally Temporal Failure protos serialized
-        /// as NexusRpc Failures.
+        /// as NexusRpc FailureInfos.
         /// </summary>
-        /// <param name="nexusFailure">The NexusRpc failure to convert.</param>
+        /// <param name="failureInfo">The NexusRpc FailureInfo to convert.</param>
         /// <param name="nonRetryable">Whether the failure is non-retryable (used for
         /// non-Temporal fallback path).</param>
         /// <returns>The reconstructed Temporal Failure proto.</returns>
         internal static Failure NexusFailureToTemporalFailure(
-            NexusRpc.Failure nexusFailure, bool nonRetryable = true)
+            NexusRpc.FailureInfo failureInfo, bool nonRetryable = true)
         {
-            Failure failure;
+            var apiFailure = new Failure();
 
             // Check if this was originally a Temporal Failure proto
-            if (nexusFailure.Metadata != null &&
-                nexusFailure.Metadata.TryGetValue("type", out var metadataType) &&
+            if (failureInfo.Metadata != null &&
+                failureInfo.Metadata.TryGetValue("type", out var metadataType) &&
                 metadataType == Failure.Descriptor.FullName)
             {
-                // Round-trip: details contain the serialized proto fields as JSON-compatible dict
-                if (nexusFailure.Details != null)
+                // Details contains a JSON-serialized Temporal failure
+                if (!string.IsNullOrEmpty(failureInfo.Details))
                 {
-                    var json = JsonSerializer.Serialize(nexusFailure.Details);
-                    failure = JsonParser.Default.Parse<Failure>(json);
-                }
-                else
-                {
-                    failure = new Failure();
+                    apiFailure = ProtoJsonParser.Parse<Failure>(failureInfo.Details);
                 }
             }
             else
             {
-                // Non-Temporal Nexus failure: wrap as ApplicationFailureInfo with type
-                // "NexusFailure" and serialize the remaining failure fields as a JSON payload
-                // in the details.
-                var detailsPayload = new Payload()
+                // Create an ApplicationFailure with the Nexus failure data
+                var appFailureInfo = new ApplicationFailureInfo()
                 {
-                    Metadata = { ["encoding"] = ByteString.CopyFromUtf8("json/plain") },
+                    Type = "NexusFailure",
+                    NonRetryable = nonRetryable,
                 };
-                // Serialize the NexusRpc Failure (with message cleared) as JSON
-                var failureForDetails = new NexusRpc.Failure(
-                    string.Empty,
-                    nexusFailure.Metadata,
-                    nexusFailure.Details,
-                    nexusFailure.StackTrace,
-                    nexusFailure.Cause);
-                detailsPayload.Data = ByteString.CopyFromUtf8(
-                    JsonSerializer.Serialize(failureForDetails));
-                failure = new Failure()
+                var payloads = NexusFailureInfoToPayloads(failureInfo);
+                if (payloads != null)
                 {
-                    ApplicationFailureInfo = new()
-                    {
-                        Type = "NexusFailure",
-                        NonRetryable = nonRetryable,
-                        Details = new() { Payloads_ = { detailsPayload } },
-                    },
-                };
+                    appFailureInfo.Details = payloads;
+                }
+
+                apiFailure.ApplicationFailureInfo = appFailureInfo;
             }
 
-            // Restore message and stack trace from the NexusRpc Failure
-            failure.Message = nexusFailure.Message;
-            failure.StackTrace = nexusFailure.StackTrace ?? string.Empty;
+            // Ensure these always get written
+            apiFailure.Message = failureInfo.Message;
+            if (!string.IsNullOrEmpty(failureInfo.StackTrace))
+            {
+                apiFailure.StackTrace = failureInfo.StackTrace;
+            }
 
-            return failure;
+            return apiFailure;
         }
 
         /// <summary>
-        /// Convert a Temporal Failure proto to a NexusRpc.Failure. This is the reverse of
+        /// Convert a Temporal Failure proto to a NexusRpc.FailureInfo. This is the reverse of
         /// <see cref="NexusFailureToTemporalFailure"/>. Used when deserializing
         /// NexusHandlerFailureInfo to set OriginalFailure on HandlerException for
         /// round-tripping.
         /// </summary>
         /// <param name="failure">The Temporal Failure proto to convert.</param>
-        /// <returns>The NexusRpc Failure for round-tripping.</returns>
-        internal static NexusRpc.Failure TemporalFailureToNexusFailure(Failure failure)
+        /// <returns>The NexusRpc FailureInfo for round-tripping.</returns>
+        internal static NexusRpc.FailureInfo TemporalFailureToNexusFailure(Failure failure)
         {
-            // Temporarily zero out message and stack trace, serialize the rest as a
-            // JSON dict, then restore.
-            var message = failure.Message;
-            var stackTrace = failure.StackTrace;
-            failure.Message = string.Empty;
-            failure.StackTrace = string.Empty;
-            var failureDict = JsonSerializer.Deserialize<Dictionary<string, object>>(
-                JsonFormatter.Default.Format(failure));
-            failure.Message = message;
-            failure.StackTrace = stackTrace;
-            return new NexusRpc.Failure(
-                message: message,
+            string detailsJson;
+            try
+            {
+                var stripped = failure.Clone();
+                stripped.Message = string.Empty;
+                stripped.StackTrace = string.Empty;
+                detailsJson = JsonFormatter.Default.Format(stripped);
+            }
+            catch (InvalidProtocolBufferException e)
+            {
+                return new NexusRpc.FailureInfo(
+                    message: "Failed to serialize failure details",
+                    details: e.Message);
+            }
+
+            return new NexusRpc.FailureInfo(
+                message: failure.Message,
                 metadata: new Dictionary<string, string>
                 {
                     ["type"] = Failure.Descriptor.FullName,
                 },
-                details: failureDict,
-                stackTrace: string.IsNullOrEmpty(stackTrace) ? null : stackTrace);
+                details: detailsJson,
+                stackTrace: string.IsNullOrEmpty(failure.StackTrace) ? null : failure.StackTrace);
+        }
+
+        /// <summary>
+        /// Convert a NexusRpc.FailureInfo to Payloads for the non-Temporal failure path.
+        /// Serializes the entire FailureInfo (with message cleared) as a JSON payload.
+        /// </summary>
+        private static Payloads? NexusFailureInfoToPayloads(NexusRpc.FailureInfo failureInfo)
+        {
+            if ((failureInfo.Metadata == null || failureInfo.Metadata.Count == 0) &&
+                string.IsNullOrEmpty(failureInfo.Details))
+            {
+                return null;
+            }
+
+            // Create a copy without the message before serializing
+            var copy = new NexusRpc.FailureInfo(
+                string.Empty,
+                failureInfo.Metadata,
+                failureInfo.Details,
+                failureInfo.StackTrace,
+                failureInfo.Cause);
+            var json = JsonSerializer.Serialize(copy);
+            return new Payloads
+            {
+                Payloads_ =
+                {
+                    new Payload()
+                    {
+                        Metadata = { ["encoding"] = ByteString.CopyFromUtf8("json/plain") },
+                        Data = ByteString.CopyFromUtf8(json),
+                    },
+                },
+            };
         }
 
         private Failure CreateFailureFromException(

--- a/src/Temporalio/Exceptions/CanceledFailureException.cs
+++ b/src/Temporalio/Exceptions/CanceledFailureException.cs
@@ -13,11 +13,13 @@ namespace Temporalio.Exceptions
         /// Initializes a new instance of the <see cref="CanceledFailureException"/> class.
         /// </summary>
         /// <param name="message">Message for the exception.</param>
+        /// <param name="inner">Optional inner exception cause.</param>
         /// <param name="details">Details for the exception.</param>
         internal protected CanceledFailureException(
             string message,
+            Exception? inner = null,
             IReadOnlyCollection<object?>? details = null)
-            : base(message) =>
+            : base(message, inner) =>
             Details = new OutboundFailureDetails(details ?? Array.Empty<object?>());
 
         /// <summary>

--- a/src/Temporalio/Nexus/WorkflowRunOperationHandler.cs
+++ b/src/Temporalio/Nexus/WorkflowRunOperationHandler.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Threading.Tasks;
-using NexusRpc;
 using NexusRpc.Handlers;
 
 namespace Temporalio.Nexus
@@ -90,14 +89,6 @@ namespace Temporalio.Nexus
             var handle = await handleFactory(new(context), input).ConfigureAwait(false);
             return OperationStartResult.AsyncResult<TResult>(handle.ToToken());
         }
-
-        /// <inheritdoc/>
-        public Task<TResult> FetchResultAsync(OperationFetchResultContext context) =>
-            throw new NotImplementedException();
-
-        /// <inheritdoc/>
-        public Task<OperationInfo> FetchInfoAsync(OperationFetchInfoContext context) =>
-            throw new NotImplementedException();
 
         /// <inheritdoc/>
         public Task CancelAsync(OperationCancelContext context)

--- a/src/Temporalio/Temporalio.csproj
+++ b/src/Temporalio/Temporalio.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="NexusRpc" Version="0.2.0" />
+    <ProjectReference Include="..\..\..\nexus\sdk-dotnet\src\NexusRpc\NexusRpc.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Temporalio/Temporalio.csproj
+++ b/src/Temporalio/Temporalio.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <ProjectReference Include="..\..\..\nexus\sdk-dotnet\src\NexusRpc\NexusRpc.csproj" />
+    <PackageReference Include="NexusRpc" Version="0.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Temporalio/Worker/NexusMiddlewareForInterceptors.cs
+++ b/src/Temporalio/Worker/NexusMiddlewareForInterceptors.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using NexusRpc;
 using NexusRpc.Handlers;
 using Temporalio.Worker.Interceptors;
 
@@ -42,12 +41,6 @@ namespace Temporalio.Worker
             public Task<OperationStartResult<object?>> StartAsync(
                 OperationStartContext context, object? input) =>
                 nextInterceptor.ExecuteNexusOperationStartAsync(new(context, input));
-
-            public Task<object?> FetchResultAsync(OperationFetchResultContext context) =>
-                throw new System.NotImplementedException();
-
-            public Task<OperationInfo> FetchInfoAsync(OperationFetchInfoContext context) =>
-                throw new System.NotImplementedException();
 
             public Task CancelAsync(OperationCancelContext context) =>
                 nextInterceptor.ExecuteNexusOperationCancelAsync(new(context));

--- a/src/Temporalio/Worker/NexusWorker.cs
+++ b/src/Temporalio/Worker/NexusWorker.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Logging;
 using NexusRpc;
 using NexusRpc.Handlers;
 using Temporalio.Api.Common.V1;
-using Temporalio.Api.Enums.V1;
 using Temporalio.Api.Nexus.V1;
 using Temporalio.Api.WorkflowService.V1;
 using Temporalio.Bridge.Api.Nexus;
@@ -233,16 +232,16 @@ namespace Temporalio.Worker
             }
             catch (OperationException e)
             {
-#pragma warning disable CS0612 // OperationError deprecated, use Failure
-                return new()
-                {
-                    OperationError = new()
-                    {
-                        OperationState = e.State.ToString().ToLower(),
-                        Failure = await ExceptionToNexusFailureAsync(e).ConfigureAwait(false),
-                    },
-                };
-#pragma warning restore CS0612
+                // Convert OperationException to the appropriate FailureException and encode
+                // via the failure converter, matching Python SDK behavior exactly.
+                // Python: CANCELED -> CancelledError, FAILED -> ApplicationError("OperationError")
+                Exception convertedException = e.State == OperationState.Canceled
+                    ? new CanceledFailureException(e.Message)
+                    : new ApplicationFailureException(
+                        e.Message, e.InnerException, "OperationError", nonRetryable: true);
+                var opFailure = await worker.Client.Options.DataConverter
+                    .ToFailureAsync(convertedException).ConfigureAwait(false);
+                return new() { Failure = opFailure };
             }
             catch (Exception e)
             {
@@ -319,19 +318,13 @@ namespace Temporalio.Worker
 #pragma warning restore CA1031
             {
                 logger.LogWarning(e, "Completing Nexus {OperationType} task as failed", task.Request.VariantCase);
-#pragma warning disable CS0612 // Error deprecated, use Failure
+                var handlerException = e as HandlerException ?? ConvertToHandlerException(e);
+                var failure = await worker.Client.Options.DataConverter.ToFailureAsync(handlerException).ConfigureAwait(false);
                 return new()
                 {
                     TaskToken = task.TaskToken,
-                    Error = new()
-                    {
-                        ErrorType = (e as HandlerException)?.RawErrorType ?? "INTERNAL",
-                        Failure = await ExceptionToNexusFailureAsync(e).ConfigureAwait(false),
-                        RetryBehavior = (NexusHandlerErrorRetryBehavior)(int)(
-                            (e as HandlerException)?.ErrorRetryBehavior ?? HandlerErrorRetryBehavior.Unspecified),
-                    },
+                    Failure = failure,
                 };
-#pragma warning restore CS0612
             }
         }
 
@@ -342,33 +335,6 @@ namespace Temporalio.Worker
                 logger: worker.LoggerFactory.CreateLogger($"Temporalio.Nexus:{handlerContext.Operation}"),
                 runtimeMetricMeter: worker.MetricMeter,
                 temporalClient: worker.Client as ITemporalClient);
-
-        private async Task<Failure> ExceptionToNexusFailureAsync(Exception exc)
-        {
-            // Convert to failure, then capture message, then remove message and capture rest of
-            // failure as proto JSON
-            Api.Failure.V1.Failure failureProto;
-            try
-            {
-                failureProto = await worker.Client.Options.DataConverter.ToFailureAsync(exc).ConfigureAwait(false);
-            }
-#pragma warning disable CA1031 // We're ok catching all exceptions here
-            catch (Exception e)
-#pragma warning restore CA1031
-            {
-                logger.LogError(e, "Failure converting existing failure");
-                failureProto = new() { Message = $"Failure converting existing failure: {e.Message}" };
-            }
-            // Capture message, then remove and serialize rest of failure as proto JSON
-            var message = failureProto.Message;
-            failureProto.Message = string.Empty;
-            return new()
-            {
-                Message = message,
-                Details = ByteString.CopyFromUtf8(JsonFormatter.Default.Format(failureProto)),
-                Metadata = { ["type"] = Api.Failure.V1.Failure.Descriptor.FullName },
-            };
-        }
 
         private HandlerException ConvertToHandlerException(Exception exc)
         {

--- a/src/Temporalio/Worker/NexusWorker.cs
+++ b/src/Temporalio/Worker/NexusWorker.cs
@@ -235,7 +235,7 @@ namespace Temporalio.Worker
                 // Convert OperationException to the appropriate FailureException and encode
                 // via the failure converter.
                 Exception convertedException = e.State == OperationState.Canceled
-                    ? new CanceledFailureException(e.Message)
+                    ? new CanceledFailureException(e.Message, e.InnerException)
                     : new ApplicationFailureException(
                         e.Message, e.InnerException, "OperationError", nonRetryable: true);
                 var opFailure = await worker.Client.Options.DataConverter

--- a/src/Temporalio/Worker/NexusWorker.cs
+++ b/src/Temporalio/Worker/NexusWorker.cs
@@ -233,8 +233,7 @@ namespace Temporalio.Worker
             catch (OperationException e)
             {
                 // Convert OperationException to the appropriate FailureException and encode
-                // via the failure converter, matching Python SDK behavior exactly.
-                // Python: CANCELED -> CancelledError, FAILED -> ApplicationError("OperationError")
+                // via the failure converter.
                 Exception convertedException = e.State == OperationState.Canceled
                     ? new CanceledFailureException(e.Message)
                     : new ApplicationFailureException(

--- a/tests/Temporalio.Tests/Converters/FailureConverterTests.cs
+++ b/tests/Temporalio.Tests/Converters/FailureConverterTests.cs
@@ -118,111 +118,65 @@ public class FailureConverterTests : TestBase
     }
 
     [Fact]
-    public void ToFailure_HandlerException_WithOriginalFailure_PreservesOriginalFailureInfo()
+    public void ToFailure_HandlerException_WithOriginalFailure_RoundTripsCorrectly()
     {
-        // Simulate a round-trip: an ApplicationFailureInfo that was serialized to
-        // NexusRpc.Failure and is now being restored
-        var originalProto = new Failure()
-        {
-            Message = "Original error",
-            StackTrace = "at SomeMethod()",
-            ApplicationFailureInfo = new()
-            {
-                Type = "CustomError",
-                NonRetryable = true,
-            },
-        };
-        // Simulate what ExceptionToNexusFailureAsync used to do: serialize proto to JSON
-        var message = originalProto.Message;
-        originalProto.Message = string.Empty;
-        var json = Google.Protobuf.JsonFormatter.Default.Format(originalProto);
-        originalProto.Message = message;
-
-        // Create a NexusRpc.Failure with the serialized proto in details
-        var detailsDict = System.Text.Json.JsonSerializer.Deserialize<
-            Dictionary<string, object>>(json)!;
-        var nexusFailure = new NexusRpc.Failure(
-            message: "Original error",
-            metadata: new Dictionary<string, string>
-            {
-                ["type"] = Failure.Descriptor.FullName,
-            },
-            details: detailsDict,
-            stackTrace: "at SomeMethod()");
-
-        // Create a HandlerException with OriginalFailure set
-        var handlerExc = new HandlerException(
+        // Start from what a user would actually throw in a handler
+        var userException = new HandlerException(
             HandlerErrorType.Internal,
-            "Handler wrapper message",
-            innerException: null,
-            errorRetryBehavior: HandlerErrorRetryBehavior.NonRetryable,
-            originalFailure: nexusFailure);
+            "Handler error message",
+            new ApplicationFailureException("Root cause", errorType: "CustomError", nonRetryable: true),
+            HandlerErrorRetryBehavior.NonRetryable);
 
-        var failure = DataConverter.Default.FailureConverter.ToFailure(
+        // Serialize to Failure proto (handler side)
+        var failureProto = DataConverter.Default.FailureConverter.ToFailure(
+            userException, DataConverter.Default.PayloadConverter);
+
+        // Deserialize back to exception (caller side) — this produces a HandlerException
+        // with OriginalFailure set for round-tripping
+        var deserialized = DataConverter.Default.FailureConverter.ToException(
+            failureProto, DataConverter.Default.PayloadConverter);
+        var handlerExc = Assert.IsType<HandlerException>(deserialized);
+        Assert.NotNull(handlerExc.OriginalFailure);
+
+        // Now re-serialize (simulates the round-trip through another Nexus boundary)
+        var roundTripped = DataConverter.Default.FailureConverter.ToFailure(
             handlerExc, DataConverter.Default.PayloadConverter);
 
-        // CRITICAL: The original ApplicationFailureInfo must be preserved, NOT overwritten
-        // with NexusHandlerFailureInfo
-        Assert.NotNull(failure.ApplicationFailureInfo);
-        Assert.Equal("CustomError", failure.ApplicationFailureInfo.Type);
-        Assert.True(failure.ApplicationFailureInfo.NonRetryable);
-        Assert.Equal("Original error", failure.Message);
-        Assert.Equal("at SomeMethod()", failure.StackTrace);
-        // NexusHandlerFailureInfo should NOT be set (protobuf oneof)
-        Assert.Null(failure.NexusHandlerFailureInfo);
+        // The round-tripped proto should preserve the full structure
+        Assert.NotNull(roundTripped.NexusHandlerFailureInfo);
+        Assert.Equal("INTERNAL", roundTripped.NexusHandlerFailureInfo.Type);
+        Assert.Equal("Handler error message", roundTripped.Message);
+        Assert.NotNull(roundTripped.Cause);
+        Assert.Equal("Root cause", roundTripped.Cause.Message);
+        Assert.NotNull(roundTripped.Cause.ApplicationFailureInfo);
+        Assert.Equal("CustomError", roundTripped.Cause.ApplicationFailureInfo.Type);
     }
 
     [Fact]
     public void ToFailure_HandlerException_WithOriginalFailure_AppliesEncodeCommonAttributes()
     {
-        // EncodeCommonAttributes applies uniformly to all failures including round-trip
-        var nexusFailure = new NexusRpc.Failure(
-            message: "Test message",
-            metadata: new Dictionary<string, string>
-            {
-                ["type"] = Failure.Descriptor.FullName,
-            },
-            details: new Dictionary<string, object>(),
-            stackTrace: "test stack");
-
-        var handlerExc = new HandlerException(
+        var userException = new HandlerException(
             HandlerErrorType.Internal,
-            "wrapper",
-            innerException: null,
-            originalFailure: nexusFailure);
+            "Handler error",
+            errorRetryBehavior: HandlerErrorRetryBehavior.NonRetryable);
 
+        // First pass: serialize and deserialize to get a HandlerException with OriginalFailure
+        var firstProto = DataConverter.Default.FailureConverter.ToFailure(
+            userException, DataConverter.Default.PayloadConverter);
+        var deserialized = Assert.IsType<HandlerException>(
+            DataConverter.Default.FailureConverter.ToException(
+                firstProto, DataConverter.Default.PayloadConverter));
+        Assert.NotNull(deserialized.OriginalFailure);
+
+        // Second pass: re-serialize with EncodeCommonAttributes
         var converter = new DefaultFailureConverter.WithEncodedCommonAttributes();
         var failure = converter.ToFailure(
-            handlerExc, DataConverter.Default.PayloadConverter);
+            deserialized, DataConverter.Default.PayloadConverter);
 
         // EncodeCommonAttributes applies uniformly, including round-trip path
         Assert.Equal("Encoded failure", failure.Message);
         Assert.Empty(failure.StackTrace);
         Assert.NotNull(failure.EncodedAttributes);
-    }
-
-    [Fact]
-    public void NexusFailureToTemporalFailure_NonTemporalFailure_ProducesNexusFailureType()
-    {
-        // A NexusRpc.Failure without the Temporal proto metadata should produce
-        // an ApplicationFailureInfo with type "NexusFailure"
-        var nexusFailure = new NexusRpc.Failure(
-            message: "Some nexus error",
-            metadata: new Dictionary<string, string> { ["custom"] = "value" },
-            stackTrace: "remote stack");
-
-        var failure = DefaultFailureConverter.NexusFailureToTemporalFailure(
-            nexusFailure, nonRetryable: false);
-
-        Assert.Equal("Some nexus error", failure.Message);
-        Assert.Equal("remote stack", failure.StackTrace);
-        Assert.NotNull(failure.ApplicationFailureInfo);
-        Assert.Equal("NexusFailure", failure.ApplicationFailureInfo.Type);
-        // nonRetryable parameter should be respected
-        Assert.False(failure.ApplicationFailureInfo.NonRetryable);
-        // Details payload should contain serialized NexusRpc.Failure
-        Assert.NotNull(failure.ApplicationFailureInfo.Details);
-        Assert.Single(failure.ApplicationFailureInfo.Details.Payloads_);
     }
 
     [Fact]

--- a/tests/Temporalio.Tests/Converters/FailureConverterTests.cs
+++ b/tests/Temporalio.Tests/Converters/FailureConverterTests.cs
@@ -1,9 +1,7 @@
 namespace Temporalio.Tests.Converters;
 
-using System.Collections.Generic;
 using NexusRpc.Handlers;
 using Temporalio.Api.Enums.V1;
-using Temporalio.Api.Failure.V1;
 using Temporalio.Converters;
 using Temporalio.Exceptions;
 using Xunit;

--- a/tests/Temporalio.Tests/Converters/FailureConverterTests.cs
+++ b/tests/Temporalio.Tests/Converters/FailureConverterTests.cs
@@ -1,5 +1,9 @@
 namespace Temporalio.Tests.Converters;
 
+using System.Collections.Generic;
+using NexusRpc.Handlers;
+using Temporalio.Api.Enums.V1;
+using Temporalio.Api.Failure.V1;
 using Temporalio.Converters;
 using Temporalio.Exceptions;
 using Xunit;
@@ -61,5 +65,185 @@ public class FailureConverterTests : TestBase
         Assert.Equal("exc1", exc.Message);
         Assert.Contains("FailureConverterTests", exc.StackTrace);
         Assert.Equal("exc2", exc.InnerException!.Message);
+    }
+
+    [Fact]
+    public void ToFailure_HandlerException_FreshError_ProducesNexusHandlerFailureInfo()
+    {
+        // A fresh HandlerException (no OriginalFailure) should produce a Failure with
+        // NexusHandlerFailureInfo
+        var handlerExc = new HandlerException(
+            HandlerErrorType.BadRequest,
+            "Bad input",
+            new InvalidOperationException("inner cause"),
+            HandlerErrorRetryBehavior.NonRetryable);
+        var failure = DataConverter.Default.FailureConverter.ToFailure(
+            handlerExc, DataConverter.Default.PayloadConverter);
+
+        Assert.Equal("Bad input", failure.Message);
+        Assert.NotNull(failure.NexusHandlerFailureInfo);
+        Assert.Equal("BAD_REQUEST", failure.NexusHandlerFailureInfo.Type);
+        Assert.Equal(
+            NexusHandlerErrorRetryBehavior.NonRetryable,
+            failure.NexusHandlerFailureInfo.RetryBehavior);
+        // Inner exception serialized as Cause
+        Assert.NotNull(failure.Cause);
+        Assert.Equal("inner cause", failure.Cause.Message);
+        Assert.Equal(
+            "InvalidOperationException", failure.Cause.ApplicationFailureInfo.Type);
+    }
+
+    [Fact]
+    public void ToFailure_HandlerException_FreshError_RoundTripsViaToException()
+    {
+        var handlerExc = new HandlerException(
+            HandlerErrorType.Internal,
+            "Server error",
+            errorRetryBehavior: HandlerErrorRetryBehavior.Retryable);
+        var failure = DataConverter.Default.FailureConverter.ToFailure(
+            handlerExc, DataConverter.Default.PayloadConverter);
+        var exc = DataConverter.Default.FailureConverter.ToException(
+            failure, DataConverter.Default.PayloadConverter);
+
+        var nexusExc = Assert.IsType<HandlerException>(exc);
+        Assert.Equal(HandlerErrorType.Internal, nexusExc.ErrorType);
+        Assert.Equal("INTERNAL", nexusExc.RawErrorType);
+        Assert.Equal(
+            HandlerErrorRetryBehavior.Retryable,
+            nexusExc.ErrorRetryBehavior);
+        Assert.Equal("Server error", nexusExc.Message);
+        Assert.Null(nexusExc.InnerException);
+        // OriginalFailure should be set for round-tripping
+        Assert.NotNull(nexusExc.OriginalFailure);
+    }
+
+    [Fact]
+    public void ToFailure_HandlerException_WithOriginalFailure_PreservesOriginalFailureInfo()
+    {
+        // Simulate a round-trip: an ApplicationFailureInfo that was serialized to
+        // NexusRpc.Failure and is now being restored
+        var originalProto = new Failure()
+        {
+            Message = "Original error",
+            StackTrace = "at SomeMethod()",
+            ApplicationFailureInfo = new()
+            {
+                Type = "CustomError",
+                NonRetryable = true,
+            },
+        };
+        // Simulate what ExceptionToNexusFailureAsync used to do: serialize proto to JSON
+        var message = originalProto.Message;
+        originalProto.Message = string.Empty;
+        var json = Google.Protobuf.JsonFormatter.Default.Format(originalProto);
+        originalProto.Message = message;
+
+        // Create a NexusRpc.Failure with the serialized proto in details
+        var detailsDict = System.Text.Json.JsonSerializer.Deserialize<
+            Dictionary<string, object>>(json)!;
+        var nexusFailure = new NexusRpc.Failure(
+            message: "Original error",
+            metadata: new Dictionary<string, string>
+            {
+                ["type"] = Failure.Descriptor.FullName,
+            },
+            details: detailsDict,
+            stackTrace: "at SomeMethod()");
+
+        // Create a HandlerException with OriginalFailure set
+        var handlerExc = new HandlerException(
+            HandlerErrorType.Internal,
+            "Handler wrapper message",
+            innerException: null,
+            errorRetryBehavior: HandlerErrorRetryBehavior.NonRetryable,
+            originalFailure: nexusFailure);
+
+        var failure = DataConverter.Default.FailureConverter.ToFailure(
+            handlerExc, DataConverter.Default.PayloadConverter);
+
+        // CRITICAL: The original ApplicationFailureInfo must be preserved, NOT overwritten
+        // with NexusHandlerFailureInfo
+        Assert.NotNull(failure.ApplicationFailureInfo);
+        Assert.Equal("CustomError", failure.ApplicationFailureInfo.Type);
+        Assert.True(failure.ApplicationFailureInfo.NonRetryable);
+        Assert.Equal("Original error", failure.Message);
+        Assert.Equal("at SomeMethod()", failure.StackTrace);
+        // NexusHandlerFailureInfo should NOT be set (protobuf oneof)
+        Assert.Null(failure.NexusHandlerFailureInfo);
+    }
+
+    [Fact]
+    public void ToFailure_HandlerException_WithOriginalFailure_AppliesEncodeCommonAttributes()
+    {
+        // EncodeCommonAttributes applies uniformly to all failures including round-trip
+        var nexusFailure = new NexusRpc.Failure(
+            message: "Test message",
+            metadata: new Dictionary<string, string>
+            {
+                ["type"] = Failure.Descriptor.FullName,
+            },
+            details: new Dictionary<string, object>(),
+            stackTrace: "test stack");
+
+        var handlerExc = new HandlerException(
+            HandlerErrorType.Internal,
+            "wrapper",
+            innerException: null,
+            originalFailure: nexusFailure);
+
+        var converter = new DefaultFailureConverter.WithEncodedCommonAttributes();
+        var failure = converter.ToFailure(
+            handlerExc, DataConverter.Default.PayloadConverter);
+
+        // EncodeCommonAttributes applies uniformly, including round-trip path
+        Assert.Equal("Encoded failure", failure.Message);
+        Assert.Empty(failure.StackTrace);
+        Assert.NotNull(failure.EncodedAttributes);
+    }
+
+    [Fact]
+    public void NexusFailureToTemporalFailure_NonTemporalFailure_ProducesNexusFailureType()
+    {
+        // A NexusRpc.Failure without the Temporal proto metadata should produce
+        // an ApplicationFailureInfo with type "NexusFailure"
+        var nexusFailure = new NexusRpc.Failure(
+            message: "Some nexus error",
+            metadata: new Dictionary<string, string> { ["custom"] = "value" },
+            stackTrace: "remote stack");
+
+        var failure = DefaultFailureConverter.NexusFailureToTemporalFailure(
+            nexusFailure, nonRetryable: false);
+
+        Assert.Equal("Some nexus error", failure.Message);
+        Assert.Equal("remote stack", failure.StackTrace);
+        Assert.NotNull(failure.ApplicationFailureInfo);
+        Assert.Equal("NexusFailure", failure.ApplicationFailureInfo.Type);
+        // nonRetryable parameter should be respected
+        Assert.False(failure.ApplicationFailureInfo.NonRetryable);
+        // Details payload should contain serialized NexusRpc.Failure
+        Assert.NotNull(failure.ApplicationFailureInfo.Details);
+        Assert.Single(failure.ApplicationFailureInfo.Details.Payloads_);
+    }
+
+    [Fact]
+    public void ToFailure_HandlerException_RetryableAppFailure_SetsRetryable()
+    {
+        // Verify that a retryable ApplicationFailureException wrapped in a HandlerException
+        // gets Retryable retry behavior (not Unspecified)
+        var appExc = new ApplicationFailureException("retryable error");
+        // Simulate ConvertToHandlerException for retryable case
+        var handlerExc = new HandlerException(
+            HandlerErrorType.Internal,
+            "Handler failed with application error",
+            appExc,
+            HandlerErrorRetryBehavior.Retryable);
+
+        var failure = DataConverter.Default.FailureConverter.ToFailure(
+            handlerExc, DataConverter.Default.PayloadConverter);
+
+        Assert.NotNull(failure.NexusHandlerFailureInfo);
+        Assert.Equal(
+            NexusHandlerErrorRetryBehavior.Retryable,
+            failure.NexusHandlerFailureInfo.RetryBehavior);
     }
 }

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -78,12 +78,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
 
             public Task CancelAsync(OperationCancelContext context) =>
                 throw new NotImplementedException();
-
-            public Task<int> FetchResultAsync(OperationFetchResultContext context) =>
-                throw new NotImplementedException();
-
-            public Task<OperationInfo> FetchInfoAsync(OperationFetchInfoContext context) =>
-                throw new NotImplementedException();
         }
     }
 

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -646,6 +646,34 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    public async Task ExecuteNexusOperationAsync_OperationExceptionCanceledWithCause_PreservesCauseChain()
+    {
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (context, input) =>
+                    throw OperationException.CreateCanceled(
+                        "Operation was canceled",
+                        new ApplicationFailureException("Root cause", errorType: "CustomError"))))).
+            AddWorkflow<SimpleWorkflow>();
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+        // How the exceptions come out:
+        // Temporalio.Exceptions.WorkflowFailedException : Workflow failed
+        // ---- Temporalio.Exceptions.NexusOperationFailureException : nexus operation completed unsuccessfully
+        // -------- Temporalio.Exceptions.CanceledFailureException : Operation was canceled
+        // ------------ Temporalio.Exceptions.ApplicationFailureException : Root cause
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
+            RunInWorkflowAsync(workerOptions, () =>
+                Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"))));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        var exc3 = Assert.IsType<CanceledFailureException>(exc2.InnerException);
+        Assert.Equal("Operation was canceled", exc3.Message);
+        var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
+        Assert.Equal("Root cause", exc4.Message);
+        Assert.Equal("CustomError", exc4.ErrorType);
+    }
+
+    [Fact]
     public async Task ExecuteNexusOperationAsync_HandlerException_ProperlyFails()
     {
         // Non-retryable

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -73,12 +73,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
 
             public Task CancelAsync(OperationCancelContext context) =>
                 cancel is { } cancelFunc ? cancelFunc(context) : throw new NotImplementedException();
-
-            public Task<string> FetchResultAsync(OperationFetchResultContext context) =>
-                throw new NotImplementedException();
-
-            public Task<OperationInfo> FetchInfoAsync(OperationFetchInfoContext context) =>
-                throw new NotImplementedException();
         }
     }
 
@@ -455,9 +449,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         exc = exc.InnerException;
         Assert.IsType<NexusOperationFailureException>(exc);
         exc = exc.InnerException;
-        Assert.IsType<NexusHandlerFailureException>(exc);
-        exc = exc.InnerException;
-        Assert.IsType<ApplicationFailureException>(exc);
+        Assert.IsType<HandlerException>(exc);
         exc = exc.InnerException;
         Assert.IsType<ApplicationFailureException>(exc);
         Assert.StartsWith("Workflow execution is already running", exc!.Message);
@@ -513,10 +505,10 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                 async () => await Workflow.CreateNexusWorkflowClient("StringService", endpoint).
                     ExecuteNexusOperationAsync<string>("DoSomething", 1234)));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
-        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.BadRequest, exc3.ErrorType);
         Assert.Equal(
-            NexusHandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
+            HandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
     }
 
     [Fact]
@@ -563,22 +555,20 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                     throw new ApplicationFailureException("Intentional failure", nonRetryable: true)))).
             AddWorkflow<SimpleWorkflow>();
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
-        // How the exceptions come out:
+        // How the exceptions come out with the new Temporal Failure proto format:
         // Temporalio.Exceptions.WorkflowFailedException : Workflow failed
         // ---- Temporalio.Exceptions.NexusOperationFailureException : nexus operation completed unsuccessfully
-        // -------- Temporalio.Exceptions.NexusHandlerFailureException : handler error (INTERNAL): Handler failed with non-retryable application error
-        // ------------ Temporalio.Exceptions.ApplicationFailureException : Handler failed with non-retryable application error
-        // ---------------- Temporalio.Exceptions.ApplicationFailureException : Intentional failure
+        // -------- NexusRpc.Handlers.HandlerException : handler error (INTERNAL): Handler failed with non-retryable application error
+        // ------------ Temporalio.Exceptions.ApplicationFailureException : Intentional failure
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
                 Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"))));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
-        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.Internal, exc3.ErrorType);
         var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
-        var exc5 = Assert.IsType<ApplicationFailureException>(exc4.InnerException);
-        Assert.Equal("Intentional failure", exc5.Message);
+        Assert.Equal("Intentional failure", exc4.Message);
     }
 
     [Fact]
@@ -587,7 +577,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
             AddNexusService(new HandlerFactoryStringService(() =>
                 OperationHandler.Sync<string, string>(async (context, input) =>
-                    throw OperationException.CreateFailure("Intentional failure")))).
+                    throw OperationException.CreateFailed("Intentional failure")))).
             AddWorkflow<SimpleWorkflow>();
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
         // How the exceptions come out:
@@ -604,6 +594,58 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    public async Task ExecuteNexusOperationAsync_OperationExceptionWithCause_PreservesCauseChain()
+    {
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (context, input) =>
+                    throw OperationException.CreateFailed(
+                        "Operation failed",
+                        new ApplicationFailureException("Root cause", errorType: "CustomError"))))).
+            AddWorkflow<SimpleWorkflow>();
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+        // How the exceptions come out:
+        // Temporalio.Exceptions.WorkflowFailedException : Workflow failed
+        // ---- Temporalio.Exceptions.NexusOperationFailureException : nexus operation completed unsuccessfully
+        // -------- Temporalio.Exceptions.ApplicationFailureException : Operation failed
+        // ------------ Temporalio.Exceptions.ApplicationFailureException : Root cause
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
+            RunInWorkflowAsync(workerOptions, () =>
+                Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"))));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        var exc3 = Assert.IsType<ApplicationFailureException>(exc2.InnerException);
+        Assert.Equal("Operation failed", exc3.Message);
+        Assert.Equal("OperationError", exc3.ErrorType);
+        Assert.True(exc3.NonRetryable);
+        var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
+        Assert.Equal("Root cause", exc4.Message);
+        Assert.Equal("CustomError", exc4.ErrorType);
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_OperationExceptionCanceled_ProperlyFails()
+    {
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (context, input) =>
+                    throw OperationException.CreateCanceled("Operation was canceled")))).
+            AddWorkflow<SimpleWorkflow>();
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+        // How the exceptions come out:
+        // Temporalio.Exceptions.WorkflowFailedException : Workflow failed
+        // ---- Temporalio.Exceptions.NexusOperationFailureException : nexus operation completed unsuccessfully
+        // -------- Temporalio.Exceptions.CanceledFailureException : Operation was canceled
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
+            RunInWorkflowAsync(workerOptions, () =>
+                Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"))));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        var exc3 = Assert.IsType<CanceledFailureException>(exc2.InnerException);
+        Assert.Equal("Operation was canceled", exc3.Message);
+    }
+
+    [Fact]
     public async Task ExecuteNexusOperationAsync_HandlerException_ProperlyFails()
     {
         // Non-retryable
@@ -613,20 +655,18 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                     throw new HandlerException(HandlerErrorType.BadRequest, "Intentional failure")))).
             AddWorkflow<SimpleWorkflow>();
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
-        // How the exceptions come out:
+        // How the exceptions come out with Temporal Failure proto format:
         // Temporalio.Exceptions.WorkflowFailedException : Workflow failed
         // ---- Temporalio.Exceptions.NexusOperationFailureException : nexus operation completed unsuccessfully
-        // -------- Temporalio.Exceptions.NexusHandlerFailureException : handler error (BAD_REQUEST): Intentional failure
-        // ------------ Temporalio.Exceptions.ApplicationFailureException : Intentional failure
+        // -------- NexusRpc.Handlers.HandlerException : handler error (BAD_REQUEST): Intentional failure
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
                 Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
                     ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"))));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
-        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.BadRequest, exc3.ErrorType);
-        var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
-        Assert.Equal("Intentional failure", exc4.Message);
+        Assert.Equal("Intentional failure", exc3.Message);
     }
 
     [Fact]
@@ -736,14 +776,14 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         // How the exceptions come out:
         // Temporalio.Exceptions.WorkflowFailedException : Workflow failed
         // ---- Temporalio.Exceptions.NexusOperationFailureException : nexus operation completed unsuccessfully
-        // -------- Temporalio.Exceptions.NexusHandlerFailureException : handler error (NOT_FOUND): Unrecognized service missing-service or operation unknown-operation
+        // -------- NexusRpc.Handlers.HandlerException : handler error (NOT_FOUND): Unrecognized service missing-service or operation unknown-operation
         // ------------ Temporalio.Exceptions.ApplicationFailureException : Unrecognized service missing-service or operation unknown-operation
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
                 Workflow.CreateNexusWorkflowClient("missing-service", endpoint).
                     ExecuteNexusOperationAsync("unknown-operation", "some-param")));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
-        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.NotFound, exc3.ErrorType);
     }
 
@@ -758,14 +798,14 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         // How the exceptions come out:
         // Temporalio.Exceptions.WorkflowFailedException : Workflow failed
         // ---- Temporalio.Exceptions.NexusOperationFailureException : nexus operation completed unsuccessfully
-        // -------- Temporalio.Exceptions.NexusHandlerFailureException : handler error (NOT_FOUND): Unrecognized service StringService or operation unknown-operation
+        // -------- NexusRpc.Handlers.HandlerException : handler error (NOT_FOUND): Unrecognized service StringService or operation unknown-operation
         // ------------ Temporalio.Exceptions.ApplicationFailureException : Unrecognized service StringService or operation unknown-operation
         var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunInWorkflowAsync(workerOptions, () =>
                 Workflow.CreateNexusWorkflowClient("StringService", endpoint).
                     ExecuteNexusOperationAsync("unknown-operation", "some-param")));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
-        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.NotFound, exc3.ErrorType);
     }
 
@@ -909,12 +949,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                 OperationStartContext context, NoValue input) =>
                 Underlying.StartAsync(context, input);
 
-            public Task<NoValue> FetchResultAsync(OperationFetchResultContext context) =>
-                Underlying.FetchResultAsync(context);
-
-            public Task<OperationInfo> FetchInfoAsync(OperationFetchInfoContext context) =>
-                Underlying.FetchInfoAsync(context);
-
             public Task CancelAsync(OperationCancelContext context) =>
                 throw new HandlerException(HandlerErrorType.NotImplemented, "Intentional failure");
         }
@@ -993,10 +1027,9 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() =>
             RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.WaitRequestedHandlerFail));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc.InnerException);
-        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.NotImplemented, exc3.ErrorType);
-        var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
-        Assert.Equal("Intentional failure", exc4.Message);
+        Assert.Equal("Intentional failure", exc3.Message);
     }
 
     [Fact]
@@ -1206,13 +1239,13 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                 await handle.GetResultAsync();
             }));
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
-        var exc3 = Assert.IsType<NexusHandlerFailureException>(exc2.InnerException);
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.BadRequest, exc3.ErrorType);
         Assert.Equal(
-            NexusHandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
+            HandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
         Assert.Contains(
             "Payload converter failed to decode Nexus operation input",
-            exc3.Failure.Cause.Message);
+            exc3.Message);
     }
 
     private async Task<string> CreateNexusEndpointAsync(string taskQueue)

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -555,7 +555,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                     throw new ApplicationFailureException("Intentional failure", nonRetryable: true)))).
             AddWorkflow<SimpleWorkflow>();
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
-        // How the exceptions come out with the new Temporal Failure proto format:
+        // How the exceptions come out with the Temporal Failure proto format:
         // Temporalio.Exceptions.WorkflowFailedException : Workflow failed
         // ---- Temporalio.Exceptions.NexusOperationFailureException : nexus operation completed unsuccessfully
         // -------- NexusRpc.Handlers.HandlerException : handler error (INTERNAL): Handler failed with non-retryable application error

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -13,7 +13,6 @@ using NexusRpc.Handlers;
 using Temporalio.Activities;
 using Temporalio.Api.Common.V1;
 using Temporalio.Api.Enums.V1;
-using Temporalio.Api.Failure.V1;
 using Temporalio.Api.History.V1;
 using Temporalio.Client;
 using Temporalio.Client.Schedules;

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -27,6 +27,7 @@ using Temporalio.Worker.Tuning;
 using Temporalio.Workflows;
 using Xunit;
 using Xunit.Abstractions;
+using Failure = Temporalio.Api.Failure.V1.Failure;
 
 public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
 {


### PR DESCRIPTION
Switch dotnet SDK to the new Nexus failure serialization format we are using in Go, Java, Python and soon TS.                                                                                                                                        
  
# Summary                                                                                                                                  
                                                                                                                              
  - ToException() for NexusHandlerFailureInfo now returns HandlerException (NexusRpc type) instead of NexusHandlerFailureException,        
  matching Python's nexusrpc.HandlerError                                                                                                  
  - ToFailure() handles HandlerException with NexusHandlerFailureInfo and recursive cause chains
  - OperationException: Failed → ApplicationFailureException("OperationError"), Canceled → CanceledFailureException                        
  - Removed ExceptionToNexusFailureAsync() and FetchResultAsync/FetchInfoAsync stubs                                                                                                                                   
                                                                                                                                           
  # Breaking Changes                                                                                                                       
                                                                                                                                           
  - Callers now receive HandlerException instead of NexusHandlerFailureException in the Nexus error chain                               

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Nexus error/Failure serialization and exception types surfaced to callers (`HandlerException` instead of `NexusHandlerFailureException`), which can break error-handling code and affects cross-language interoperability and retry semantics.
> 
> **Overview**
> Switches Nexus error propagation to the newer cross-SDK format by treating `NexusRpc.Handlers.HandlerException` as the primary Nexus handler error type and round-tripping it through Temporal `Failure` protos.
> 
> `DefaultFailureConverter` now (1) serializes fresh `HandlerException`s into `NexusHandlerFailureInfo`, (2) deserializes `NexusHandlerFailureInfo` into `HandlerException` (including retry behavior) while preserving original Temporal failure structure via JSON proto round-tripping, and (3) adds support for non-Temporal Nexus failure payload fallbacks.
> 
> `NexusWorker` now returns `Failure` directly (removing deprecated `Error`/`OperationError` paths) and maps `OperationException` states to `CanceledFailureException` or a non-retryable `ApplicationFailureException("OperationError")`, preserving cause chains; related `IOperationHandler` `FetchInfoAsync`/`FetchResultAsync` stubs are removed across hosting/worker/test helpers. Tests are updated/expanded accordingly, and `NexusRpc` is bumped to `0.3.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c4ce267dbd3cbd99ecc8e0619ff93f6c44767b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->