### PR TITLE
Treat non-critical vulnerabilities as warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/temporalio/sdk-dotnet</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Treat all non-critical vulnerabilities as warnings. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903</WarningsNotAsErrors>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>

--- a/src/Temporalio.ApiDoc/docfx.json
+++ b/src/Temporalio.ApiDoc/docfx.json
@@ -21,6 +21,9 @@
       "disableGitFeatures": false,
       "disableDefaultFilter": false,
       "noRestore": false,
+      "properties": {
+        "NuGetAudit": "false"
+      },
       "namespaceLayout": "nested",
       "memberLayout": "samePage",
       "allowCompilationErrors": false


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Treat all non-critical NuGet vulnerabilities as warnings instead of errors to allow builds to proceed.
