### PR TITLE
Expose Nexus Endpoint in a Nexus Operation Handler

### DIFF
--- a/src/Temporalio/Bridge/Api/Nexus/Nexus.cs
+++ b/src/Temporalio/Bridge/Api/Nexus/Nexus.cs
@@ -41,25 +41,26 @@ namespace Temporalio.Bridge.Api.Nexus {
             "djEuUmVzcG9uc2VIABI4CgVlcnJvchgDIAEoCzIjLnRlbXBvcmFsLmFwaS5u",
             "ZXh1cy52MS5IYW5kbGVyRXJyb3JCAhgBSAASFAoKYWNrX2NhbmNlbBgEIAEo",
             "CEgAEjMKB2ZhaWx1cmUYBSABKAsyIC50ZW1wb3JhbC5hcGkuZmFpbHVyZS52",
-            "MS5GYWlsdXJlSABCCAoGc3RhdHVzItABCglOZXh1c1Rhc2sSSwoEdGFzaxgB",
+            "MS5GYWlsdXJlSABCCAoGc3RhdHVzIuIBCglOZXh1c1Rhc2sSSwoEdGFzaxgB",
             "IAEoCzI7LnRlbXBvcmFsLmFwaS53b3JrZmxvd3NlcnZpY2UudjEuUG9sbE5l",
             "eHVzVGFza1F1ZXVlUmVzcG9uc2VIABI1CgtjYW5jZWxfdGFzaxgCIAEoCzIe",
             "LmNvcmVzZGsubmV4dXMuQ2FuY2VsTmV4dXNUYXNrSAASNAoQcmVxdWVzdF9k",
-            "ZWFkbGluZRgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBCCQoH",
-            "dmFyaWFudCJbCg9DYW5jZWxOZXh1c1Rhc2sSEgoKdGFza190b2tlbhgBIAEo",
-            "DBI0CgZyZWFzb24YAiABKA4yJC5jb3Jlc2RrLm5leHVzLk5leHVzVGFza0Nh",
-            "bmNlbFJlYXNvbio7ChVOZXh1c1Rhc2tDYW5jZWxSZWFzb24SDQoJVElNRURf",
-            "T1VUEAASEwoPV09SS0VSX1NIVVRET1dOEAEqfwoeTmV4dXNPcGVyYXRpb25D",
-            "YW5jZWxsYXRpb25UeXBlEh8KG1dBSVRfQ0FOQ0VMTEFUSU9OX0NPTVBMRVRF",
-            "RBAAEgsKB0FCQU5ET04QARIOCgpUUllfQ0FOQ0VMEAISHwobV0FJVF9DQU5D",
-            "RUxMQVRJT05fUkVRVUVTVEVEEANCK+oCKFRlbXBvcmFsaW86OkludGVybmFs",
-            "OjpCcmlkZ2U6OkFwaTo6TmV4dXNiBnByb3RvMw=="));
+            "ZWFkbGluZRgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASEAoI",
+            "ZW5kcG9pbnQYBCABKAlCCQoHdmFyaWFudCJbCg9DYW5jZWxOZXh1c1Rhc2sS",
+            "EgoKdGFza190b2tlbhgBIAEoDBI0CgZyZWFzb24YAiABKA4yJC5jb3Jlc2Rr",
+            "Lm5leHVzLk5leHVzVGFza0NhbmNlbFJlYXNvbio7ChVOZXh1c1Rhc2tDYW5j",
+            "ZWxSZWFzb24SDQoJVElNRURfT1VUEAASEwoPV09SS0VSX1NIVVRET1dOEAEq",
+            "fwoeTmV4dXNPcGVyYXRpb25DYW5jZWxsYXRpb25UeXBlEh8KG1dBSVRfQ0FO",
+            "Q0VMTEFUSU9OX0NPTVBMRVRFRBAAEgsKB0FCQU5ET04QARIOCgpUUllfQ0FO",
+            "Q0VMEAISHwobV0FJVF9DQU5DRUxMQVRJT05fUkVRVUVTVEVEEANCK+oCKFRl",
+            "bXBvcmFsaW86OkludGVybmFsOjpCcmlkZ2U6OkFwaTo6TmV4dXNiBnByb3Rv",
+            "Mw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Temporalio.Api.Common.V1.MessageReflection.Descriptor, global::Temporalio.Api.Failure.V1.MessageReflection.Descriptor, global::Temporalio.Api.Nexus.V1.MessageReflection.Descriptor, global::Temporalio.Api.WorkflowService.V1.RequestResponseReflection.Descriptor, global::Temporalio.Bridge.Api.Common.CommonReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Temporalio.Bridge.Api.Nexus.NexusTaskCancelReason), typeof(global::Temporalio.Bridge.Api.Nexus.NexusOperationCancellationType), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Temporalio.Bridge.Api.Nexus.NexusOperationResult), global::Temporalio.Bridge.Api.Nexus.NexusOperationResult.Parser, new[]{ "Completed", "Failed", "Cancelled", "TimedOut" }, new[]{ "Status" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Temporalio.Bridge.Api.Nexus.NexusTaskCompletion), global::Temporalio.Bridge.Api.Nexus.NexusTaskCompletion.Parser, new[]{ "TaskToken", "Completed", "Error", "AckCancel", "Failure" }, new[]{ "Status" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Temporalio.Bridge.Api.Nexus.NexusTask), global::Temporalio.Bridge.Api.Nexus.NexusTask.Parser, new[]{ "Task", "CancelTask", "RequestDeadline" }, new[]{ "Variant" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Temporalio.Bridge.Api.Nexus.NexusTask), global::Temporalio.Bridge.Api.Nexus.NexusTask.Parser, new[]{ "Task", "CancelTask", "RequestDeadline", "Endpoint" }, new[]{ "Variant" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Temporalio.Bridge.Api.Nexus.CancelNexusTask), global::Temporalio.Bridge.Api.Nexus.CancelNexusTask.Parser, new[]{ "TaskToken", "Reason" }, null, null, null, null)
           }));
     }
@@ -986,6 +987,7 @@ namespace Temporalio.Bridge.Api.Nexus {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public NexusTask(NexusTask other) : this() {
       requestDeadline_ = other.requestDeadline_ != null ? other.requestDeadline_.Clone() : null;
+      endpoint_ = other.endpoint_;
       switch (other.VariantCase) {
         case VariantOneofCase.Task:
           Task = other.Task.Clone();
@@ -1061,6 +1063,22 @@ namespace Temporalio.Bridge.Api.Nexus {
       }
     }
 
+    /// <summary>Field number for the "endpoint" field.</summary>
+    public const int EndpointFieldNumber = 4;
+    private string endpoint_ = "";
+    /// <summary>
+    /// The endpoint this request was addressed to. Extracted from the request for convenient access.
+    /// Only set when variant is `task`.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Endpoint {
+      get { return endpoint_; }
+      set {
+        endpoint_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     private object variant_;
     /// <summary>Enum of possible cases for the "variant" oneof.</summary>
     public enum VariantOneofCase {
@@ -1100,6 +1118,7 @@ namespace Temporalio.Bridge.Api.Nexus {
       if (!object.Equals(Task, other.Task)) return false;
       if (!object.Equals(CancelTask, other.CancelTask)) return false;
       if (!object.Equals(RequestDeadline, other.RequestDeadline)) return false;
+      if (Endpoint != other.Endpoint) return false;
       if (VariantCase != other.VariantCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -1111,6 +1130,7 @@ namespace Temporalio.Bridge.Api.Nexus {
       if (variantCase_ == VariantOneofCase.Task) hash ^= Task.GetHashCode();
       if (variantCase_ == VariantOneofCase.CancelTask) hash ^= CancelTask.GetHashCode();
       if (requestDeadline_ != null) hash ^= RequestDeadline.GetHashCode();
+      if (Endpoint.Length != 0) hash ^= Endpoint.GetHashCode();
       hash ^= (int) variantCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -1142,6 +1162,10 @@ namespace Temporalio.Bridge.Api.Nexus {
         output.WriteRawTag(26);
         output.WriteMessage(RequestDeadline);
       }
+      if (Endpoint.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(Endpoint);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1164,6 +1188,10 @@ namespace Temporalio.Bridge.Api.Nexus {
         output.WriteRawTag(26);
         output.WriteMessage(RequestDeadline);
       }
+      if (Endpoint.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(Endpoint);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1183,6 +1211,9 @@ namespace Temporalio.Bridge.Api.Nexus {
       if (requestDeadline_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(RequestDeadline);
       }
+      if (Endpoint.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Endpoint);
+      }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -1200,6 +1231,9 @@ namespace Temporalio.Bridge.Api.Nexus {
           RequestDeadline = new global::Google.Protobuf.WellKnownTypes.Timestamp();
         }
         RequestDeadline.MergeFrom(other.RequestDeadline);
+      }
+      if (other.Endpoint.Length != 0) {
+        Endpoint = other.Endpoint;
       }
       switch (other.VariantCase) {
         case VariantOneofCase.Task:
@@ -1256,6 +1290,10 @@ namespace Temporalio.Bridge.Api.Nexus {
             input.ReadMessage(RequestDeadline);
             break;
           }
+          case 34: {
+            Endpoint = input.ReadString();
+            break;
+          }
         }
       }
     #endif
@@ -1294,6 +1332,10 @@ namespace Temporalio.Bridge.Api.Nexus {
               RequestDeadline = new global::Google.Protobuf.WellKnownTypes.Timestamp();
             }
             input.ReadMessage(RequestDeadline);
+            break;
+          }
+          case 34: {
+            Endpoint = input.ReadString();
             break;
           }
         }

--- a/src/Temporalio/Nexus/NexusOperationInfo.cs
+++ b/src/Temporalio/Nexus/NexusOperationInfo.cs
@@ -5,8 +5,10 @@ namespace Temporalio.Nexus
     /// </summary>
     /// <param name="Namespace">Current namespace.</param>
     /// <param name="TaskQueue">Current task queue.</param>
+    /// <param name="Endpoint">Endpoint this request was addressed to.</param>
     /// <remarks>WARNING: Nexus support is experimental.</remarks>
     public record NexusOperationInfo(
         string Namespace,
-        string TaskQueue);
+        string TaskQueue,
+        string Endpoint);
 }

--- a/src/Temporalio/Worker/NexusWorker.cs
+++ b/src/Temporalio/Worker/NexusWorker.cs
@@ -45,7 +45,6 @@ namespace Temporalio.Worker
         private readonly TemporalWorker worker;
         private readonly ILogger logger;
         private readonly Handler handler;
-        private readonly NexusOperationInfo operationInfo;
         private readonly ConcurrentDictionary<ByteString, RunningTask> runningTasks = new();
 
         /// <summary>
@@ -68,7 +67,6 @@ namespace Temporalio.Worker
                 worker.Options.NexusServices,
                 new NexusPayloadSerializer(worker.Client.Options.DataConverter),
                 middleware);
-            operationInfo = new(worker.Client.Options.Namespace, worker.Options.TaskQueue!);
         }
 
         /// <summary>
@@ -102,7 +100,7 @@ namespace Temporalio.Worker
                             var requestDeadline = task.RequestDeadline?.ToDateTime();
 #pragma warning disable CA2008 // We don't have to pass a scheduler, factory already implies one
                             running.Task = worker.Options.NexusTaskFactory.StartNew(
-                                () => HandlePollTaskAsync(running, task.Task, requestDeadline)).Unwrap();
+                                () => HandlePollTaskAsync(running, task.Task, requestDeadline, task.Endpoint)).Unwrap();
 #pragma warning restore CA2008
                             break;
                         case NexusTask.VariantOneofCase.CancelTask:
@@ -142,12 +140,12 @@ namespace Temporalio.Worker
             headers.Remove("Request-Timeout");
         }
 
-        private async Task HandlePollTaskAsync(RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline)
+        private async Task HandlePollTaskAsync(RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline, string endpoint)
         {
             try
             {
                 // Handle poll and post back to Core
-                var completion = await HandlePollTaskInternalAsync(running, task, requestDeadline).ConfigureAwait(false);
+                var completion = await HandlePollTaskInternalAsync(running, task, requestDeadline, endpoint).ConfigureAwait(false);
                 logger.LogTrace("Sending Nexus completion: {Completion}", completion);
                 await worker.BridgeWorker.CompleteNexusTaskAsync(completion).ConfigureAwait(false);
             }
@@ -166,7 +164,7 @@ namespace Temporalio.Worker
         }
 
         private async Task<StartOperationResponse> HandleStartOperationAsync(
-            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline)
+            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline, string endpoint)
         {
             // Create context
             RemoveInvalidHeaders(task.Request.Header);
@@ -201,7 +199,7 @@ namespace Temporalio.Worker
             running.OnCancelReason = reason => context.CancellationReason = reason;
 
             // Start operation
-            NexusOperationExecutionContext.AsyncLocalCurrent.Value = NewExecutionContext(context);
+            NexusOperationExecutionContext.AsyncLocalCurrent.Value = NewExecutionContext(context, endpoint);
             try
             {
                 var result = await handler.StartOperationAsync(
@@ -255,7 +253,7 @@ namespace Temporalio.Worker
         }
 
         private async Task<CancelOperationResponse> HandleCancelOperationAsync(
-            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline)
+            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline, string endpoint)
         {
             // Create context
             RemoveInvalidHeaders(task.Request.Header);
@@ -273,7 +271,7 @@ namespace Temporalio.Worker
             running.OnCancelReason = reason => context.CancellationReason = reason;
 
             // Cancel operation
-            NexusOperationExecutionContext.AsyncLocalCurrent.Value = NewExecutionContext(context);
+            NexusOperationExecutionContext.AsyncLocalCurrent.Value = NewExecutionContext(context, endpoint);
             try
             {
                 await handler.CancelOperationAsync(context).ConfigureAwait(false);
@@ -290,7 +288,7 @@ namespace Temporalio.Worker
         }
 
         private async Task<NexusTaskCompletion> HandlePollTaskInternalAsync(
-            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline)
+            RunningTask running, PollNexusTaskQueueResponse task, DateTime? requestDeadline, string endpoint)
         {
             try
             {
@@ -298,14 +296,14 @@ namespace Temporalio.Worker
                 switch (task.Request.VariantCase)
                 {
                     case Request.VariantOneofCase.StartOperation:
-                        var startResp = await HandleStartOperationAsync(running, task, requestDeadline).ConfigureAwait(false);
+                        var startResp = await HandleStartOperationAsync(running, task, requestDeadline, endpoint).ConfigureAwait(false);
                         return new()
                         {
                             TaskToken = task.TaskToken,
                             Completed = new() { StartOperation = startResp },
                         };
                     case Request.VariantOneofCase.CancelOperation:
-                        var cancelResp = await HandleCancelOperationAsync(running, task, requestDeadline).ConfigureAwait(false);
+                        var cancelResp = await HandleCancelOperationAsync(running, task, requestDeadline, endpoint).ConfigureAwait(false);
                         return new()
                         {
                             TaskToken = task.TaskToken,
@@ -330,10 +328,10 @@ namespace Temporalio.Worker
             }
         }
 
-        private NexusOperationExecutionContext NewExecutionContext(OperationContext handlerContext) =>
+        private NexusOperationExecutionContext NewExecutionContext(OperationContext handlerContext, string endpoint) =>
             new(
                 handlerContext: handlerContext,
-                info: operationInfo,
+                info: new(worker.Client.Options.Namespace, worker.Options.TaskQueue!, endpoint),
                 logger: worker.LoggerFactory.CreateLogger($"Temporalio.Nexus:{handlerContext.Operation}"),
                 runtimeMetricMeter: worker.MetricMeter,
                 temporalClient: worker.Client as ITemporalClient);

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -101,6 +101,22 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         }
     }
 
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_ContextHasEndpoint()
+    {
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) =>
+                    NexusOperationExecutionContext.Current.Info.Endpoint)));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+        await RunInWorkflowAsync(workerOptions, async () =>
+        {
+            var result = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
+            Assert.Equal(endpoint, result);
+        });
+    }
+
     [Workflow]
     public class SimpleWorkflow
     {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose the Nexus Endpoint to the SDK.

## Why?
So the handler knows what endpoint the request originally came from for visibility and per endpoint encryption

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

closes https://github.com/temporalio/sdk-dotnet/issues/642

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `endpoint` field to the Nexus bridge task proto and threads it through Nexus worker execution context; while additive, it touches the poll/dispatch path and generated proto code, so regressions could affect Nexus task handling.
> 
> **Overview**
> Exposes the Nexus *endpoint name* to operation handlers by adding `Endpoint` to `NexusOperationInfo` and populating it in `NexusWorker` when creating `NexusOperationExecutionContext` for both start and cancel requests.
> 
> Updates the bridge `NexusTask` proto (`Nexus.cs`) to carry an `endpoint` string alongside the polled task, and adds a unit test asserting `NexusOperationExecutionContext.Current.Info.Endpoint` matches the invoked endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee11fe1d90eb1424c035d95655e7c37d1b79e5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->