### PR TITLE
Fix assignment of typed search attributes on CaN and child workflows

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -1015,7 +1015,7 @@ namespace Temporalio.Worker
                     }
                     if (e.Input.Options?.TypedSearchAttributes is SearchAttributeCollection attrs)
                     {
-                        cmd.SearchAttributes.IndexedFields.Add(attrs.ToProto().IndexedFields);
+                        cmd.SearchAttributes = attrs.ToProto();
                     }
                     if (e.Input.Headers is IDictionary<string, Payload> headers)
                     {
@@ -2420,7 +2420,7 @@ namespace Temporalio.Worker
                 }
                 if (input.Options?.TypedSearchAttributes is SearchAttributeCollection attrs)
                 {
-                    cmd.SearchAttributes.IndexedFields.Add(attrs.ToProto().IndexedFields);
+                    cmd.SearchAttributes = attrs.ToProto();
                 }
                 if (input.Headers is IDictionary<string, Payload> headers)
                 {

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -1519,6 +1519,52 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Workflow]
+    public class ChildWorkflowSearchAttributesWorkflow
+    {
+        [Workflow]
+        public class ChildWorkflow
+        {
+            [WorkflowRun]
+            public Task RunAsync() => Workflow.DelayAsync(Timeout.Infinite);
+        }
+
+        [WorkflowRun]
+        public async Task<string> RunAsync()
+        {
+            var attrs = new SearchAttributeCollection.Builder()
+                .Set(AttrKeyword, "child-keyword")
+                .ToSearchAttributeCollection();
+
+            var childHandle = await Workflow.StartChildWorkflowAsync(
+                (ChildWorkflow wf) => wf.RunAsync(),
+                new() { TypedSearchAttributes = attrs });
+
+            return childHandle.Id;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_ChildWorkflowSearchAttributes_SetProperly()
+    {
+        await EnsureSearchAttributesPresentAsync();
+        await ExecuteWorkerAsync<ChildWorkflowSearchAttributesWorkflow>(
+            async worker =>
+            {
+                var handle = await Env.Client.StartWorkflowAsync(
+                    (ChildWorkflowSearchAttributesWorkflow wf) => wf.RunAsync(),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!)
+                    {
+                        ExecutionTimeout = TimeSpan.FromSeconds(5),
+                    });
+                var childId = await handle.GetResultAsync();
+                var childDesc = await Env.Client.GetWorkflowHandle(childId).DescribeAsync();
+                Assert.Equal("child-keyword", childDesc.TypedSearchAttributes.Get(AttrKeyword));
+            },
+            new TemporalWorkerOptions()
+                .AddWorkflow<ChildWorkflowSearchAttributesWorkflow.ChildWorkflow>());
+    }
+
+    [Workflow]
     public class MemoWorkflow
     {
         public static readonly Dictionary<string, object> MemoInitial = new()
@@ -1640,6 +1686,45 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             var result = await handle.GetResultAsync();
             Assert.Equal(5, result.Count);
             Assert.Equal(handle.FirstExecutionRunId, result[0]);
+        });
+    }
+
+    [Workflow]
+    public class ContinueAsNewSearchAttributesWorkflow
+    {
+        [WorkflowRun]
+        public async Task RunAsync(bool continued)
+        {
+            if (continued)
+            {
+                return;
+            }
+            throw Workflow.CreateContinueAsNewException(
+                (ContinueAsNewSearchAttributesWorkflow wf) => wf.RunAsync(true),
+                new()
+                {
+                    TypedSearchAttributes = new SearchAttributeCollection.Builder()
+                        .Set(AttrKeyword, "can-keyword")
+                        .ToSearchAttributeCollection(),
+                });
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_ContinueAsNewSearchAttributes_SetProperly()
+    {
+        await EnsureSearchAttributesPresentAsync();
+        await ExecuteWorkerAsync<ContinueAsNewSearchAttributesWorkflow>(async worker =>
+        {
+            var handle = await Env.Client.StartWorkflowAsync(
+                (ContinueAsNewSearchAttributesWorkflow wf) => wf.RunAsync(false),
+                new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!)
+                {
+                    ExecutionTimeout = TimeSpan.FromSeconds(5),
+                });
+            await handle.GetResultAsync();
+            var desc = await handle.DescribeAsync();
+            Assert.Equal("can-keyword", desc.TypedSearchAttributes.Get(AttrKeyword));
         });
     }
 


### PR DESCRIPTION
## What was changed
A regression was introduced in [this change](https://github.com/temporalio/sdk-dotnet/pull/625/changes#diff-7d5de4dd86e4fda729feeeac183fc71ca2f35e30324a3a631228d311e150f1d8) that directly assigned typed search attributes to `SearchAttributes.IndexedFields` on continue-as-new or for child workflows.

However, `SearchAttributes` is `null` on this assignment, resulting in a null assignment reference:
```
18:50:28 warn: Temporalio.Workflow:kitchenSink[0] => System.Collections.Generic.Dictionary`2[System.String,System.Object] => System.Collections.Generic.Dictionary`2[System.String,System.Object] Failed activation on workflow kitchenSink with ID w-dotnet-20260331-183334-8b9e-1f62d5c4b00f1126-8 and run ID 019d453b-958a-7f2a-87bf-6711fad00bca System.NullReferenceException: Object reference not set to an instance of an object.    at Temporalio.Worker.WorkflowInstance.OutboundImpl.StartChildWorkflowAsync[TWorkflow,TResult](StartChildWorkflowInput input) in /app/repo/src/Temporalio/Worker/WorkflowInstance.cs:line 2423
...
```

This change fixed the assignment and adds a couple small integration tests to verify the fix.

2. How was this tested:
Couple integration tests

3. Any docs updates needed?
Maybe ?
