### PR TITLE
chore: ignore lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ obj/
 /.zed
 /.omc
 Temporalio.sln.DotSettings.user
+
+# C# Dev Kit language service cache (https://aka.ms/lscache)
+*.lscache


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add `*.lscache` files to `.gitignore` so they are not included in source control.

## Why?

These cache files _can_ be committed into source control, but:
- They are experimental at this time
- Only the C# Dev Kit produces them

We can consider adding them if they truly improve startup time and are more widely adopted.
