### PR TITLE
Ignore null elements in array-valued search attributes

### DIFF
--- a/src/Temporalio/Common/SearchAttributeCollection.cs
+++ b/src/Temporalio/Common/SearchAttributeCollection.cs
@@ -213,7 +213,11 @@ namespace Temporalio.Common
             static object JsonElementToObject(JsonElement elem, IndexedValueType valueType) => elem.ValueKind switch
             {
                 JsonValueKind.Array =>
-                    elem.EnumerateArray().Select(j => JsonElementToObject(j, valueType)).OfType<string>().ToList(),
+                    elem.EnumerateArray()
+                        .Where(j => j.ValueKind != JsonValueKind.Null)
+                        .Select(j => JsonElementToObject(j, valueType))
+                        .OfType<string>()
+                        .ToList(),
                 JsonValueKind.False or JsonValueKind.True =>
                     elem.GetBoolean(),
                 JsonValueKind.Number when valueType == IndexedValueType.Int =>

--- a/tests/Temporalio.Tests/Common/SearchAttributeCollectionTests.cs
+++ b/tests/Temporalio.Tests/Common/SearchAttributeCollectionTests.cs
@@ -1,0 +1,57 @@
+namespace Temporalio.Tests.Common;
+
+using Google.Protobuf;
+using Temporalio.Api.Common.V1;
+using Temporalio.Common;
+using Xunit;
+
+public class SearchAttributeCollectionTests
+{
+    [Fact]
+    public void FromProto_KeywordListWithNullElement_DoesNotThrow()
+    {
+        // A KeywordList payload whose JSON array contains a null element. The
+        // server (or another SDK) can produce this, and decoding it should not
+        // throw "Unexpected search attribute kind Null".
+        var proto = new SearchAttributes
+        {
+            IndexedFields =
+            {
+                ["MyList"] = new Payload
+                {
+                    Metadata =
+                    {
+                        ["encoding"] = ByteString.CopyFromUtf8("json/plain"),
+                        ["type"] = ByteString.CopyFromUtf8("KeywordList"),
+                    },
+                    Data = ByteString.CopyFromUtf8("[\"a\", null, \"b\"]"),
+                },
+            },
+        };
+
+        var collection = SearchAttributeCollection.FromProto(proto);
+
+        var key = SearchAttributeKey.CreateKeywordList("MyList");
+        Assert.Equal(["a", "b"], collection.Get(key));
+    }
+
+    [Fact]
+    public void ToProto_KeywordWithEmptyString_EncodesAsJsonEmptyString()
+    {
+        var key = SearchAttributeKey.CreateKeyword("MyKeyword");
+        var collection = new SearchAttributeCollection.Builder()
+            .Set(key, string.Empty)
+            .ToSearchAttributeCollection();
+
+        var proto = collection.ToProto();
+
+        Assert.True(proto.IndexedFields.TryGetValue("MyKeyword", out var payload));
+        Assert.Equal("json/plain", payload.Metadata["encoding"].ToStringUtf8());
+        Assert.Equal("Keyword", payload.Metadata["type"].ToStringUtf8());
+        Assert.Equal("\"\"", payload.Data.ToStringUtf8());
+
+        // And the empty string survives a round-trip back through FromProto.
+        var roundTripped = SearchAttributeCollection.FromProto(proto);
+        Assert.Equal(string.Empty, roundTripped.Get(key));
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix search attribute collection decoding to ignore null elements in array-valued attributes.

## Why?

Avoid throwing exceptions for improperly encoded array-valued null elements.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Unit test
1. Any docs updates needed? No
