### PR TITLE
Suppress GHSA-g94r-2vxg-569j to unblock builds

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  <!-- Suppress until OpenTelemetry.Api is updated to 1.5.3 -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g94r-2vxg-569j" />
+  </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="Google.Protobuf" Version="3.26.1" />


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Suppress GHSA-g94r-2vxg-569j to unblock builds for now. https://github.com/temporalio/sdk-dotnet/pull/652 was opened to address the need to update the affected packages.

## Why?

Get builds moving again.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: PR
1. Any docs updates needed? No
