### PR TITLE
[backport 1.13.1] Update core to pickup shutdown fix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g94r-2vxg-569j" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)src\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Pick up shutdown fix cherry-pick for v1.14.1 patch release, https://github.com/temporalio/sdk-rust/pull/1238

## Why?
<!-- Tell your future self why have you made these changes -->
bug fix

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build/packaging change that only suppresses a single NuGet vulnerability advisory during auditing; no runtime behavior is affected.
> 
> **Overview**
> Adds a `NuGetAuditSuppress` entry in `Directory.Build.props` to suppress the NuGet audit warning for advisory `GHSA-g94r-2vxg-569j` during builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40b3f2f7bdf3d025611a46d24cceea80c15272e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->