### PR TITLE
fix(tests): poll metrics on each loop

### DIFF
--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -7816,18 +7816,20 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         async worker =>
         {
             using var httpClient = new HttpClient();
-            var resp = await httpClient.GetAsync(new Uri($"http://{promAddr}/metrics"));
-            var body = await resp.Content.ReadAsStringAsync();
-            var bodyLines = body.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
-            var matches = bodyLines.Where(l => l.Contains("temporal_num_pollers")).ToList();
-            var activityPollers = matches.Where(l => l.Contains("activity_task")).ToList();
-
-            Assert.Single(activityPollers);
-            Assert.True(activityPollers[0].EndsWith('2'), "Activity poller count should be 2");
-            var workflowPollers = matches.Where(l => l.Contains("workflow_task")).ToList();
 
             await AssertMore.EventuallyAsync(async () =>
             {
+                var resp = await httpClient.GetAsync(new Uri($"http://{promAddr}/metrics"));
+                var body = await resp.Content.ReadAsStringAsync();
+                var bodyLines = body.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+                var matches = bodyLines.Where(l => l.Contains("temporal_num_pollers")).ToList();
+                var activityPollers = matches.Where(l => l.Contains("activity_task")).ToList();
+
+                Assert.Single(activityPollers);
+                Assert.True(activityPollers[0].EndsWith('2'), "Activity poller count should be 2");
+
+                var workflowPollers = matches.Where(l => l.Contains("workflow_task")).ToList();
+
                 // Should have exactly two workflow poller metrics (sticky and non-sticky)
                 Assert.Equal(2, workflowPollers.Count);
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Update `ExecuteWorkflowAsync_PollingBehavior_Autoscaling` test to poll metrics on each loop in the `AssertMore.EventuallyAsync` instead of reading `/metrics` once.

## Why?

The prior behavior only invoked the `/metrics` route once and continuously checked the response. The response doesn't change since (1) it is not streamed and (2) response reading serializes a snapshot.

## Checklist
<!--- add/delete as needed --->

1. Closes #549
