### PR TITLE
Wire up deadline on Nexus context

### DIFF
--- a/src/Temporalio/Worker/NexusWorker.cs
+++ b/src/Temporalio/Worker/NexusWorker.cs
@@ -99,9 +99,10 @@ namespace Temporalio.Worker
                             // we're late-binding it here.
                             var running = new RunningTask();
                             runningTasks[task.Task.TaskToken] = running;
+                            var requestDeadline = task.RequestDeadline?.ToDateTime();
 #pragma warning disable CA2008 // We don't have to pass a scheduler, factory already implies one
                             running.Task = worker.Options.NexusTaskFactory.StartNew(
-                                () => HandlePollTaskAsync(running, task.Task)).Unwrap();
+                                () => HandlePollTaskAsync(running, task.Task, requestDeadline)).Unwrap();
 #pragma warning restore CA2008
                             break;
                         case NexusTask.VariantOneofCase.CancelTask:
@@ -141,12 +142,12 @@ namespace Temporalio.Worker
             headers.Remove("Request-Timeout");
         }
 
-        private async Task HandlePollTaskAsync(RunningTask running, PollNexusTaskQueueResponse task)
+        private async Task HandlePollTaskAsync(RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline)
         {
             try
             {
                 // Handle poll and post back to Core
-                var completion = await HandlePollTaskInternalAsync(running, task).ConfigureAwait(false);
+                var completion = await HandlePollTaskInternalAsync(running, task, requestDeadline).ConfigureAwait(false);
                 logger.LogTrace("Sending Nexus completion: {Completion}", completion);
                 await worker.BridgeWorker.CompleteNexusTaskAsync(completion).ConfigureAwait(false);
             }
@@ -165,7 +166,7 @@ namespace Temporalio.Worker
         }
 
         private async Task<StartOperationResponse> HandleStartOperationAsync(
-            RunningTask running, PollNexusTaskQueueResponse task)
+            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline)
         {
             // Create context
             RemoveInvalidHeaders(task.Request.Header);
@@ -195,6 +196,7 @@ namespace Temporalio.Worker
                             e);
                     }
                 }).ToList(),
+                RequestDeadline = requestDeadline,
             };
             running.OnCancelReason = reason => context.CancellationReason = reason;
 
@@ -253,7 +255,7 @@ namespace Temporalio.Worker
         }
 
         private async Task<CancelOperationResponse> HandleCancelOperationAsync(
-            RunningTask running, PollNexusTaskQueueResponse task)
+            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline)
         {
             // Create context
             RemoveInvalidHeaders(task.Request.Header);
@@ -266,6 +268,7 @@ namespace Temporalio.Worker
             {
                 Headers = task.Request.Header.Count == 0 ? null :
                     new Dictionary<string, string>(task.Request.Header, StringComparer.OrdinalIgnoreCase),
+                RequestDeadline = requestDeadline,
             };
             running.OnCancelReason = reason => context.CancellationReason = reason;
 
@@ -287,7 +290,7 @@ namespace Temporalio.Worker
         }
 
         private async Task<NexusTaskCompletion> HandlePollTaskInternalAsync(
-            RunningTask running, PollNexusTaskQueueResponse task)
+            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline)
         {
             try
             {
@@ -295,14 +298,14 @@ namespace Temporalio.Worker
                 switch (task.Request.VariantCase)
                 {
                     case Request.VariantOneofCase.StartOperation:
-                        var startResp = await HandleStartOperationAsync(running, task).ConfigureAwait(false);
+                        var startResp = await HandleStartOperationAsync(running, task, requestDeadline).ConfigureAwait(false);
                         return new()
                         {
                             TaskToken = task.TaskToken,
                             Completed = new() { StartOperation = startResp },
                         };
                     case Request.VariantOneofCase.CancelOperation:
-                        var cancelResp = await HandleCancelOperationAsync(running, task).ConfigureAwait(false);
+                        var cancelResp = await HandleCancelOperationAsync(running, task, requestDeadline).ConfigureAwait(false);
                         return new()
                         {
                             TaskToken = task.TaskToken,

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -302,6 +302,29 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    public async Task ExecuteNexusOperationAsync_RequestDeadline_SetOnContext()
+    {
+        var contextSource = new TaskCompletionSource<OperationStartContext>();
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new AsyncFuncStringService(
+                start: (ctx, input) =>
+                {
+                    contextSource.SetResult(ctx);
+                    return Task.FromResult(OperationStartResult.SyncResult($"Hello, {input}"));
+                }));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+        await RunInWorkflowAsync(workerOptions, async () =>
+        {
+            var result = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
+            Assert.Equal("Hello, some-name", result);
+        });
+        var ctx = await contextSource.Task;
+        // Server always sends a request timeout header, so the deadline should be set
+        Assert.NotNull(ctx.RequestDeadline);
+    }
+
+    [Fact]
     public async Task ExecuteNexusOperationAsync_OperationSummary_FoundInHistory()
     {
         string expectedSummary = "custom operation summary";


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Wire up deadline on Nexus context

## Why?
So handlers can know how long they can run for

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small, additive wiring change that passes a parsed deadline through existing Nexus task handling and adds a targeted test; it should only affect handler-visible context data.
> 
> **Overview**
> Propagates the server-provided Nexus `RequestDeadline` timestamp into handler contexts by parsing `NexusTask.RequestDeadline` and threading it through `HandlePollTask*` into both `OperationStartContext` and `OperationCancelContext`.
> 
> Adds a new worker test asserting that `ctx.RequestDeadline` is populated when executing a Nexus operation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b15134c73514dbf1b3041cf4656564cabc04f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->