### PR TITLE
Automated NuGet release workflow

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,0 +1,97 @@
+name: Smoke test Temporalio package
+description: >
+  Restore the Temporalio package from a given source and run the smoke test
+  projects on the current runner. Callers own the platform matrix and pass the
+  per-leg flags (is-alpine, run-dotnet-framework).
+
+inputs:
+  package-source:
+    description: >
+      Semicolon-separated NuGet source(s) passed to `dotnet add package -s`. For
+      a local folder feed, use a path relative to the repo root (e.g.
+      "nuget-package/Temporalio/bin/Release").
+    required: true
+  version:
+    description: "Exact Temporalio version to restore (empty = highest available)."
+    required: false
+    default: ""
+  is-alpine:
+    description: "Set to 'true' on Alpine legs (runs in a dotnet SDK container)."
+    required: false
+    default: "false"
+  run-dotnet-framework:
+    description: "Set to 'true' to also run the net462 smoke test (Windows x64 only)."
+    required: false
+    default: "false"
+  dotnet-version:
+    description: ".NET SDK version to install on non-Alpine runners."
+    required: false
+    default: "10.x"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup .NET (non-Alpine)
+      if: ${{ inputs.is-alpine != 'true' }}
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+      with:
+        # Specific .NET version required because GitHub macos ARM image has
+        # bad pre-installed .NET version
+        dotnet-version: ${{ inputs.dotnet-version }}
+
+    - name: Run smoke test (Alpine)
+      if: ${{ inputs.is-alpine == 'true' }}
+      shell: bash
+      # Use Docker specifically for Alpine ARM 64 to avoid JS action limitations.
+      env:
+        PACKAGE_SOURCE: ${{ inputs.package-source }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        docker run --rm -v "$(pwd):/workspace" -w /workspace \
+          -e PACKAGE_SOURCE -e VERSION \
+          mcr.microsoft.com/dotnet/sdk:10.0-alpine \
+          sh -c '
+            version_arg=""
+            [ -n "$VERSION" ] && version_arg="--version $VERSION"
+            dotnet add tests/Temporalio.SmokeTest package Temporalio $version_arg -s "$PACKAGE_SOURCE" --prerelease \
+              && dotnet run --project tests/Temporalio.SmokeTest
+          '
+
+    - name: Run smoke test (Linux/macOS)
+      if: ${{ inputs.is-alpine != 'true' && runner.os != 'Windows' }}
+      shell: bash
+      env:
+        PACKAGE_SOURCE: ${{ inputs.package-source }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        version_arg=()
+        [ -n "$VERSION" ] && version_arg=(--version "$VERSION")
+        dotnet add tests/Temporalio.SmokeTest package Temporalio "${version_arg[@]}" -s "$PACKAGE_SOURCE" --prerelease
+        dotnet run --project tests/Temporalio.SmokeTest
+
+    - name: Run smoke test (Windows)
+      if: ${{ inputs.is-alpine != 'true' && runner.os == 'Windows' }}
+      shell: pwsh
+      env:
+        PACKAGE_SOURCE: ${{ inputs.package-source }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        $versionArg = if ($env:VERSION) { @("--version", $env:VERSION) } else { @() }
+        dotnet add tests/Temporalio.SmokeTest package Temporalio @versionArg -s "$env:PACKAGE_SOURCE" --prerelease
+        dotnet run --project tests/Temporalio.SmokeTest
+
+    - name: Setup msbuild (Windows x64 only)
+      if: ${{ inputs.run-dotnet-framework == 'true' }}
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
+
+    - name: Run .NET framework smoke test (Windows x64 only)
+      if: ${{ inputs.run-dotnet-framework == 'true' }}
+      shell: pwsh
+      env:
+        PACKAGE_SOURCE: ${{ inputs.package-source }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        $versionArg = if ($env:VERSION) { @("--version", $env:VERSION) } else { @() }
+        dotnet add tests/Temporalio.SmokeTestDotNetFramework package Temporalio @versionArg -s "$env:PACKAGE_SOURCE" --prerelease
+        msbuild tests/Temporalio.SmokeTestDotNetFramework -t:restore,build -p:Platform=x64
+        tests/Temporalio.SmokeTestDotNetFramework/bin/x64/Debug/Temporalio.SmokeTestDotNetFramework.exe

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -1,10 +1,11 @@
-name: Build Package
+name: NuGet Package
 on:
   push:
     branches:
       - main
       - "releases/*"
   workflow_dispatch: {}
+  workflow_call: {}
 permissions:
   contents: read
 
@@ -219,44 +220,11 @@ jobs:
           name: nuget-package
           path: ${{ github.workspace }}/nuget-package
 
-      - name: Setup .NET (non-Alpine)
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        if: ${{ !contains(matrix.os, 'alpine') }}
+      - name: Run smoke test
+        uses: ./.github/actions/smoke-test
         with:
-          # Specific .NET version required because GitHub macos ARM image has
-          # bad pre-installed .NET version
-          dotnet-version: 10.x
-
-      - name: Run smoke test (Alpine)
-        if: ${{ contains(matrix.os, 'alpine') }}
-        # Use Docker specifically for Alpine ARM 64 to avoid JS action limitations
-        run: |
-          docker run --rm -v "$(pwd):/workspace" -w /workspace \
-            mcr.microsoft.com/dotnet/sdk:10.0-alpine \
-            sh -c ' \
-                dotnet add tests/Temporalio.SmokeTest package Temporalio -s "/workspace/nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json" --prerelease \
-             && dotnet run --project tests/Temporalio.SmokeTest \
-            '
-
-      - name: Run smoke test (Linux/macOS)
-        if: ${{ !contains(matrix.os, 'alpine') && !contains(matrix.os, 'windows') }}
-        run: |
-          dotnet add tests/Temporalio.SmokeTest package Temporalio -s "$GITHUB_WORKSPACE/nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json" --prerelease
-          dotnet run --project tests/Temporalio.SmokeTest
-
-      - name: Run smoke test (Windows)
-        if: ${{ contains(matrix.os, 'windows') }}
-        run: |
-          dotnet add tests/Temporalio.SmokeTest package Temporalio -s "$env:GITHUB_WORKSPACE/nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json" --prerelease
-          dotnet run --project tests/Temporalio.SmokeTest
-
-      - name: Setup msbuild (Windows x64 only)
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
-
-      - name: Run .NET framework smoke test (Windows x64 only)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          dotnet add tests/Temporalio.SmokeTestDotNetFramework package Temporalio -s "$env:GITHUB_WORKSPACE/nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json" --prerelease
-          msbuild tests/Temporalio.SmokeTestDotNetFramework -t:restore,build -p:Platform=x64
-          tests/Temporalio.SmokeTestDotNetFramework/bin/x64/Debug/Temporalio.SmokeTestDotNetFramework.exe
+          # Local folder feed (relative to repo root so it resolves both on the
+          # host and inside the Alpine container) plus nuget.org for dependencies.
+          package-source: "nuget-package/Temporalio/bin/Release;https://api.nuget.org/v3/index.json"
+          is-alpine: ${{ contains(matrix.os, 'alpine') }}
+          run-dotnet-framework: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,113 @@
+name: NuGet Publish
+
+# Reusable publish step: pushes the packed packages to a NuGet gallery using
+# Trusted Publishing (OIDC), then waits until every package is restorable from
+# that gallery.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: >
+          GitHub environment to run the push under. Holds the Trusted Publishing
+          scoping and any manual-approval gate (required reviewers).
+        required: true
+        type: string
+      index-url:
+        description: >
+          V3 package source to push to. Its host is also polled (via
+          /v3-flatcontainer) to confirm the packages are restorable.
+        required: true
+        type: string
+      token-service-url:
+        description: "Trusted Publishing OIDC token-exchange endpoint for this gallery."
+        required: true
+        type: string
+      version:
+        description: "Version expected to appear in the gallery listing."
+        required: true
+        type: string
+      artifact-name:
+        description: "Run artifact containing the .nupkg/.snupkg files to publish."
+        required: false
+        type: string
+        default: nuget-package
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write # Required for Trusted Publishing OIDC token issuance
+    steps:
+      - name: Download NuGet artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ github.workspace }}/nuget-package
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: 10.x
+
+      # Request the short-lived (~1h, single-use) API key immediately before the
+      # push so it cannot expire in transit.
+      - name: NuGet login
+        id: login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        with:
+          user: Temporal
+          token-service-url: ${{ inputs.token-service-url }}
+
+      - name: Push packages
+        run: |
+          dotnet nuget push "$GITHUB_WORKSPACE/nuget-package/**/*.nupkg" \
+            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
+            --source "${{ inputs.index-url }}" \
+            --skip-duplicate
+
+  wait:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Wait for packages to be available
+        env:
+          VERSION: ${{ inputs.version }}
+          INDEX_URL: ${{ inputs.index-url }}
+        run: |
+          set -euo pipefail
+          # Flat-container is served from the same host as the V3 index.
+          host="${INDEX_URL#https://}"
+          host="${host%%/*}"
+          remaining="temporalio temporalio.extensions.diagnosticsource temporalio.extensions.hosting temporalio.extensions.opentelemetry"
+          deadline=$(( $(date +%s) + 1800 )) # 30 minutes
+          while true; do
+            pending=""
+            for pkg in $remaining; do
+              if curl -fsSL "https://$host/v3-flatcontainer/$pkg/index.json" 2>/dev/null \
+                   | jq -e --arg v "$VERSION" '.versions | index($v)' >/dev/null; then
+                echo "  $pkg $VERSION is available on $host"
+              else
+                pending="$pending $pkg"
+              fi
+            done
+            remaining="${pending# }"
+            [ -z "$remaining" ] && break
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "Timed out on $host; still not available:" >&2
+              printf '  - %s\n' $remaining >&2
+              exit 1
+            fi
+            echo "Pending on $host:"
+            printf '  - %s\n' $remaining
+            echo "Waiting for 15s..."
+            sleep 15
+          done
+          echo "All packages $VERSION available on $host"

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -65,10 +65,13 @@ jobs:
           token-service-url: ${{ inputs.token-service-url }}
 
       - name: Push packages
+        env:
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+          INDEX_URL: ${{ inputs.index-url }}
         run: |
           dotnet nuget push "$GITHUB_WORKSPACE/nuget-package/**/*.nupkg" \
-            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
-            --source "${{ inputs.index-url }}" \
+            --api-key "$NUGET_API_KEY" \
+            --source "$INDEX_URL" \
             --skip-duplicate
 
   wait:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,104 @@
+name: Release Publish
+run-name: Release ${{ github.ref_name }}
+
+# Automated NuGet publishing and smoke testing.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/nuget-package.yml
+    permissions:
+      contents: read
+
+  read-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.read.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Read version
+        id: read
+        run: |
+          version=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)
+          if [ -z "$version" ]; then
+            echo "Could not read <Version> from Directory.Build.props" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: $version"
+
+  publish-int:
+    needs:
+      - build
+      - read-version
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/nuget-publish.yml
+    with:
+      environment: nugetint
+      index-url: https://apiint.nugettest.org/v3/index.json
+      token-service-url: https://int.nugettest.org/api/v2/token
+      version: ${{ needs.read-version.outputs.version }}
+
+  smoke-int:
+    needs:
+      - publish-int
+      - read-version
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+      - name: Smoke test against int.nugettest.org
+        uses: ./.github/actions/smoke-test
+        with:
+          # New package resolves from int; transitive/third-party deps from prod.
+          package-source: "https://apiint.nugettest.org/v3/index.json;https://api.nuget.org/v3/index.json"
+          version: ${{ needs.read-version.outputs.version }}
+          run-dotnet-framework: true
+
+  publish-prod:
+    needs:
+      - smoke-int
+      - read-version
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/nuget-publish.yml
+    with:
+      environment: nugetprod
+      index-url: https://api.nuget.org/v3/index.json
+      token-service-url: https://www.nuget.org/api/v2/token
+      version: ${{ needs.read-version.outputs.version }}
+
+  smoke-prod:
+    needs:
+      - publish-prod
+      - read-version
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+      - name: Smoke test against nuget.org
+        uses: ./.github/actions/smoke-test
+        with:
+          package-source: "https://api.nuget.org/v3/index.json"
+          version: ${{ needs.read-version.outputs.version }}
+          run-dotnet-framework: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Renamed `package` GitHub workflow to `nuget-package`; refactored smoke testing steps into `smoke-test` GitHub action.
- New `nuget-publish` GitHub workflow: takes nuget packages from a source, publishes them to the specified registry, and waits for them to be available.
- New `release-publish` GitHub workflow: call `nuget-package` (build, package, full smoke test), call `nuget-publish` for int registry, call `smoke-test` for int registry, call `nuget-publish` for prod registry, and call `smoke-test` for prod registry.

## Why?

Automate the publishing and validation processes.

## Checklist

1. How was this tested: Will test `nuget-package` changes by pushing to `release/test` branch; `release-publish` testing has to happen after it lands in `main` branch, but there is no issue since this is manually invoked.

1. Any docs updates needed? No
