### PR TITLE
CaN USE_RAMPING_VERSION versioning behaviour

### DIFF
--- a/src/Temporalio/Workflows/ContinueAsNewOptions.cs
+++ b/src/Temporalio/Workflows/ContinueAsNewOptions.cs
@@ -56,7 +56,9 @@ namespace Temporalio.Workflows
         /// Gets or sets the versioning behavior for the first task of the new workflow run.
         /// For example, set to <see cref="Workflows.InitialVersioningBehavior.AutoUpgrade" /> to
         /// upgrade to the latest version on continue-as-new instead of inheriting the pinned
-        /// version from the previous run.
+        /// version from the previous run, or
+        /// <see cref="Workflows.InitialVersioningBehavior.UseRampingVersion" /> to use the current
+        /// ramping version for the first workflow task.
         /// </summary>
         /// <remarks>WARNING: Worker deployment based versioning is currently experimental.</remarks>
         public InitialVersioningBehavior? InitialVersioningBehavior { get; set; }

--- a/src/Temporalio/Workflows/InitialVersioningBehavior.cs
+++ b/src/Temporalio/Workflows/InitialVersioningBehavior.cs
@@ -19,5 +19,22 @@ namespace Temporalio.Workflows
         /// workflow code.
         /// </summary>
         AutoUpgrade = Temporalio.Api.Enums.V1.ContinueAsNewVersioningBehavior.AutoUpgrade,
+
+        /// <summary>
+        /// Use the Ramping Version of the workflow's task queue at start time, regardless of the
+        /// workflow's Target Version. After the first workflow task completes, use whatever
+        /// Versioning Behavior the workflow is annotated with in the workflow code. If there is no
+        /// Ramping Version when the first workflow task is dispatched, the task goes to the Current
+        /// Version.
+        /// <para>
+        /// This is discouraged for workflows annotated with AutoUpgrade behavior because this
+        /// setting only applies to the first task of the new run.
+        /// </para>
+        /// <para>
+        /// If the workflow being continued has a Pinned override, that override is inherited by the
+        /// new run regardless of this setting.
+        /// </para>
+        /// </summary>
+        UseRampingVersion = Temporalio.Api.Enums.V1.ContinueAsNewVersioningBehavior.UseRampingVersion,
     }
 }

--- a/tests/Temporalio.Tests/TestUtils.cs
+++ b/tests/Temporalio.Tests/TestUtils.cs
@@ -291,7 +291,8 @@ public static class TestUtils
     public static async Task WaitForRoutingConfigPropagationAsync(
         ITemporalClient client,
         string deploymentName,
-        string expectedCurrentBuildId)
+        string expectedCurrentBuildId,
+        string? expectedRampingBuildId = null)
     {
         await AssertMore.EventuallyAsync(async () =>
         {
@@ -306,6 +307,11 @@ public static class TestUtils
             Assert.NotNull(info.RoutingConfig);
             Assert.NotNull(info.RoutingConfig.CurrentDeploymentVersion);
             Assert.Equal(expectedCurrentBuildId, info.RoutingConfig.CurrentDeploymentVersion.BuildId);
+            if (expectedRampingBuildId != null)
+            {
+                Assert.NotNull(info.RoutingConfig.RampingDeploymentVersion);
+                Assert.Equal(expectedRampingBuildId, info.RoutingConfig.RampingDeploymentVersion.BuildId);
+            }
             Assert.NotEqual(
                 Temporalio.Api.Enums.V1.RoutingConfigUpdateState.InProgress,
                 info.RoutingConfigUpdateState);

--- a/tests/Temporalio.Tests/Worker/WorkerDeploymentVersioningTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkerDeploymentVersioningTests.cs
@@ -563,6 +563,43 @@ public class WorkerDeploymentVersioningTests : WorkflowEnvironmentTestBase
         }
     }
 
+    [Workflow("CanRampingVersionWorkflow", VersioningBehavior = VersioningBehavior.Pinned)]
+    public class CanRampingVersionWorkflowV1
+    {
+        private bool continueAsNew;
+
+        [WorkflowRun]
+        public async Task<string> RunAsync(int attempt)
+        {
+            if (attempt > 0)
+            {
+                return "v1.0";
+            }
+
+            await Workflow.WaitConditionAsync(() => continueAsNew);
+
+            throw Workflow.CreateContinueAsNewException(
+                (CanRampingVersionWorkflowV1 wf) => wf.RunAsync(attempt + 1),
+                new ContinueAsNewOptions
+                {
+                    InitialVersioningBehavior = InitialVersioningBehavior.UseRampingVersion,
+                });
+        }
+
+        [WorkflowSignal]
+        public async Task ContinueAsNewAsync() => continueAsNew = true;
+    }
+
+    [Workflow("CanRampingVersionWorkflow", VersioningBehavior = VersioningBehavior.Pinned)]
+    public class CanRampingVersionWorkflowV2
+    {
+        [WorkflowRun]
+        public async Task<string> RunAsync(int attempt)
+        {
+            return "v2.0";
+        }
+    }
+
     [Fact]
     public async Task ContinueAsNew_WithVersionUpgrade_MovesToNewVersion()
     {
@@ -611,6 +648,58 @@ public class WorkerDeploymentVersioningTests : WorkflowEnvironmentTestBase
 
             // The v1 workflow should detect the version change, CAN with AUTO_UPGRADE,
             // and the new run should execute on v2
+            var result = await handle.GetResultAsync();
+            Assert.Equal("v2.0", result);
+        }
+    }
+
+    [Fact]
+    public async Task ContinueAsNew_WithRampingVersion_MovesToRampingVersion()
+    {
+        var deploymentName = $"deployment-can-ramp-{Guid.NewGuid()}";
+        var v1 = new WorkerDeploymentVersion(deploymentName, "1.0");
+        var v2 = new WorkerDeploymentVersion(deploymentName, "2.0");
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+
+        using var worker1 = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions(taskQueue)
+            {
+                DeploymentOptions = new(v1, true),
+            }.AddWorkflow<CanRampingVersionWorkflowV1>());
+
+        using var worker2 = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions(taskQueue)
+            {
+                DeploymentOptions = new(v2, true),
+            }.AddWorkflow<CanRampingVersionWorkflowV2>());
+
+        var testTask = ExecuteTest();
+        await Task.WhenAll(
+            worker1.ExecuteAsync(() => testTask),
+            worker2.ExecuteAsync(() => testTask));
+
+        async Task ExecuteTest()
+        {
+            var describe1 = await TestUtils.WaitUntilWorkerDeploymentVisibleAsync(Client, v1);
+            var currentResponse = await TestUtils.SetCurrentDeploymentVersionAsync(
+                Client, describe1.ConflictToken, v1);
+            await TestUtils.WaitForRoutingConfigPropagationAsync(Client, deploymentName, v1.BuildId);
+
+            var handle = await Client.StartWorkflowAsync(
+                (CanRampingVersionWorkflowV1 wf) => wf.RunAsync(0),
+                new(id: $"can-ramping-version-{Guid.NewGuid()}", taskQueue: taskQueue));
+
+            await TestUtils.WaitForWorkflowRunningOnVersionAsync(Client, handle.Id, v1.BuildId);
+
+            await TestUtils.WaitUntilWorkerDeploymentVisibleAsync(Client, v2);
+            await TestUtils.SetRampingVersionAsync(Client, currentResponse.ConflictToken, v2, 0);
+            await TestUtils.WaitForRoutingConfigPropagationAsync(
+                Client, deploymentName, v1.BuildId, v2.BuildId);
+
+            await handle.SignalAsync(wf => wf.ContinueAsNewAsync());
+
             var result = await handle.GetResultAsync();
             Assert.Equal("v2.0", result);
         }

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -67,7 +67,7 @@ public class WorkflowEnvironment : IAsyncLifetime
             {
                 DevServerOptions = new()
                 {
-                    DownloadVersion = "v1.6.2-server-1.31.0-151.6",
+                    DownloadVersion = "v1.7.0",
                     ExtraArgs = new List<string>
                     {
                         // Disable search attribute cache


### PR DESCRIPTION
## What was changed
DWISOTT  - adds UseRampingVersion as a CaN versioning option

## Why?
support new versioning option


1. Part of https://github.com/temporalio/features/issues/807

How was this tested:
Added integration test

Any docs updates needed?
Maybe ?