### PR TITLE
Fix NexusWorkerTests to not capture OperationStartContext

### DIFF
--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -282,20 +282,26 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     [Fact]
     public async Task ExecuteNexusOperationAsync_SyncTimeout_FailsAsExpected()
     {
-        var contextSource = new TaskCompletionSource<OperationStartContext>();
+        var cancellationReasonSource = new TaskCompletionSource<string?>();
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
             AddNexusService(new HandlerFactoryStringService(() =>
                 OperationHandler.Sync<string, string>(async (ctx, name) =>
                 {
-                    contextSource.SetResult(ctx);
                     try
                     {
                         await Task.Delay(40000, ctx.CancellationToken);
+                        cancellationReasonSource.SetResult("none");
                         return "done";
                     }
                     catch (TaskCanceledException)
                     {
+                        cancellationReasonSource.SetResult(ctx.CancellationReason);
                         return "canceled";
+                    }
+                    catch (Exception)
+                    {
+                        cancellationReasonSource.SetResult("other exception");
+                        throw;
                     }
                 })));
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
@@ -311,21 +317,21 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var timeoutExc = Assert.IsType<TimeoutFailureException>(
             Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);
         Assert.Equal(TimeoutType.ScheduleToClose, timeoutExc.TimeoutType);
-        // Also check that our cancel token is canceled for the proper reason
-        var ctx = await contextSource.Task;
-        Assert.True(await Task.Run(() => ctx.CancellationToken.WaitHandle.WaitOne(2000)));
-        Assert.Equal("timed out", ctx.CancellationReason);
+        // Check that it is cancelled for the proper reason
+        using CancellationTokenSource timeoutSource = new(TimeSpan.FromSeconds(5));
+        var reason = await cancellationReasonSource.Task.WaitAsync(timeoutSource.Token);
+        Assert.Equal("timed out", reason);
     }
 
     [Fact]
     public async Task ExecuteNexusOperationAsync_RequestDeadline_SetOnContext()
     {
-        var contextSource = new TaskCompletionSource<OperationStartContext>();
+        var requestDeadlineSource = new TaskCompletionSource<DateTime?>();
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
             AddNexusService(new AsyncFuncStringService(
                 start: (ctx, input) =>
                 {
-                    contextSource.SetResult(ctx);
+                    requestDeadlineSource.SetResult(ctx.RequestDeadline);
                     return Task.FromResult(OperationStartResult.SyncResult($"Hello, {input}"));
                 }));
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
@@ -335,9 +341,9 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                 ExecuteNexusOperationAsync(svc => svc.DoSomething("some-name"));
             Assert.Equal("Hello, some-name", result);
         });
-        var ctx = await contextSource.Task;
         // Server always sends a request timeout header, so the deadline should be set
-        Assert.NotNull(ctx.RequestDeadline);
+        using CancellationTokenSource timeoutSource = new(TimeSpan.FromSeconds(5));
+        Assert.NotNull(await requestDeadlineSource.Task.WaitAsync(timeoutSource.Token));
     }
 
     [Fact]
@@ -376,20 +382,26 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     [Fact]
     public async Task ExecuteNexusOperationAsync_ScheduleToStartTimeout_FailsAsExpected()
     {
-        var contextSource = new TaskCompletionSource<OperationStartContext>();
+        var cancellationReasonSource = new TaskCompletionSource<string?>();
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
             AddNexusService(new HandlerFactoryStringService(() =>
                 OperationHandler.Sync<string, string>(async (ctx, name) =>
                 {
-                    contextSource.SetResult(ctx);
                     try
                     {
                         await Task.Delay(40000, ctx.CancellationToken);
+                        cancellationReasonSource.SetResult("none");
                         return "done";
                     }
                     catch (TaskCanceledException)
                     {
+                        cancellationReasonSource.SetResult(ctx.CancellationReason);
                         return "canceled";
+                    }
+                    catch (Exception)
+                    {
+                        cancellationReasonSource.SetResult("other exception");
+                        throw;
                     }
                 })));
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
@@ -405,10 +417,10 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var timeoutExc = Assert.IsType<TimeoutFailureException>(
             Assert.IsType<NexusOperationFailureException>(exc.InnerException).InnerException);
         Assert.Equal(TimeoutType.ScheduleToStart, timeoutExc.TimeoutType);
-        // Also check that our cancel token is canceled for the proper reason
-        var ctx = await contextSource.Task;
-        Assert.True(await Task.Run(() => ctx.CancellationToken.WaitHandle.WaitOne(2000)));
-        Assert.Equal("timed out", ctx.CancellationReason);
+        // Check that it is cancelled for the proper reason
+        using CancellationTokenSource timeoutSource = new(TimeSpan.FromSeconds(5));
+        var reason = await cancellationReasonSource.Task.WaitAsync(timeoutSource.Token);
+        Assert.Equal("timed out", reason);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix some NexusWorkerTests to not capture the OperationStartContext. The tests not capture the relevant parts of the context that they want to validate before returning from the handler.

## Why?

The context is only meant to be used within the handler and not stored outside of the handler invocation. Storing it causes lifetime and disposal issues that are raced with the assertions in the tests.

## Checklist
<!--- add/delete as needed --->

1. Closes #592

2. How was this tested: Test fixes

3. Any docs updates needed? No
