### PR TITLE
Make README.md more specific about which AWS Lambda images cause CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,7 +1265,7 @@ See the earlier part of this section for details on what environments are suppor
 
 Some platforms are not loading the system CA list properly due to quirks with how the platforms work.
 
-#### AWS Lambda .NET CA Loading Issues
+#### AWS Lambda .NET 8 CA Loading Issues
 
 Due to a [change](https://github.com/aws/aws-lambda-dotnet/pull/1661) in AWS .NET 8 Lambda images to force
 override the `SSL_CERT_FILE` environment variable, the CA list cannot be loaded from the system properly in our

--- a/README.md
+++ b/README.md
@@ -1267,7 +1267,7 @@ Some platforms are not loading the system CA list properly due to quirks with ho
 
 #### AWS Lambda .NET CA Loading Issues
 
-Due to a [recent change](https://github.com/aws/aws-lambda-dotnet/pull/1661) in newer AWS .NET Lambda images to force
+Due to a [change](https://github.com/aws/aws-lambda-dotnet/pull/1661) in AWS .NET 8 Lambda images to force
 override the `SSL_CERT_FILE` environment variable, the CA list cannot be loaded from the system properly in our
 Rust-based extension. This may cause errors like:
 


### PR DESCRIPTION
issues

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
README section about CA loading issues on AWS lambda was changed to reflect that the issue should only appear for the AWS Lambda .NET 8 image

## Why?
The verbiage was slightly stale and didn't reflect that the performance regression was fixed in .NET 9 and thus AWS only kept the change for their .NET 8 image.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
