### PR TITLE
test(client): fix race in activity interceptor test

### DIFF
--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -348,6 +348,7 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
                 new(activityId, taskQueue)
                 {
                     ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+                    HeartbeatTimeout = TimeSpan.FromSeconds(10),
                 });
 
             await AssertMore.EventuallyAsync(async () =>
@@ -357,11 +358,10 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
             });
 
             await handle.CancelAsync();
-            await AssertMore.EventuallyAsync(async () =>
-            {
-                var desc = await handle.DescribeAsync();
-                Assert.Equal(ActivityExecutionStatus.Canceled, desc.Status);
-            });
+
+            var err = await Assert.ThrowsAsync<ActivityFailedException>(
+                () => handle.GetResultAsync());
+            Assert.IsType<CanceledFailureException>(err.InnerException);
 
             Assert.Equal("StartActivity", interceptor.Events[0].Name);
             Assert.Equal(
@@ -399,6 +399,7 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
                 new(activityId, taskQueue)
                 {
                     ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+                    HeartbeatTimeout = TimeSpan.FromSeconds(10),
                 });
 
             await AssertMore.EventuallyAsync(async () =>
@@ -409,11 +410,9 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
 
             await handle.TerminateAsync();
 
-            await AssertMore.EventuallyAsync(async () =>
-            {
-                var desc = await handle.DescribeAsync();
-                Assert.Equal(ActivityExecutionStatus.Terminated, desc.Status);
-            });
+            var err = await Assert.ThrowsAsync<ActivityFailedException>(
+                () => handle.GetResultAsync());
+            Assert.IsType<TerminatedFailureException>(err.InnerException);
 
             Assert.Equal("StartActivity", interceptor.Events[0].Name);
             Assert.Equal(

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -357,7 +357,11 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
             });
 
             await handle.CancelAsync();
-            await handle.TerminateAsync();
+            await AssertMore.EventuallyAsync(async () =>
+            {
+                var desc = await handle.DescribeAsync();
+                Assert.Equal(ActivityExecutionStatus.Canceled, desc.Status);
+            });
 
             Assert.Equal("StartActivity", interceptor.Events[0].Name);
             Assert.Equal(
@@ -369,15 +373,62 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
                 activityId,
                 ((DescribeActivityInput)interceptor.Events[1].Input).Id);
 
-            Assert.Equal("CancelActivity", interceptor.Events[^2].Name);
+            Assert.Equal("CancelActivity", interceptor.Events[2].Name);
             Assert.Equal(
                 activityId,
-                ((CancelActivityInput)interceptor.Events[^2].Input).Id);
+                ((CancelActivityInput)interceptor.Events[2].Input).Id);
+        });
+    }
 
-            Assert.Equal("TerminateActivity", interceptor.Events[^1].Name);
+    [Fact]
+    public async Task TerminateActivityAsync_Interceptor_IsCalledProperly()
+    {
+        var interceptor = new ActivityTracingInterceptor();
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.Interceptors = new IClientInterceptor[] { interceptor };
+        var client = new TemporalClient(Client.Connection, newOptions);
+
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        using var worker = new TemporalWorker(
+            client, new TemporalWorkerOptions(taskQueue).AddActivity(WaitForCancelAsync));
+        await worker.ExecuteAsync(async () =>
+        {
+            var activityId = $"act-{Guid.NewGuid()}";
+            var handle = await client.StartActivityAsync(
+                () => WaitForCancelAsync(),
+                new(activityId, taskQueue)
+                {
+                    ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+                });
+
+            await AssertMore.EventuallyAsync(async () =>
+            {
+                var desc = await handle.DescribeAsync();
+                Assert.Equal(ActivityExecutionStatus.Running, desc.Status);
+            });
+
+            await handle.TerminateAsync();
+
+            await AssertMore.EventuallyAsync(async () =>
+            {
+                var desc = await handle.DescribeAsync();
+                Assert.Equal(ActivityExecutionStatus.Terminated, desc.Status);
+            });
+
+            Assert.Equal("StartActivity", interceptor.Events[0].Name);
             Assert.Equal(
                 activityId,
-                ((TerminateActivityInput)interceptor.Events[^1].Input).Id);
+                ((StartActivityInput)interceptor.Events[0].Input).Options.Id);
+
+            Assert.Equal("DescribeActivity", interceptor.Events[1].Name);
+            Assert.Equal(
+                activityId,
+                ((DescribeActivityInput)interceptor.Events[1].Input).Id);
+
+            Assert.Equal("TerminateActivity", interceptor.Events[2].Name);
+            Assert.Equal(
+                activityId,
+                ((TerminateActivityInput)interceptor.Events[2].Input).Id);
         });
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Split terminate interceptor checks into their own test.

## Why?

`StartActivityAsync_Interceptors_AreCalledProperly` is frequently failing due to a race condition between cancelling the activity and terminating it. Cannot terminate an activity that is already cancelled.

## Checklist
<!--- add/delete as needed --->

1. Closes #648

2. How was this tested: New tests

3. Any docs updates needed? No
