### PR TITLE
update docker PAT secrets, and temp push trigger

### DIFF
--- a/.github/workflows/omes.yml
+++ b/.github/workflows/omes.yml
@@ -2,6 +2,7 @@ name: Omes Testing
 on:
   push:
     branches:
+      - fix/omes-docker-sdk-pat
       - main
       - "releases/*"
 permissions:
@@ -9,8 +10,10 @@ permissions:
 
 jobs:
   omes-image-build:
-    uses: temporalio/omes/.github/workflows/docker-images.yml@main
-    secrets: inherit
+    uses: temporalio/omes/.github/workflows/docker-images.yml@fix/docker-images-secret-contract
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PAT: ${{ secrets.DOCKER_SDK_PAT }}
     with:
       lang: dotnet
       sdk-repo-url: ${{ github.event.pull_request.head.repo.full_name || 'temporalio/sdk-dotnet' }}
@@ -18,3 +21,4 @@ jobs:
       # TODO: Remove once we have a good way of cleaning up sha-based pushed images
       docker-tag-ext: ci-latest
       do-push: true
+      omes-repo-ref: fix/docker-images-secret-contract


### PR DESCRIPTION
## What was changed
DWISOTT

## Why?
fixes omes build CI action

2. How was this tested:
action ran on push

**Note**: this breaks due to build before it even gets to push. Blocked on that fix first
