### PR TITLE
Add standalone activity start delay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,7 @@ Notes about the above code:
   `Workflow.ExecuteActivityAsync`.
 * `Id` and `TaskQueue` are required on `StartActivityOptions`. Either `ScheduleToCloseTimeout` or
   `StartToCloseTimeout` must also be set.
+* `StartDelay` can be set to delay dispatch of the first activity task.
 * Non-type-safe forms of `StartActivityAsync` exist that accept a string activity name and an object array for
   arguments.
 * A shortcut extension `ExecuteActivityAsync` is available that is just `StartActivityAsync` + `GetResultAsync`.

--- a/README.md
+++ b/README.md
@@ -1153,7 +1153,6 @@ Notes about the above code:
   `Workflow.ExecuteActivityAsync`.
 * `Id` and `TaskQueue` are required on `StartActivityOptions`. Either `ScheduleToCloseTimeout` or
   `StartToCloseTimeout` must also be set.
-* `StartDelay` can be set to delay dispatch of the first activity task.
 * Non-type-safe forms of `StartActivityAsync` exist that accept a string activity name and an object array for
   arguments.
 * A shortcut extension `ExecuteActivityAsync` is available that is just `StartActivityAsync` + `GetResultAsync`.

--- a/src/Temporalio/Client/StartActivityOptions.cs
+++ b/src/Temporalio/Client/StartActivityOptions.cs
@@ -104,6 +104,12 @@ namespace Temporalio.Client
         public Priority? Priority { get; set; }
 
         /// <summary>
+        /// Gets or sets the time to wait before dispatching the first activity task. This delay
+        /// is not applied to retry attempts.
+        /// </summary>
+        public TimeSpan? StartDelay { get; set; }
+
+        /// <summary>
         /// Gets or sets RPC options for starting the activity.
         /// </summary>
         public RpcOptions? Rpc { get; set; }

--- a/src/Temporalio/Client/TemporalClient.Activity.cs
+++ b/src/Temporalio/Client/TemporalClient.Activity.cs
@@ -91,6 +91,10 @@ namespace Temporalio.Client
                     throw new ArgumentException(
                         "Activity must have ScheduleToCloseTimeout or StartToCloseTimeout");
                 }
+                if (input.Options.StartDelay is { } startDelay && startDelay < TimeSpan.Zero)
+                {
+                    throw new ArgumentException("StartDelay must be non-negative");
+                }
                 try
                 {
                     // Activity-specific data converter
@@ -144,6 +148,10 @@ namespace Temporalio.Client
                     if (input.Options.HeartbeatTimeout is TimeSpan hb)
                     {
                         req.HeartbeatTimeout = Duration.FromTimeSpan(hb);
+                    }
+                    if (input.Options.StartDelay is TimeSpan delay)
+                    {
+                        req.StartDelay = Duration.FromTimeSpan(delay);
                     }
                     if (input.Options.TypedSearchAttributes != null && input.Options.TypedSearchAttributes.Count > 0)
                     {

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -12,6 +12,8 @@ using Xunit.Abstractions;
 
 public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
 {
+    private const string StartDelayTestCliVersion = "v1.7.1-standalone-nexus-operations";
+
     private static volatile TaskCompletionSource? waitForCancelReached;
 
     public TemporalClientActivityTests(ITestOutputHelper output, WorkflowEnvironment env)
@@ -138,6 +140,72 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
                 Client.StartActivityAsync(
                     () => SimpleActivityAsync("second"), opts));
             Assert.Equal(activityId, err.ActivityId);
+        });
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_NegativeStartDelay_Throws()
+    {
+        var err = await Assert.ThrowsAsync<ArgumentException>(() =>
+            Client.StartActivityAsync(
+                () => SimpleActivityAsync("test"),
+                new($"act-{Guid.NewGuid()}", $"tq-{Guid.NewGuid()}")
+                {
+                    StartToCloseTimeout = TimeSpan.FromSeconds(5),
+                    StartDelay = TimeSpan.FromSeconds(-1),
+                }));
+        Assert.Contains("StartDelay must be non-negative", err.Message);
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_StartDelay_WaitsProperly()
+    {
+        await using var env = await Temporalio.Testing.WorkflowEnvironment.StartLocalAsync(new()
+        {
+            DevServerOptions = new()
+            {
+                DownloadVersion = StartDelayTestCliVersion,
+                ExtraArgs = new List<string>
+                {
+                    "--dynamic-config-value",
+                    "frontend.activityAPIsEnabled=true",
+                    "--dynamic-config-value",
+                    "activity.enableStandalone=true",
+                    "--dynamic-config-value",
+                    "history.enableChasm=true",
+                    "--dynamic-config-value",
+                    "history.enableTransitionHistory=true",
+                    "--dynamic-config-value",
+                    "activity.startDelayEnabled=true",
+                },
+            },
+        });
+        var newOptions = (TemporalClientOptions)env.Client.Options.Clone();
+        newOptions.LoggerFactory = LoggerFactory;
+        var client = new TemporalClient(env.Client.Connection, newOptions);
+
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        using var worker = new TemporalWorker(
+            client, new TemporalWorkerOptions(taskQueue).AddActivity(SimpleActivityAsync));
+        await worker.ExecuteAsync(async () =>
+        {
+            var startDelay = TimeSpan.FromSeconds(2);
+            var handle = await client.StartActivityAsync(
+                () => SimpleActivityAsync("delayed"),
+                new($"act-{Guid.NewGuid()}", taskQueue)
+                {
+                    StartToCloseTimeout = TimeSpan.FromSeconds(5),
+                    StartDelay = startDelay,
+                });
+
+            Assert.Equal("echo:delayed", await handle.GetResultAsync());
+
+            var desc = await handle.DescribeAsync();
+            Assert.Equal(ActivityExecutionStatus.Completed, desc.Status);
+            Assert.True(desc.ScheduledTime > DateTime.MinValue);
+            Assert.NotNull(desc.LastStartedTime);
+            Assert.True(
+                desc.LastStartedTime.Value - desc.ScheduledTime >= startDelay - TimeSpan.FromMilliseconds(500));
         });
     }
 

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -12,8 +12,6 @@ using Xunit.Abstractions;
 
 public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
 {
-    private const string StartDelayTestCliVersion = "v1.7.1-standalone-nexus-operations";
-
     private static volatile TaskCompletionSource? waitForCancelReached;
 
     public TemporalClientActivityTests(ITestOutputHelper output, WorkflowEnvironment env)
@@ -160,37 +158,10 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
     [Fact]
     public async Task StartActivityAsync_StartDelay_WaitsProperly()
     {
-        await using var env = await Temporalio.Testing.WorkflowEnvironment.StartLocalAsync(new()
-        {
-            DevServerOptions = new()
-            {
-                DownloadVersion = StartDelayTestCliVersion,
-                ExtraArgs = new List<string>
-                {
-                    "--dynamic-config-value",
-                    "frontend.activityAPIsEnabled=true",
-                    "--dynamic-config-value",
-                    "activity.enableStandalone=true",
-                    "--dynamic-config-value",
-                    "history.enableChasm=true",
-                    "--dynamic-config-value",
-                    "history.enableTransitionHistory=true",
-                    "--dynamic-config-value",
-                    "activity.startDelayEnabled=true",
-                },
-            },
-        });
-        var newOptions = (TemporalClientOptions)env.Client.Options.Clone();
-        newOptions.LoggerFactory = LoggerFactory;
-        var client = new TemporalClient(env.Client.Connection, newOptions);
-
-        var taskQueue = $"tq-{Guid.NewGuid()}";
-        using var worker = new TemporalWorker(
-            client, new TemporalWorkerOptions(taskQueue).AddActivity(SimpleActivityAsync));
-        await worker.ExecuteAsync(async () =>
+        await ExecuteActivityWorkerAsync(SimpleActivityAsync, async taskQueue =>
         {
             var startDelay = TimeSpan.FromSeconds(2);
-            var handle = await client.StartActivityAsync(
+            var handle = await Client.StartActivityAsync(
                 () => SimpleActivityAsync("delayed"),
                 new($"act-{Guid.NewGuid()}", taskQueue)
                 {

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -92,6 +92,7 @@ public class WorkflowEnvironment : IAsyncLifetime
                         "--dynamic-config-value", "activity.enableStandalone=true",
                         "--dynamic-config-value", "history.enableChasm=true",
                         "--dynamic-config-value", "history.enableTransitionHistory=true",
+                        "--dynamic-config-value", "activity.startDelayEnabled=true",
                         // Enable standalone Nexus operations
                         "--dynamic-config-value", "nexusoperation.enableStandalone=true",
                         "--dynamic-config-value", "history.enableChasmCallbacks=true",


### PR DESCRIPTION
Expose StartDelay on StartActivityOptions, validate that it is non-negative, and pass it through to StartActivityExecutionRequest.

Add integration coverage for delayed standalone activity dispatch and document the new option.

## What was changed
Added `StartActivityOptions.StartDelay` for standalone activities.

The client now validates that `StartDelay` is non-negative and maps it to `StartActivityExecutionRequest.StartDelay` when starting a standalone activity. The README standalone activity section now mentions the new option.

Added tests covering client-side rejection of negative start delays and an integration test that verifies a delayed standalone activity starts after the configured delay.

## Why?
Standalone activities support delayed first dispatch at the service API level, but the .NET client was not exposing or wiring that field. This gives users a typed way to delay the first activity task without affecting retries.

## Checklist

1. Closes N/A

2. How was this tested:
`dotnet format --verify-no-changes`

`dotnet build -p:RestoreLockedMode=true`

`dotnet test tests/Temporalio.Tests/Temporalio.Tests.csproj --no-restore --filter FullyQualifiedName~Temporalio.Tests.Client.TemporalClientActivityTests.StartActivityAsync_NegativeStartDelay_Throws`

`dotnet test tests/Temporalio.Tests/Temporalio.Tests.csproj --no-restore --filter FullyQualifiedName~Temporalio.Tests.Client.TemporalClientActivityTests.StartActivityAsync_StartDelay_WaitsProperly`

3. Any docs updates needed?
README updated for standalone activity `StartDelay`. No docs.temporal.io update included.

