### PR TITLE
expose DnsLoadBalancingOptions

### DIFF
--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -188,6 +188,15 @@ namespace Temporalio.Bridge.Interop
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal unsafe delegate void TemporalCoreClientGrpcOverrideCallback([NativeTypeName("struct TemporalCoreClientGrpcOverrideRequest *")] TemporalCoreClientGrpcOverrideRequest* request, void* user_data);
 
+    internal partial struct TemporalCoreClientDnsLoadBalancingOptions
+    {
+        [NativeTypeName("bool")]
+        public byte enabled;
+
+        [NativeTypeName("uint64_t")]
+        public ulong resolution_interval_millis;
+    }
+
     internal unsafe partial struct TemporalCoreConnectionOptions
     {
         [NativeTypeName("struct TemporalCoreByteArrayRef")]
@@ -227,6 +236,9 @@ namespace Temporalio.Bridge.Interop
         public IntPtr grpc_override_callback;
 
         public void* grpc_override_callback_user_data;
+
+        [NativeTypeName("const struct TemporalCoreClientDnsLoadBalancingOptions *")]
+        public TemporalCoreClientDnsLoadBalancingOptions* dns_load_balancing_options;
     }
 
     internal unsafe partial struct TemporalCoreByteArray

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -279,6 +279,10 @@ namespace Temporalio.Bridge
                     options.HttpConnectProxy == null
                         ? null
                         : scope.Pointer(options.HttpConnectProxy.ToInteropOptions(scope)),
+                dns_load_balancing_options =
+                    options.DnsLoadBalancing == null
+                        ? null
+                        : scope.Pointer(options.DnsLoadBalancing.ToInteropOptions()),
             };
         }
 
@@ -342,6 +346,19 @@ namespace Temporalio.Bridge
             {
                 interval_millis = (ulong)options.Interval.TotalMilliseconds,
                 timeout_millis = (ulong)options.Timeout.TotalMilliseconds,
+            };
+
+        /// <summary>
+        /// Convert DNS load balancing options.
+        /// </summary>
+        /// <param name="options">Options to convert.</param>
+        /// <returns>Converted options.</returns>
+        public static Interop.TemporalCoreClientDnsLoadBalancingOptions ToInteropOptions(
+            this Temporalio.Client.DnsLoadBalancingOptions options) =>
+            new()
+            {
+                enabled = (byte)(options.Enabled ? 1 : 0),
+                resolution_interval_millis = (ulong)options.ResolutionInterval.TotalMilliseconds,
             };
 
         /// <summary>

--- a/src/Temporalio/Client/DnsLoadBalancingOptions.cs
+++ b/src/Temporalio/Client/DnsLoadBalancingOptions.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Temporalio.Client
+{
+    /// <summary>
+    /// DNS-based load balancing options for Temporal connections.
+    /// </summary>
+    public class DnsLoadBalancingOptions : ICloneable
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether DNS-based load balancing is enabled.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets how often to re-resolve DNS.
+        /// </summary>
+        public TimeSpan ResolutionInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Create a shallow copy of these options.
+        /// </summary>
+        /// <returns>A shallow copy of these options.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -67,6 +67,18 @@ namespace Temporalio.Client
         public HttpConnectProxyOptions? HttpConnectProxy { get; set; }
 
         /// <summary>
+        /// Gets or sets DNS-based load balancing options for this connection.
+        /// </summary>
+        /// <remarks>
+        /// Default null, which uses Core's defaults (enabled with a 30 second resolution
+        /// interval). To disable, set this to a <see cref="DnsLoadBalancingOptions"/>
+        /// with <see cref="DnsLoadBalancingOptions.Enabled"/> set to false. DNS load
+        /// balancing is automatically disabled when <see cref="HttpConnectProxy"/> is
+        /// configured.
+        /// </remarks>
+        public DnsLoadBalancingOptions? DnsLoadBalancing { get; set; }
+
+        /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).
         /// </summary>
         /// <remarks>
@@ -134,6 +146,10 @@ namespace Temporalio.Client
             if (KeepAlive != null)
             {
                 copy.KeepAlive = (KeepAliveOptions)KeepAlive.Clone();
+            }
+            if (DnsLoadBalancing != null)
+            {
+                copy.DnsLoadBalancing = (DnsLoadBalancingOptions)DnsLoadBalancing.Clone();
             }
             return copy;
         }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

https://github.com/temporalio/sdk-rust/issues/1250

DNS load balancing was introduced in https://github.com/temporalio/sdk-rust/pull/1212, and it defaults to enabled for users of the C bridge.

These options should be exposed through the C bridge, so that users of the C bridge, such as .NET SDK users, can configure DNS load balancing.

## Why?
<!-- Tell your future self why have you made these changes -->

.NET users want to be able to change the DNS load balancing options of the gRPC client

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I ran the tests locally

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

If the Rust side change is merged, will need to update the submodule to point to the upstream repo instead of my fork: https://github.com/temporalio/sdk-rust/issues/1250