### PR TITLE
Nexus - Fix null operation input handling in workflow

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -2584,7 +2584,7 @@ namespace Temporalio.Worker
                     Endpoint = input.ClientOptions.Endpoint,
                     Service = input.Service,
                     Operation = input.OperationName,
-                    Input = input.Arg == null ? null : payloadConverter.ToPayload(input.Arg),
+                    Input = payloadConverter.ToPayload(input.Arg),
                     CancellationType = (Bridge.Api.Nexus.NexusOperationCancellationType)input.Options.CancellationType,
                 };
                 if (input.Options.ScheduleToCloseTimeout is TimeSpan schedToCloseTimeout)

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1241,7 +1241,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
 
         workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
-        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.Interceptors = [new XunitExceptionInterceptor()];
         workerOptions.AddWorkflow(WorkflowDefinition.Create(
             typeof(CustomFuncWorkflow),
             null,
@@ -1267,6 +1267,58 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         Assert.True(
             codec.DecodeCallCount >= 2,
             $"Expected at least 2 decode calls (confirming retry), got {codec.DecodeCallCount}");
+    }
+
+    [NexusService]
+    public interface INoArgService
+    {
+        [NexusOperation]
+        string DoSomething();
+    }
+
+    [NexusServiceHandler(typeof(INoArgService))]
+    public class NoArgService
+    {
+        [NexusOperationHandler]
+        public IOperationHandler<NoValue, string> DoSomething() =>
+            OperationHandler.Sync<NoValue, string>((ctx, _) => "hello");
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_NoValueInputWithCodec_Succeeds()
+    {
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadCodec = new Converters.Base64PayloadCodec(),
+        };
+        var codecClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new NoArgService());
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                var result = await Workflow.CreateNexusWorkflowClient<INoArgService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething());
+                Assert.Equal("hello", result);
+                return null;
+            })));
+
+        using var worker = new TemporalWorker(codecClient, workerOptions);
+        await worker.ExecuteAsync(async () =>
+        {
+            var handle = await codecClient.StartWorkflowAsync(
+                (CustomFuncWorkflow wf) => wf.RunAsync(),
+                new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+            await handle.GetResultAsync();
+        });
     }
 
     private class AlwaysFailPayloadConverter : IPayloadConverter
@@ -1295,7 +1347,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
 
         workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
-        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.Interceptors = [new XunitExceptionInterceptor()];
         workerOptions.AddWorkflow(WorkflowDefinition.Create(
             typeof(CustomFuncWorkflow),
             null,

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1241,7 +1241,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
 
         workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
-        workerOptions.Interceptors =[new XunitExceptionInterceptor()];
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
         workerOptions.AddWorkflow(WorkflowDefinition.Create(
             typeof(CustomFuncWorkflow),
             null,
@@ -1347,7 +1347,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
 
         workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
-        workerOptions.Interceptors =[new XunitExceptionInterceptor()];
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
         workerOptions.AddWorkflow(WorkflowDefinition.Create(
             typeof(CustomFuncWorkflow),
             null,

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1241,7 +1241,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
 
         workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
-        workerOptions.Interceptors = [new XunitExceptionInterceptor()];
+        workerOptions.Interceptors =[new XunitExceptionInterceptor()];
         workerOptions.AddWorkflow(WorkflowDefinition.Create(
             typeof(CustomFuncWorkflow),
             null,
@@ -1347,7 +1347,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
 
         workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
-        workerOptions.Interceptors = [new XunitExceptionInterceptor()];
+        workerOptions.Interceptors =[new XunitExceptionInterceptor()];
         workerOptions.AddWorkflow(WorkflowDefinition.Create(
             typeof(CustomFuncWorkflow),
             null,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Change how a `null` input is treated when scheduling a Nexus operation inside a workflow

## Why?
Was inconsistent with how `null` input was treated for Activities and Workflows

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

closes https://github.com/temporalio/sdk-dotnet/issues/677

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Nexus operation scheduling to always run input through the payload converter (even when `null`), which alters on-the-wire command payloads and could affect compatibility for existing workflows relying on absent inputs.
> 
> **Overview**
> Aligns Nexus workflow operation scheduling with activity/workflow argument handling by **always serializing the operation input**, rather than omitting the payload when the arg is `null`.
> 
> Adds a regression test covering a no-arg Nexus operation (`NoValue` input) running with a payload codec enabled, ensuring the operation executes successfully and returns the expected result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab6463a77cc560338a77e95b612c863a5cb41b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->