### PR TITLE
generate apis from 1.13.0

### DIFF
--- a/src/Temporalio/Client/CloudService.Rpc.cs
+++ b/src/Temporalio/Client/CloudService.Rpc.cs
@@ -32,6 +32,17 @@ namespace Temporalio.Client
         }
 
         /// <summary>
+        /// Invoke CreateAccountAuditLogSink.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<CreateAccountAuditLogSinkResponse> CreateAccountAuditLogSinkAsync(CreateAccountAuditLogSinkRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("CreateAccountAuditLogSink", req, CreateAccountAuditLogSinkResponse.Parser, options);
+        }
+
+        /// <summary>
         /// Invoke CreateApiKey.
         /// </summary>
         /// <param name="req">Request for the call.</param>
@@ -40,6 +51,17 @@ namespace Temporalio.Client
         public Task<CreateApiKeyResponse> CreateApiKeyAsync(CreateApiKeyRequest req, RpcOptions? options = null)
         {
             return InvokeRpcAsync("CreateApiKey", req, CreateApiKeyResponse.Parser, options);
+        }
+
+        /// <summary>
+        /// Invoke CreateBillingReport.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<CreateBillingReportResponse> CreateBillingReportAsync(CreateBillingReportRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("CreateBillingReport", req, CreateBillingReportResponse.Parser, options);
         }
 
         /// <summary>
@@ -117,6 +139,17 @@ namespace Temporalio.Client
         public Task<CreateUserGroupResponse> CreateUserGroupAsync(CreateUserGroupRequest req, RpcOptions? options = null)
         {
             return InvokeRpcAsync("CreateUserGroup", req, CreateUserGroupResponse.Parser, options);
+        }
+
+        /// <summary>
+        /// Invoke DeleteAccountAuditLogSink.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<DeleteAccountAuditLogSinkResponse> DeleteAccountAuditLogSinkAsync(DeleteAccountAuditLogSinkRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("DeleteAccountAuditLogSink", req, DeleteAccountAuditLogSinkResponse.Parser, options);
         }
 
         /// <summary>
@@ -241,6 +274,28 @@ namespace Temporalio.Client
         }
 
         /// <summary>
+        /// Invoke GetAccountAuditLogSink.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<GetAccountAuditLogSinkResponse> GetAccountAuditLogSinkAsync(GetAccountAuditLogSinkRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("GetAccountAuditLogSink", req, GetAccountAuditLogSinkResponse.Parser, options);
+        }
+
+        /// <summary>
+        /// Invoke GetAccountAuditLogSinks.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<GetAccountAuditLogSinksResponse> GetAccountAuditLogSinksAsync(GetAccountAuditLogSinksRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("GetAccountAuditLogSinks", req, GetAccountAuditLogSinksResponse.Parser, options);
+        }
+
+        /// <summary>
         /// Invoke GetApiKey.
         /// </summary>
         /// <param name="req">Request for the call.</param>
@@ -274,6 +329,28 @@ namespace Temporalio.Client
         }
 
         /// <summary>
+        /// Invoke GetAuditLogs.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<GetAuditLogsResponse> GetAuditLogsAsync(GetAuditLogsRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("GetAuditLogs", req, GetAuditLogsResponse.Parser, options);
+        }
+
+        /// <summary>
+        /// Invoke GetBillingReport.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<GetBillingReportResponse> GetBillingReportAsync(GetBillingReportRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("GetBillingReport", req, GetBillingReportResponse.Parser, options);
+        }
+
+        /// <summary>
         /// Invoke GetConnectivityRule.
         /// </summary>
         /// <param name="req">Request for the call.</param>
@@ -296,6 +373,17 @@ namespace Temporalio.Client
         }
 
         /// <summary>
+        /// Invoke GetCurrentIdentity.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<GetCurrentIdentityResponse> GetCurrentIdentityAsync(GetCurrentIdentityRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("GetCurrentIdentity", req, GetCurrentIdentityResponse.Parser, options);
+        }
+
+        /// <summary>
         /// Invoke GetNamespace.
         /// </summary>
         /// <param name="req">Request for the call.</param>
@@ -304,6 +392,17 @@ namespace Temporalio.Client
         public Task<GetNamespaceResponse> GetNamespaceAsync(GetNamespaceRequest req, RpcOptions? options = null)
         {
             return InvokeRpcAsync("GetNamespace", req, GetNamespaceResponse.Parser, options);
+        }
+
+        /// <summary>
+        /// Invoke GetNamespaceCapacityInfo.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<GetNamespaceCapacityInfoResponse> GetNamespaceCapacityInfoAsync(GetNamespaceCapacityInfoRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("GetNamespaceCapacityInfo", req, GetNamespaceCapacityInfoResponse.Parser, options);
         }
 
         /// <summary>
@@ -535,6 +634,17 @@ namespace Temporalio.Client
         public Task<UpdateAccountResponse> UpdateAccountAsync(UpdateAccountRequest req, RpcOptions? options = null)
         {
             return InvokeRpcAsync("UpdateAccount", req, UpdateAccountResponse.Parser, options);
+        }
+
+        /// <summary>
+        /// Invoke UpdateAccountAuditLogSink.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<UpdateAccountAuditLogSinkResponse> UpdateAccountAuditLogSinkAsync(UpdateAccountAuditLogSinkRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("UpdateAccountAuditLogSink", req, UpdateAccountAuditLogSinkResponse.Parser, options);
         }
 
         /// <summary>

--- a/src/Temporalio/Client/WorkflowService.Rpc.cs
+++ b/src/Temporalio/Client/WorkflowService.Rpc.cs
@@ -21,6 +21,17 @@ namespace Temporalio.Client
         }
 
         /// <summary>
+        /// Invoke CountSchedules.
+        /// </summary>
+        /// <param name="req">Request for the call.</param>
+        /// <param name="options">Optional RPC options.</param>
+        /// <returns>RPC response</returns>
+        public Task<CountSchedulesResponse> CountSchedulesAsync(CountSchedulesRequest req, RpcOptions? options = null)
+        {
+            return InvokeRpcAsync("CountSchedules", req, CountSchedulesResponse.Parser, options);
+        }
+
+        /// <summary>
         /// Invoke CountWorkflowExecutions.
         /// </summary>
         /// <param name="req">Request for the call.</param>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I ran `dotnet run --project src/Temporalio.Api.Generator` to add the new cloud service endpoints

## Why?
<!-- Tell your future self why have you made these changes -->

Users want to be able to use the new cloud service endpoints like `GetAuditLogs` and `GetBillingReport` without having to maintain a fork now that the official repository has the protobuf definitions, since protobuf messages are global and the cloud protobuf messages are packaged in the `Temporalio` assembly

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
auto-generated code added, routine activity

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
no