### PR TITLE
CI: Fix Rust cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src/Temporalio/Bridge/sdk-core
+          cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          workspaces: src/Temporalio/Bridge
+          workspaces: src/Temporalio/Bridge/sdk-core
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5

--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -95,6 +95,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src/Temporalio/Bridge/sdk-core
+          cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5

--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          workspaces: src/Temporalio/Bridge
+          workspaces: src/Temporalio/Bridge/sdk-core
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           workspaces: src/Temporalio/Bridge/sdk-core
           key: ${{ matrix.os }}
+          cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
 
       - name: Install protoc
         if: ${{ !matrix.container }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -85,7 +85,7 @@ jobs:
         # Fixed version due to https://github.com/Swatinem/rust-cache/issues/183#issuecomment-1893979126
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          workspaces: src/Temporalio/Bridge
+          workspaces: src/Temporalio/Bridge/sdk-core
           key: ${{ matrix.os }}
 
       - name: Install protoc

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          workspaces: src/Temporalio/Bridge
+          workspaces: src/Temporalio/Bridge/sdk-core
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -23,6 +23,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src/Temporalio/Bridge/sdk-core
+          cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed workspace path in "Setup Rust cache" CI step.

## Why?
<!-- Tell your future self why have you made these changes -->
Rust build cache was silently failing since C bridge has been moved to Core SDK repo.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
CI step "Setup Rust cache" should not log an error about not finding Cargo.toml anymore.