### PR TITLE
ci(test-reports): add test reports to PR checks. this also fixes an issue where test reports were not being uploaded as artifacts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           dotnet test --logger "console;verbosity=detailed" --logger "trx;LogFilePrefix=test-results" --results-directory tests/Temporalio.Tests/TestResults --blame-crash -v m --blame-hang-timeout 10m
 
       - name: Upload test results
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: test-results-${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,16 @@ jobs:
         run: dotnet build
 
       - name: Test
-        run: dotnet test --logger "console;verbosity=detailed" --blame-crash -v n --blame-hang-timeout 10m
+        run: |
+          dotnet test --logger "console;verbosity=detailed" --logger "trx;LogFilePrefix=test-results" --results-directory tests/Temporalio.Tests/TestResults --blame-crash -v m --blame-hang-timeout 10m
 
-      - name: Upload test failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - name: Upload test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: test-fail-${{ matrix.os }}
-          path: tests/Temporalio.Tests/TestResults
+          name: test-results-${{ matrix.os }}
+          path: tests/Temporalio.Tests/TestResults/**/*.trx
+          if-no-files-found: warn
 
       - name: Confirm bench works
         run: dotnet run --project tests/Temporalio.SimpleBench/Temporalio.SimpleBench.csproj -- --workflow-count 5 --max-cached-workflows 100 --max-concurrent 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-results-${{ matrix.os }}
           path: tests/Temporalio.Tests/TestResults/**/*.trx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Test
         run: |
-          dotnet test --logger "console;verbosity=detailed" --logger "trx;LogFilePrefix=test-results" --results-directory tests/Temporalio.Tests/TestResults --blame-crash -v m --blame-hang-timeout 10m
+          dotnet test --logger "console;verbosity=detailed" --logger "trx;LogFilePrefix=test-results" --results-directory tests/Temporalio.Tests/TestResults --blame-crash -v n --blame-hang-timeout 10m
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,25 @@
+name: Test Report
+on:
+  workflow_run:
+    workflows:
+      - Continuous Integration
+    types:
+      - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Report
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        with:
+          artifact: /test-results-(.*)/
+          name: Test Results ($1)
+          path: '**/*.trx'
+          reporter: dotnet-trx
+          use-actions-summary: 'false'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Add checks that summarize test reports.
- Fix test report artifact uploading.

<img width="1022" height="482" alt="Screenshot 2026-04-29 at 7 10 57 PM" src="https://github.com/user-attachments/assets/e0153de6-b315-4b0e-8387-503209203604" />

## Why?
- Previously, it was difficulty to find what had actually failed in the logs. Now, failures are explicitly surfaced and easily discoverable.

## Checklist

1. This will not run until the new workflow hits `main`.
2. The new test-report workflow is completely separate from the existing ci workflow to restrict permissions.