### PR TITLE
chore: update all xunit related packages to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Google.Protobuf" Version="3.26.1" />
-    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
@@ -21,9 +21,9 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.8" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.4" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.console" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.console" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 </Project>

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -362,7 +362,7 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
 
                 var thirdPage = await Client.ListActivitiesPaginatedAsync(
                     $"TaskQueue = '{taskQueue}'", secondPage.NextPageToken, options);
-                Assert.Equal(1, thirdPage.Activities.Count);
+                Assert.Single(thirdPage.Activities);
                 Assert.Null(thirdPage.NextPageToken);
             });
         });

--- a/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
@@ -374,7 +374,7 @@ public class TemporalClientNexusOperationTests : WorkflowEnvironmentTestBase
 
                     var thirdPage = await Client.ListNexusOperationsPaginatedAsync(
                         $"Endpoint = '{endpointName}'", secondPage.NextPageToken, options);
-                    Assert.Equal(1, thirdPage.Operations.Count);
+                    Assert.Single(thirdPage.Operations);
                     Assert.Null(thirdPage.NextPageToken);
                 });
             });

--- a/tests/Temporalio.Tests/Client/TemporalClientTaskQueueTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientTaskQueueTests.cs
@@ -21,19 +21,19 @@ public class TemporalClientTaskQueueTests : WorkflowEnvironmentTestBase
         await Client.UpdateWorkerBuildIdCompatibilityAsync(taskQueue, new BuildIdOp.AddNewDefault("1.0"));
 
         var sets = (await Client.GetWorkerBuildIdCompatibilityAsync(taskQueue))!;
-        Assert.Equal(1, sets.VersionSets.Count);
+        Assert.Single(sets.VersionSets);
         Assert.Equal("1.0", sets.DefaultBuildId);
 
         await Client.UpdateWorkerBuildIdCompatibilityAsync(taskQueue, new BuildIdOp.AddNewCompatible("1.1", "1.0"));
 
         sets = (await Client.GetWorkerBuildIdCompatibilityAsync(taskQueue))!;
-        Assert.Equal(1, sets.VersionSets.Count);
+        Assert.Single(sets.VersionSets);
         Assert.Equal("1.1", sets.DefaultBuildId);
 
         await Client.UpdateWorkerBuildIdCompatibilityAsync(taskQueue, new BuildIdOp.PromoteBuildIdWithinSet("1.0"));
 
         sets = (await Client.GetWorkerBuildIdCompatibilityAsync(taskQueue))!;
-        Assert.Equal(1, sets.VersionSets.Count);
+        Assert.Single(sets.VersionSets);
         Assert.Equal("1.0", sets.DefaultBuildId);
 
         await Client.UpdateWorkerBuildIdCompatibilityAsync(taskQueue, new BuildIdOp.AddNewDefault("2.0"));
@@ -51,7 +51,7 @@ public class TemporalClientTaskQueueTests : WorkflowEnvironmentTestBase
         await Client.UpdateWorkerBuildIdCompatibilityAsync(taskQueue, new BuildIdOp.MergeSets("2.0", "1.0"));
 
         sets = (await Client.GetWorkerBuildIdCompatibilityAsync(taskQueue))!;
-        Assert.Equal(1, sets.VersionSets.Count);
+        Assert.Single(sets.VersionSets);
         Assert.Equal("2.0", sets.DefaultBuildId);
     }
 }

--- a/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
@@ -353,7 +353,7 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
         Assert.NotEmpty(secondPage.NextPageToken);
 
         var thirdPage = await Client.ListWorkflowsPaginatedAsync($"WorkflowId = '{workflowId}'", secondPage.NextPageToken, options);
-        Assert.Equal(1, thirdPage.Workflows.Count);
+        Assert.Single(thirdPage.Workflows);
         Assert.Null(thirdPage.NextPageToken);
     }
 

--- a/tests/Temporalio.Tests/packages.lock.json
+++ b/tests/Temporalio.Tests/packages.lock.json
@@ -4,13 +4,13 @@
     "net10.0": {
       "MartinCostello.Logging.XUnit": {
         "type": "Direct",
-        "requested": "[0.3.0, )",
-        "resolved": "0.3.0",
-        "contentHash": "p6SWKQRLXEqYqnzA7mulCPfdZraDXFc7gHCErj1uw9KTNi4agFZqFDCANIfwAJ7ivWlAUAFZDTDFxb4cAhkPlw==",
+        "requested": "[0.7.1, )",
+        "resolved": "0.7.1",
+        "contentHash": "ZAiCk1jfHK6KwfvBuy+36kdaRWV25qFz3iEFO0ETI6KYz0eyZE+LTT3jaOzOLp/GtUDTgFetGdO4AHITOxIGGw==",
         "dependencies": {
-          "Microsoft.Extensions.Logging": "2.0.0",
-          "xunit.abstractions": "2.0.2",
-          "xunit.extensibility.execution": "2.4.0"
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "xunit.abstractions": "2.0.3",
+          "xunit.extensibility.execution": "2.6.6"
         }
       },
       "Microsoft.Extensions.Hosting": {
@@ -92,37 +92,37 @@
       },
       "xunit": {
         "type": "Direct",
-        "requested": "[2.4.2, )",
-        "resolved": "2.4.2",
-        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
         "dependencies": {
-          "xunit.analyzers": "1.0.0",
-          "xunit.assert": "2.4.2",
-          "xunit.core": "[2.4.2]"
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
         }
       },
       "xunit.console": {
         "type": "Direct",
-        "requested": "[2.4.2, )",
-        "resolved": "2.4.2",
-        "contentHash": "ZB78iHlcNwyquDe1KRaz8VMA5qCA9JljxM13GiO5rTDDYtqd0bsYPCCabfQ78Cfl7bno7fxtWE5RF6ptegHblQ==",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "G1Y3YdJFOEnkFFJXz4cOkcnCNu5sDLaRQ9Y8zORGdaIuTrOMJxBfd1Et0h0NKdLjuU05tRNCY8Md5cNM2XxV1A==",
         "dependencies": {
-          "xunit.runner.reporters": "[2.4.2]"
+          "xunit.runner.reporters": "[2.9.3]"
         }
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[2.4.3, )",
-        "resolved": "2.4.3",
-        "contentHash": "kZZSmOmKA8OBlAJaquPXnJJLM9RwQ27H7BMVqfMLUcTi9xHinWGJiWksa3D4NEtz0wZ/nxd2mogObvBgJKCRhQ=="
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
       "Xunit.SkippableFact": {
         "type": "Direct",
-        "requested": "[1.4.13, )",
-        "resolved": "1.4.13",
-        "contentHash": "IyzZNvJEtXGlXrzxDiSbtH5Lyxf4iJdRQADuyjGdDf00LjXRLJwIoezQNFhFGKTMtvk8IIgaSHxW4mAV4O7b8A==",
+        "requested": "[1.5.61, )",
+        "resolved": "1.5.61",
+        "contentHash": "ZoahExHGire3U1b9RLUQJuoofMKwJKd6U60cqaomh0llL8ns1evvl8ivXLP1Bw3nPUR0ELfSVZ0giKnMoqPCfQ==",
         "dependencies": {
-          "Validation": "2.4.18",
+          "Validation": "2.6.68",
           "xunit.extensibility.execution": "2.4.0"
         }
       },
@@ -351,11 +351,6 @@
         "resolved": "10.0.0",
         "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
       },
-      "Microsoft.NETCore.Platforms": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "17.4.1",
@@ -371,14 +366,6 @@
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "17.4.1",
           "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "NETStandard.Library": {
-        "type": "Transitive",
-        "resolved": "1.6.1",
-        "contentHash": "WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
       "Newtonsoft.Json": {
@@ -422,8 +409,8 @@
       },
       "Validation": {
         "type": "Transitive",
-        "resolved": "2.4.18",
-        "contentHash": "NfvWJ1QeuZ1FQCkqgXTu1cOkRkbNCfxs4Tat+abXLwom6OXbULVhRGp34BTvVB4XPxj6VIAl7KfLfStXMt/Ehw=="
+        "resolved": "2.6.68",
+        "contentHash": "5mZ+aXsYQnr3Wxz5O2tmbgPaa5kn9R+ZlfnPyGBogXI2sh4uTiHtvU++N4bURtn9vmDYIu2Zu323K9hFz9poXQ=="
       },
       "xunit.abstractions": {
         "type": "Transitive",
@@ -432,59 +419,52 @@
       },
       "xunit.analyzers": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
       },
       "xunit.assert": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
       },
       "xunit.core": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
         "dependencies": {
-          "xunit.extensibility.core": "[2.4.2]",
-          "xunit.extensibility.execution": "[2.4.2]"
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
         }
       },
       "xunit.extensibility.core": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1",
           "xunit.abstractions": "2.0.3"
         }
       },
       "xunit.extensibility.execution": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1",
-          "xunit.extensibility.core": "[2.4.2]"
+          "xunit.extensibility.core": "[2.9.3]"
         }
       },
       "xunit.runner.reporters": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "VtJeno+LePwPtRO+NYN3GUy1ZiXu95G6uWnOdGMdCCp9kkEVBDyMYbr/h1t23tK/xQ4vDPi7XhUCIZ6cOX8TOw==",
+        "resolved": "2.9.3",
+        "contentHash": "qVkeEF9+VmgBEzQS+zM52BpSG4nqY8nbusH5hvn7+KiwRDr5dwuCZ1jaUeddU99YZrCe++mU4+klZU8QbyBM8w==",
         "dependencies": {
-          "NETStandard.Library": "1.6.0",
-          "xunit.runner.utility": "[2.4.2]"
+          "xunit.runner.utility": "[2.9.3]"
         }
       },
       "xunit.runner.utility": {
         "type": "Transitive",
-        "resolved": "2.4.2",
-        "contentHash": "5f3JayTAq5FcsOhIkgrD26MBlg2Xfh4rJjkYRGG5wgJ6a+sWB+ex22UDzuc6rL1kVVghiaupwmr2A3s+CbG4Aw==",
+        "resolved": "2.9.3",
+        "contentHash": "cAUw6GadBR19A9/345e3BFiAkhN9P5xPrxiZgks0xdRv+DxdIWiizE5vjyExKNyFzsm+r1jDhccpUyojBDT7OA==",
         "dependencies": {
-          "NETStandard.Library": "1.6.0",
           "xunit.abstractions": "2.0.3"
         }
       },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Update all xUnit-related packages to their latest version in one change.
- Adjust xUnit assertion usage to conform to static analysis expectations.

## Why?

Dependabot cannot update the packages due to required adjustments to the assertion usage.
