### PR TITLE
Add Standalone Nexus Operation links

### DIFF
--- a/src/Temporalio/Nexus/NexusOperationExecutionContext.cs
+++ b/src/Temporalio/Nexus/NexusOperationExecutionContext.cs
@@ -109,8 +109,9 @@ namespace Temporalio.Nexus
 
         /// <summary>
         /// Gets or sets the <c>common.v1.Link</c>s extracted from the inbound Nexus task so they can
-        /// be attached to RPCs issued by the operation handler. Only WorkflowEvent-shaped links are
-        /// stored; empty if none.
+        /// be attached to RPCs issued by the operation handler. Empty if none. Links whose variant
+        /// cannot be converted by <see cref="ProtoLinkExtensions"/> are dropped during inbound
+        /// conversion.
         /// </summary>
         internal IReadOnlyCollection<Api.Common.V1.Link> RequestLinks { get; set; } =
             Array.Empty<Api.Common.V1.Link>();

--- a/src/Temporalio/Nexus/NexusOperationExecutionContext.cs
+++ b/src/Temporalio/Nexus/NexusOperationExecutionContext.cs
@@ -125,15 +125,14 @@ namespace Temporalio.Nexus
         /// <summary>
         /// Append a link returned by an outbound RPC the operation handler issued (e.g. signal,
         /// signalWithStart, start). The task handler drains the accumulated links when building the
-        /// operation's StartOperationResponse. Null and non-WorkflowEvent links are ignored.
+        /// operation's StartOperationResponse, dropping any whose variant it cannot convert. Null
+        /// links are ignored.
         /// </summary>
         /// <param name="link">Response link to add.</param>
-        /// <returns><c>true</c> if the link was added; <c>false</c> if it was null or not a
-        /// WorkflowEvent-shaped link.</returns>
+        /// <returns><c>true</c> if the link was added; <c>false</c> if it was null.</returns>
         internal bool TryAddResponseLink(Api.Common.V1.Link? link)
         {
-            if (link == null ||
-                link.VariantCase != Api.Common.V1.Link.VariantOneofCase.WorkflowEvent)
+            if (link == null)
             {
                 return false;
             }

--- a/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
@@ -64,6 +64,10 @@ namespace Temporalio.Nexus
                 {
                     try
                     {
+                        if (link.Type == Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName)
+                        {
+                            return new Link { NexusOperation = link.ToNexusOperationLink() };
+                        }
                         return new Link { WorkflowEvent = link.ToWorkflowEvent() };
                     }
                     catch (ArgumentException e)

--- a/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
@@ -64,11 +64,7 @@ namespace Temporalio.Nexus
                 {
                     try
                     {
-                        if (link.Type == Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName)
-                        {
-                            return new Link { NexusOperation = link.ToNexusOperationLink() };
-                        }
-                        return new Link { WorkflowEvent = link.ToWorkflowEvent() };
+                        return link.ToProtoLink();
                     }
                     catch (ArgumentException e)
                     {

--- a/src/Temporalio/Nexus/ProtoLinkExtensions.cs
+++ b/src/Temporalio/Nexus/ProtoLinkExtensions.cs
@@ -86,6 +86,38 @@ namespace Temporalio.Nexus
         }
 
         /// <summary>
+        /// Convert a proto Link to a Nexus link, dispatching on the populated oneof variant.
+        /// </summary>
+        /// <param name="link">Proto link.</param>
+        /// <returns>Nexus link.</returns>
+        /// <exception cref="ArgumentException">If the link variant is not set or unknown.</exception>
+        public static NexusLink ToNexusLink(this Api.Common.V1.Link link) => link.VariantCase switch
+        {
+            Api.Common.V1.Link.VariantOneofCase.WorkflowEvent => link.WorkflowEvent.ToNexusLink(),
+            Api.Common.V1.Link.VariantOneofCase.NexusOperation => link.NexusOperation.ToNexusLink(),
+            _ => throw new ArgumentException($"Unknown link variant: {link.VariantCase}"),
+        };
+
+        /// <summary>
+        /// Convert a Nexus link to a proto Link, dispatching on the link's type.
+        /// </summary>
+        /// <param name="link">Nexus link.</param>
+        /// <returns>Proto link with the appropriate oneof variant populated.</returns>
+        /// <exception cref="ArgumentException">If the link type is unknown or the link is invalid.</exception>
+        public static Api.Common.V1.Link ToProtoLink(this NexusLink link)
+        {
+            if (link.Type == Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName)
+            {
+                return new Api.Common.V1.Link { WorkflowEvent = link.ToWorkflowEvent() };
+            }
+            if (link.Type == Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName)
+            {
+                return new Api.Common.V1.Link { NexusOperation = link.ToNexusOperationLink() };
+            }
+            throw new ArgumentException($"Unknown link type: {link.Type}");
+        }
+
+        /// <summary>
         /// Convert a Nexus link to a nexus operation link.
         /// </summary>
         /// <param name="link">Nexus link.</param>

--- a/src/Temporalio/Nexus/ProtoLinkExtensions.cs
+++ b/src/Temporalio/Nexus/ProtoLinkExtensions.cs
@@ -104,18 +104,14 @@ namespace Temporalio.Nexus
         /// <param name="link">Nexus link.</param>
         /// <returns>Proto link with the appropriate oneof variant populated.</returns>
         /// <exception cref="ArgumentException">If the link type is unknown or the link is invalid.</exception>
-        public static Api.Common.V1.Link ToProtoLink(this NexusLink link)
+        public static Api.Common.V1.Link ToProtoLink(this NexusLink link) => link.Type switch
         {
-            if (link.Type == Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName)
-            {
-                return new Api.Common.V1.Link { WorkflowEvent = link.ToWorkflowEvent() };
-            }
-            if (link.Type == Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName)
-            {
-                return new Api.Common.V1.Link { NexusOperation = link.ToNexusOperationLink() };
-            }
-            throw new ArgumentException($"Unknown link type: {link.Type}");
-        }
+            var t when t == Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName =>
+                new Api.Common.V1.Link { WorkflowEvent = link.ToWorkflowEvent() },
+            var t when t == Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName =>
+                new Api.Common.V1.Link { NexusOperation = link.ToNexusOperationLink() },
+            _ => throw new ArgumentException($"Unknown link type: {link.Type}"),
+        };
 
         /// <summary>
         /// Convert a Nexus link to a nexus operation link.
@@ -125,22 +121,7 @@ namespace Temporalio.Nexus
         /// <exception cref="ArgumentException">If the link is invalid.</exception>
         public static Api.Common.V1.Link.Types.NexusOperation ToNexusOperationLink(this NexusLink link)
         {
-            if (link.Uri.Scheme != "temporal")
-            {
-                throw new ArgumentException("Invalid scheme");
-            }
-            if (link.Uri.Host.Length > 0)
-            {
-                throw new ArgumentException("Unexpected host");
-            }
-            var pathPieces = link.Uri.AbsolutePath.TrimStart('/').Split('/');
-            if (pathPieces.Length != 6 ||
-                pathPieces[0] != "namespaces" ||
-                pathPieces[2] != "nexus-operations" ||
-                pathPieces[5] != "details")
-            {
-                throw new ArgumentException("Invalid path");
-            }
+            var pathPieces = ParseTemporalLinkPath(link, "nexus-operations", "details");
             return new Api.Common.V1.Link.Types.NexusOperation
             {
                 Namespace = Uri.UnescapeDataString(pathPieces[1]),
@@ -157,22 +138,7 @@ namespace Temporalio.Nexus
         /// <exception cref="ArgumentException">If the link is invalid.</exception>
         public static Api.Common.V1.Link.Types.WorkflowEvent ToWorkflowEvent(this NexusLink link)
         {
-            if (link.Uri.Scheme != "temporal")
-            {
-                throw new ArgumentException("Invalid scheme");
-            }
-            if (link.Uri.Host.Length > 0)
-            {
-                throw new ArgumentException("Unexpected host");
-            }
-            var pathPieces = link.Uri.AbsolutePath.TrimStart('/').Split('/');
-            if (pathPieces.Length != 6 ||
-                pathPieces[0] != "namespaces" ||
-                pathPieces[2] != "workflows" ||
-                pathPieces[5] != "history")
-            {
-                throw new ArgumentException("Invalid path");
-            }
+            var pathPieces = ParseTemporalLinkPath(link, "workflows", "history");
             var evt = new Api.Common.V1.Link.Types.WorkflowEvent
             {
                 Namespace = Uri.UnescapeDataString(pathPieces[1]),
@@ -244,6 +210,29 @@ namespace Temporalio.Nexus
             }
 
             return evt;
+        }
+
+        // Validate a Temporal-shaped link URI and return its path segments. Expected path shape
+        // is /namespaces/{namespace}/{kind}/{id}/{run}/{tail}.
+        private static string[] ParseTemporalLinkPath(NexusLink link, string expectedKind, string expectedTail)
+        {
+            if (link.Uri.Scheme != "temporal")
+            {
+                throw new ArgumentException("Invalid scheme");
+            }
+            if (link.Uri.Host.Length > 0)
+            {
+                throw new ArgumentException("Unexpected host");
+            }
+            var pathPieces = link.Uri.AbsolutePath.TrimStart('/').Split('/');
+            if (pathPieces.Length != 6 ||
+                pathPieces[0] != "namespaces" ||
+                pathPieces[2] != expectedKind ||
+                pathPieces[5] != expectedTail)
+            {
+                throw new ArgumentException("Invalid path");
+            }
+            return pathPieces;
         }
     }
 }

--- a/src/Temporalio/Nexus/ProtoLinkExtensions.cs
+++ b/src/Temporalio/Nexus/ProtoLinkExtensions.cs
@@ -71,6 +71,55 @@ namespace Temporalio.Nexus
         }
 
         /// <summary>
+        /// Convert a Nexus operation link to a proto Link.
+        /// </summary>
+        /// <param name="nexusOp">Nexus operation to convert.</param>
+        /// <returns>Nexus link.</returns>
+        public static NexusLink ToNexusLink(this Api.Common.V1.Link.Types.NexusOperation nexusOp)
+        {
+            var builder = new UriBuilder
+            {
+                Scheme = "temporal",
+                Path = "/namespaces/" + Uri.EscapeDataString(nexusOp.Namespace) +
+                    "/nexus-operations/" + Uri.EscapeDataString(nexusOp.OperationId) +
+                    "/" + Uri.EscapeDataString(nexusOp.RunId) + "/details",
+            };
+            return new(builder.Uri, Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName);
+        }
+
+        /// <summary>
+        /// Convert a Nexus link to a nexus operation link.
+        /// </summary>
+        /// <param name="link">Nexus link.</param>
+        /// <returns>Nexus operation link.</returns>
+        /// <exception cref="ArgumentException">If the link is invalid.</exception>
+        public static Api.Common.V1.Link.Types.NexusOperation ToNexusOperationLink(this NexusLink link)
+        {
+            if (link.Uri.Scheme != "temporal")
+            {
+                throw new ArgumentException("Invalid scheme");
+            }
+            if (link.Uri.Host.Length > 0)
+            {
+                throw new ArgumentException("Unexpected host");
+            }
+            var pathPieces = link.Uri.AbsolutePath.TrimStart('/').Split('/');
+            if (pathPieces.Length != 6 ||
+                pathPieces[0] != "namespaces" ||
+                pathPieces[2] != "nexus-operations" ||
+                pathPieces[5] != "details")
+            {
+                throw new ArgumentException("Invalid path");
+            }
+            return new Api.Common.V1.Link.Types.NexusOperation
+            {
+                Namespace = Uri.UnescapeDataString(pathPieces[1]),
+                OperationId = Uri.UnescapeDataString(pathPieces[3]),
+                RunId = Uri.UnescapeDataString(pathPieces[4]),
+            };
+        }
+
+        /// <summary>
         /// Convert a Nexus link to a workflow event.
         /// </summary>
         /// <param name="link">Nexus link.</param>

--- a/src/Temporalio/Nexus/ProtoLinkExtensions.cs
+++ b/src/Temporalio/Nexus/ProtoLinkExtensions.cs
@@ -57,17 +57,64 @@ namespace Temporalio.Nexus
                 queryParams["requestID"] = reqIdRef.RequestId;
             }
 
-            // Build URI
-            var builder = new UriBuilder
+            // Build URI with empty authority so there is no host. UriBuilder cannot be used here
+            // because it defaults Host to "localhost".
+            var uriStr = "temporal:///namespaces/" + Uri.EscapeDataString(evt.Namespace) +
+                "/workflows/" + Uri.EscapeDataString(evt.WorkflowId) + "/" +
+                Uri.EscapeDataString(evt.RunId) + "/history";
+            if (queryParams.Count > 0)
             {
-                Scheme = "temporal",
-                Path = "/namespaces/" + Uri.EscapeDataString(evt.Namespace) + "/workflows/" +
-                    Uri.EscapeDataString(evt.WorkflowId) + "/" + Uri.EscapeDataString(evt.RunId) +
-                    "/history",
-                Query = string.Join("&", queryParams.Select(kvp =>
-                    $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}")),
+                uriStr += "?" + string.Join("&", queryParams.Select(kvp =>
+                    $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}"));
+            }
+            return new(new Uri(uriStr), Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName);
+        }
+
+        /// <summary>
+        /// Convert a Nexus operation link to a proto Link.
+        /// </summary>
+        /// <param name="nexusOp">Nexus operation to convert.</param>
+        /// <returns>Nexus link.</returns>
+        public static NexusLink ToNexusLink(this Api.Common.V1.Link.Types.NexusOperation nexusOp)
+        {
+            // Build URI with empty authority so there is no host. UriBuilder cannot be used here
+            // because it defaults Host to "localhost".
+            var uriStr = "temporal:///namespaces/" + Uri.EscapeDataString(nexusOp.Namespace) +
+                "/nexus-operations/" + Uri.EscapeDataString(nexusOp.OperationId) +
+                "/" + Uri.EscapeDataString(nexusOp.RunId) + "/details";
+            return new(new Uri(uriStr), Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName);
+        }
+
+        /// <summary>
+        /// Convert a Nexus link to a nexus operation link.
+        /// </summary>
+        /// <param name="link">Nexus link.</param>
+        /// <returns>Nexus operation link.</returns>
+        /// <exception cref="ArgumentException">If the link is invalid.</exception>
+        public static Api.Common.V1.Link.Types.NexusOperation ToNexusOperationLink(this NexusLink link)
+        {
+            if (link.Uri.Scheme != "temporal")
+            {
+                throw new ArgumentException("Invalid scheme");
+            }
+            if (link.Uri.Host.Length > 0)
+            {
+                throw new ArgumentException("Unexpected host");
+            }
+            var pathPieces = link.Uri.AbsolutePath.TrimStart('/').Split('/');
+            if (pathPieces.Length != 6 ||
+                pathPieces[0] != "namespaces" ||
+                pathPieces[2] != "nexus-operations" ||
+                pathPieces[5] != "details")
+            {
+                throw new ArgumentException("Invalid path");
+            }
+            return new Api.Common.V1.Link.Types.NexusOperation
+            {
+                Namespace = Uri.UnescapeDataString(pathPieces[1]),
+                OperationId = Uri.UnescapeDataString(pathPieces[3]),
+                RunId = Uri.UnescapeDataString(pathPieces[4]),
             };
-            return new(builder.Uri, Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName);
         }
 
         /// <summary>

--- a/src/Temporalio/Nexus/ProtoLinkExtensions.cs
+++ b/src/Temporalio/Nexus/ProtoLinkExtensions.cs
@@ -57,8 +57,9 @@ namespace Temporalio.Nexus
                 queryParams["requestID"] = reqIdRef.RequestId;
             }
 
-            // Build URI with empty authority so there is no host. UriBuilder cannot be used here
-            // because it defaults Host to "localhost".
+            // Build URI with empty authority so there is no host. UriBuilder cannot be used
+            // here because even with Host explicitly set to "", it emits "temporal:/path"
+            // (single slash) rather than the canonical "temporal:///path" form other SDKs use.
             var uriStr = "temporal:///namespaces/" + Uri.EscapeDataString(evt.Namespace) +
                 "/workflows/" + Uri.EscapeDataString(evt.WorkflowId) + "/" +
                 Uri.EscapeDataString(evt.RunId) + "/history";
@@ -77,8 +78,9 @@ namespace Temporalio.Nexus
         /// <returns>Nexus link.</returns>
         public static NexusLink ToNexusLink(this Api.Common.V1.Link.Types.NexusOperation nexusOp)
         {
-            // Build URI with empty authority so there is no host. UriBuilder cannot be used here
-            // because it defaults Host to "localhost".
+            // Build URI with empty authority so there is no host. UriBuilder cannot be used
+            // here because even with Host explicitly set to "", it emits "temporal:/path"
+            // (single slash) rather than the canonical "temporal:///path" form other SDKs use.
             var uriStr = "temporal:///namespaces/" + Uri.EscapeDataString(nexusOp.Namespace) +
                 "/nexus-operations/" + Uri.EscapeDataString(nexusOp.OperationId) +
                 "/" + Uri.EscapeDataString(nexusOp.RunId) + "/details";
@@ -109,7 +111,7 @@ namespace Temporalio.Nexus
             var t when t == Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName =>
                 new Api.Common.V1.Link { WorkflowEvent = link.ToWorkflowEvent() },
             var t when t == Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName =>
-                new Api.Common.V1.Link { NexusOperation = link.ToNexusOperationLink() },
+                new Api.Common.V1.Link { NexusOperation = link.ToNexusOperation() },
             _ => throw new ArgumentException($"Unknown link type: {link.Type}"),
         };
 
@@ -119,7 +121,7 @@ namespace Temporalio.Nexus
         /// <param name="link">Nexus link.</param>
         /// <returns>Nexus operation link.</returns>
         /// <exception cref="ArgumentException">If the link is invalid.</exception>
-        public static Api.Common.V1.Link.Types.NexusOperation ToNexusOperationLink(this NexusLink link)
+        public static Api.Common.V1.Link.Types.NexusOperation ToNexusOperation(this NexusLink link)
         {
             var pathPieces = ParseTemporalLinkPath(link, "nexus-operations", "details");
             return new Api.Common.V1.Link.Types.NexusOperation

--- a/src/Temporalio/Worker/NexusWorker.cs
+++ b/src/Temporalio/Worker/NexusWorker.cs
@@ -203,21 +203,19 @@ namespace Temporalio.Worker
             NexusOperationExecutionContext.AsyncLocalCurrent.Value = executionContext;
             // Stash the inbound links in common.v1.Link form on the operation context so the RPCs
             // the handler issues (e.g. signal, signalWithStart, start) can attach them to their
-            // request's links field. ToWorkflowEvent only succeeds for WorkflowEvent-shaped links;
-            // links of other shapes (e.g. non-temporal URLs) are intentionally dropped because the
-            // RPCs the handler issues require the WorkflowEvent variant. Log so a debugging session
-            // can see what was dropped.
+            // request's links field. Unparseable links are dropped with a warning so a debugging
+            // session can see what was dropped.
             executionContext.RequestLinks = context.InboundLinks.Select(link =>
             {
                 try
                 {
-                    return new Api.Common.V1.Link { WorkflowEvent = link.ToWorkflowEvent() };
+                    return link.ToProtoLink();
                 }
                 catch (ArgumentException e)
                 {
                     logger.LogWarning(
                         e,
-                        "Dropping inbound Nexus link from outbound link propagation: type='{Type}', url='{Url}' (not a parseable temporal WorkflowEvent link)",
+                        "Dropping inbound Nexus link from outbound link propagation: type='{Type}', url='{Url}'",
                         link.Type,
                         link.Uri);
                     return null;
@@ -231,8 +229,22 @@ namespace Temporalio.Worker
                 // Drain any response links captured from outbound RPCs the handler issued (e.g.
                 // signal, signalWithStart, start) and attach them to both the sync and async
                 // response so the caller workflow's history event links to each event on the callee.
-                var responseLinks = executionContext.ResponseLinks
-                    .Select(l => l.WorkflowEvent.ToNexusLink());
+                // Links whose variant isn't a supported shape are dropped with a warning.
+                var responseLinks = executionContext.ResponseLinks.Select(l =>
+                {
+                    try
+                    {
+                        return l.ToNexusLink();
+                    }
+                    catch (ArgumentException e)
+                    {
+                        logger.LogWarning(
+                            e,
+                            "Dropping outbound RPC response link with unsupported variant: {Variant}",
+                            l.VariantCase);
+                        return null;
+                    }
+                }).OfType<NexusLink>();
                 var links = context.OutboundLinks
                     .Concat(responseLinks)
                     .Select(l => new Api.Nexus.V1.Link() { Type = l.Type, Url = l.Uri.ToString(), });

--- a/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
@@ -115,6 +115,29 @@ public class TemporalClientNexusOperationTests : WorkflowEnvironmentTestBase
                 (Func<OperationStartContext, string, NoValue>)((ctx, input) => default!));
     }
 
+    [NexusServiceHandler(typeof(ITestService))]
+    public class CapturingWorkflowBackedEchoHandler
+    {
+        public NexusWorkflowRunHandle<string>? CapturedHandle { get; private set; }
+
+        [NexusOperationHandler]
+        public IOperationHandler<string, string> Echo() =>
+            WorkflowRunOperationHandler.FromHandleFactory(
+                async (WorkflowRunOperationContext context, string input) =>
+                {
+                    var handle = await context.StartWorkflowAsync(
+                        (EchoWorkflow wf) => wf.RunAsync(input),
+                        new() { Id = $"wf-{Guid.NewGuid()}" });
+                    CapturedHandle = handle;
+                    return handle;
+                });
+
+        [NexusOperationHandler]
+        public IOperationHandler<string, NoValue> NoResult() =>
+            OperationHandler.Sync<string, NoValue>(
+                (Func<OperationStartContext, string, NoValue>)((ctx, input) => default!));
+    }
+
     [Fact]
     public async Task ExecuteNexusOperationAsync_SimpleWithResult_Succeeds()
     {
@@ -434,6 +457,43 @@ public class TemporalClientNexusOperationTests : WorkflowEnvironmentTestBase
             Assert.Equal(
                 operationId,
                 ((TerminateNexusOperationInput)interceptor.Events[^1].Input).Id);
+        });
+    }
+
+    [Fact]
+    public async Task StartNexusOperationAsync_WorkflowBacked_OutboundLinkPointsToStartedWorkflow()
+    {
+        var handler = new CapturingWorkflowBackedEchoHandler();
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var workerOptions = new TemporalWorkerOptions(taskQueue).
+            AddNexusService(handler).
+            AddWorkflow<EchoWorkflow>();
+        var endpointName = $"nexus-endpoint-{taskQueue}";
+        await Env.TestEnv.CreateNexusEndpointAsync(endpointName, taskQueue);
+
+        using var worker = new TemporalWorker(Client, workerOptions);
+        await worker.ExecuteAsync(async () =>
+        {
+            var nexusClient = Client.CreateNexusClient<ITestService>(endpointName);
+            var operationId = $"op-{Guid.NewGuid()}";
+            var handle = await nexusClient.StartNexusOperationAsync<string>(
+                svc => svc.Echo("hello"),
+                new(operationId) { ScheduleToCloseTimeout = TimeSpan.FromMinutes(5) });
+            Assert.Equal("echo:hello", await handle.GetResultAsync());
+
+            Assert.NotNull(handler.CapturedHandle);
+
+            await AssertMore.EventuallyAsync(async () =>
+            {
+                var desc = await handle.DescribeAsync();
+                var link = Assert.Single(desc.RawDescription.Info.Links);
+                Assert.Equal(Client.Options.Namespace, link.WorkflowEvent.Namespace);
+                Assert.Equal(handler.CapturedHandle.WorkflowId, link.WorkflowEvent.WorkflowId);
+                Assert.Equal(1, link.WorkflowEvent.EventRef.EventId);
+                Assert.Equal(
+                    Api.Enums.V1.EventType.WorkflowExecutionStarted,
+                    link.WorkflowEvent.EventRef.EventType);
+            });
         });
     }
 

--- a/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
@@ -494,6 +494,20 @@ public class TemporalClientNexusOperationTests : WorkflowEnvironmentTestBase
                     Api.Enums.V1.EventType.WorkflowExecutionStarted,
                     link.WorkflowEvent.EventRef.EventType);
             });
+
+            // The started workflow's WorkflowExecutionStarted event should carry the nexus
+            // operation link on its completion callback so the workflow's completion can be
+            // tied back to the nexus operation.
+            var wfHandle = Client.GetWorkflowHandle(handler.CapturedHandle.WorkflowId);
+            var startedEvent = Assert.Single(
+                (await wfHandle.FetchHistoryAsync()).Events,
+                evt => evt.WorkflowExecutionStartedEventAttributes != null);
+            var callback = Assert.Single(
+                startedEvent.WorkflowExecutionStartedEventAttributes.CompletionCallbacks);
+            var backlink = Assert.Single(callback.Links);
+            Assert.Equal(Client.Options.Namespace, backlink.NexusOperation.Namespace);
+            Assert.Equal(operationId, backlink.NexusOperation.OperationId);
+            Assert.Equal(handle.RunId, backlink.NexusOperation.RunId);
         });
     }
 

--- a/tests/Temporalio.Tests/Nexus/NexusOperationExecutionContextTests.cs
+++ b/tests/Temporalio.Tests/Nexus/NexusOperationExecutionContextTests.cs
@@ -57,14 +57,28 @@ public class NexusOperationExecutionContextTests
     }
 
     [Fact]
-    public void TryAddResponseLink_IgnoresNonWorkflowEventLink()
+    public void TryAddResponseLink_AcceptsNexusOperationLink()
     {
         var context = NewContext();
-        // A link with no variant set (e.g. an unset response link) must be dropped.
-        Assert.False(context.TryAddResponseLink(new Link()));
-        // A non-WorkflowEvent variant must also be dropped.
-        Assert.False(context.TryAddResponseLink(new Link { BatchJob = new() { JobId = "batch" } }));
-        Assert.Empty(context.ResponseLinks);
+        var link = new Link
+        {
+            NexusOperation = new() { Namespace = "ns", OperationId = "op", RunId = "run" },
+        };
+        Assert.True(context.TryAddResponseLink(link));
+        Assert.Equal(new[] { link }, context.ResponseLinks);
+    }
+
+    [Fact]
+    public void TryAddResponseLink_AcceptsUnsupportedVariants()
+    {
+        // The gate accepts any non-null link; the drain in NexusWorker is responsible for
+        // dropping links whose variant cannot be converted to a NexusLink.
+        var context = NewContext();
+        var unsetLink = new Link();
+        var batchLink = new Link { BatchJob = new() { JobId = "batch" } };
+        Assert.True(context.TryAddResponseLink(unsetLink));
+        Assert.True(context.TryAddResponseLink(batchLink));
+        Assert.Equal(new[] { unsetLink, batchLink }, context.ResponseLinks);
     }
 
     private static NexusOperationExecutionContext NewContext()

--- a/tests/Temporalio.Tests/Nexus/NexusOperationExecutionContextTests.cs
+++ b/tests/Temporalio.Tests/Nexus/NexusOperationExecutionContextTests.cs
@@ -69,7 +69,7 @@ public class NexusOperationExecutionContextTests
     }
 
     [Fact]
-    public void TryAddResponseLink_AcceptsUnsupportedVariants()
+    public void TryAddResponseLink_AcceptsAllNonNullVariants_DroppingDeferredToDrain()
     {
         // The gate accepts any non-null link; the drain in NexusWorker is responsible for
         // dropping links whose variant cannot be converted to a NexusLink.

--- a/tests/Temporalio.Tests/Nexus/ProtoLinkExtensionsTests.cs
+++ b/tests/Temporalio.Tests/Nexus/ProtoLinkExtensionsTests.cs
@@ -21,7 +21,7 @@ public class ProtoLinkExtensionsTests
             Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName,
             nexusLink.Type);
 
-        var roundTripped = nexusLink.ToNexusOperationLink();
+        var roundTripped = nexusLink.ToNexusOperation();
         Assert.Equal(nexusOp.Namespace, roundTripped.Namespace);
         Assert.Equal(nexusOp.OperationId, roundTripped.OperationId);
         Assert.Equal(nexusOp.RunId, roundTripped.RunId);
@@ -38,7 +38,7 @@ public class ProtoLinkExtensionsTests
         };
 
         var nexusLink = nexusOp.ToNexusLink();
-        var roundTripped = nexusLink.ToNexusOperationLink();
+        var roundTripped = nexusLink.ToNexusOperation();
         Assert.Equal(nexusOp.Namespace, roundTripped.Namespace);
         Assert.Equal(nexusOp.OperationId, roundTripped.OperationId);
         Assert.Equal(nexusOp.RunId, roundTripped.RunId);
@@ -50,7 +50,7 @@ public class ProtoLinkExtensionsTests
         var link = new NexusLink(
             new Uri("https://somehost/namespaces/ns/nexus-operations/op/run/details"),
             Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName);
-        Assert.Throws<ArgumentException>(() => link.ToNexusOperationLink());
+        Assert.Throws<ArgumentException>(() => link.ToNexusOperation());
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class ProtoLinkExtensionsTests
         var link = new NexusLink(
             new Uri("temporal://somehost/namespaces/ns/nexus-operations/op/run/details"),
             Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName);
-        Assert.Throws<ArgumentException>(() => link.ToNexusOperationLink());
+        Assert.Throws<ArgumentException>(() => link.ToNexusOperation());
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class ProtoLinkExtensionsTests
         var link = new NexusLink(
             new Uri("temporal:///namespaces/ns/workflows/wf/run/history"),
             Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName);
-        Assert.Throws<ArgumentException>(() => link.ToNexusOperationLink());
+        Assert.Throws<ArgumentException>(() => link.ToNexusOperation());
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class ProtoLinkExtensionsTests
         Assert.Equal(
             Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName,
             nexusLink.Type);
-        Assert.Equal(protoLink.NexusOperation, nexusLink.ToNexusOperationLink());
+        Assert.Equal(protoLink.NexusOperation, nexusLink.ToNexusOperation());
     }
 
     [Fact]

--- a/tests/Temporalio.Tests/Nexus/ProtoLinkExtensionsTests.cs
+++ b/tests/Temporalio.Tests/Nexus/ProtoLinkExtensionsTests.cs
@@ -72,6 +72,82 @@ public class ProtoLinkExtensionsTests
     }
 
     [Fact]
+    public void ToProtoLink_NexusOperationShape_RoundTrips()
+    {
+        var nexusOp = new Api.Common.V1.Link.Types.NexusOperation
+        {
+            Namespace = "ns",
+            OperationId = "op-id",
+            RunId = "run-id",
+        };
+        var protoLink = nexusOp.ToNexusLink().ToProtoLink();
+        Assert.Equal(nexusOp, protoLink.NexusOperation);
+    }
+
+    [Fact]
+    public void ToProtoLink_WorkflowEventShape_RoundTrips()
+    {
+        var wfEvent = new Api.Common.V1.Link.Types.WorkflowEvent
+        {
+            Namespace = "ns",
+            WorkflowId = "wf",
+            RunId = "run-id",
+            EventRef = new() { EventId = 1, EventType = Api.Enums.V1.EventType.WorkflowExecutionStarted },
+        };
+        var protoLink = wfEvent.ToNexusLink().ToProtoLink();
+        Assert.Equal(wfEvent, protoLink.WorkflowEvent);
+    }
+
+    [Fact]
+    public void ToProtoLink_RejectsUnknownType()
+    {
+        var link = new NexusLink(
+            new Uri("temporal:///namespaces/ns/nexus-operations/op/run/details"),
+            "some.unknown.LinkType");
+        Assert.Throws<ArgumentException>(() => link.ToProtoLink());
+    }
+
+    [Fact]
+    public void ProtoToNexusLink_NexusOperationVariant_Dispatches()
+    {
+        var protoLink = new Api.Common.V1.Link
+        {
+            NexusOperation = new() { Namespace = "ns", OperationId = "op", RunId = "run" },
+        };
+        var nexusLink = protoLink.ToNexusLink();
+        Assert.Equal(
+            Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName,
+            nexusLink.Type);
+        Assert.Equal(protoLink.NexusOperation, nexusLink.ToNexusOperationLink());
+    }
+
+    [Fact]
+    public void ProtoToNexusLink_WorkflowEventVariant_Dispatches()
+    {
+        var protoLink = new Api.Common.V1.Link
+        {
+            WorkflowEvent = new()
+            {
+                Namespace = "ns",
+                WorkflowId = "wf",
+                RunId = "run",
+                EventRef = new() { EventId = 1, EventType = Api.Enums.V1.EventType.WorkflowExecutionStarted },
+            },
+        };
+        var nexusLink = protoLink.ToNexusLink();
+        Assert.Equal(
+            Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName,
+            nexusLink.Type);
+        Assert.Equal(protoLink.WorkflowEvent, nexusLink.ToWorkflowEvent());
+    }
+
+    [Fact]
+    public void ProtoToNexusLink_RejectsUnsetVariant()
+    {
+        Assert.Throws<ArgumentException>(() => new Api.Common.V1.Link().ToNexusLink());
+    }
+
+    [Fact]
     public void WorkflowEvent_ToNexusLink_RoundTrips()
     {
         var wfEvent = new Api.Common.V1.Link.Types.WorkflowEvent

--- a/tests/Temporalio.Tests/Nexus/ProtoLinkExtensionsTests.cs
+++ b/tests/Temporalio.Tests/Nexus/ProtoLinkExtensionsTests.cs
@@ -1,0 +1,97 @@
+namespace Temporalio.Tests.Nexus;
+
+using NexusRpc;
+using Temporalio.Nexus;
+using Xunit;
+
+public class ProtoLinkExtensionsTests
+{
+    [Fact]
+    public void NexusOperation_ToNexusLink_RoundTrips()
+    {
+        var nexusOp = new Api.Common.V1.Link.Types.NexusOperation
+        {
+            Namespace = "my-namespace",
+            OperationId = "my-op-id",
+            RunId = "my-run-id",
+        };
+
+        var nexusLink = nexusOp.ToNexusLink();
+        Assert.Equal(
+            Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName,
+            nexusLink.Type);
+
+        var roundTripped = nexusLink.ToNexusOperationLink();
+        Assert.Equal(nexusOp.Namespace, roundTripped.Namespace);
+        Assert.Equal(nexusOp.OperationId, roundTripped.OperationId);
+        Assert.Equal(nexusOp.RunId, roundTripped.RunId);
+    }
+
+    [Fact]
+    public void NexusOperation_ToNexusLink_SpecialCharactersRoundTrip()
+    {
+        var nexusOp = new Api.Common.V1.Link.Types.NexusOperation
+        {
+            Namespace = "ns/with spaces",
+            OperationId = "op?id=1&foo=bar",
+            RunId = "run+id",
+        };
+
+        var nexusLink = nexusOp.ToNexusLink();
+        var roundTripped = nexusLink.ToNexusOperationLink();
+        Assert.Equal(nexusOp.Namespace, roundTripped.Namespace);
+        Assert.Equal(nexusOp.OperationId, roundTripped.OperationId);
+        Assert.Equal(nexusOp.RunId, roundTripped.RunId);
+    }
+
+    [Fact]
+    public void ToNexusOperationLink_RejectsNonTemporalScheme()
+    {
+        var link = new NexusLink(
+            new Uri("https://somehost/namespaces/ns/nexus-operations/op/run/details"),
+            Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName);
+        Assert.Throws<ArgumentException>(() => link.ToNexusOperationLink());
+    }
+
+    [Fact]
+    public void ToNexusOperationLink_RejectsUnexpectedHost()
+    {
+        var link = new NexusLink(
+            new Uri("temporal://somehost/namespaces/ns/nexus-operations/op/run/details"),
+            Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName);
+        Assert.Throws<ArgumentException>(() => link.ToNexusOperationLink());
+    }
+
+    [Fact]
+    public void ToNexusOperationLink_RejectsInvalidPath()
+    {
+        var link = new NexusLink(
+            new Uri("temporal:///namespaces/ns/workflows/wf/run/history"),
+            Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName);
+        Assert.Throws<ArgumentException>(() => link.ToNexusOperationLink());
+    }
+
+    [Fact]
+    public void WorkflowEvent_ToNexusLink_RoundTrips()
+    {
+        var wfEvent = new Api.Common.V1.Link.Types.WorkflowEvent
+        {
+            Namespace = "my-namespace",
+            WorkflowId = "my-wf",
+            RunId = "my-run-id",
+            EventRef = new() { EventId = 1, EventType = Api.Enums.V1.EventType.WorkflowExecutionStarted },
+        };
+
+        var nexusLink = wfEvent.ToNexusLink();
+        Assert.Equal(
+            Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName,
+            nexusLink.Type);
+
+        var roundTripped = nexusLink.ToWorkflowEvent();
+        Assert.Equal(wfEvent.Namespace, roundTripped.Namespace);
+        Assert.Equal(wfEvent.WorkflowId, roundTripped.WorkflowId);
+        Assert.Equal(wfEvent.RunId, roundTripped.RunId);
+        Assert.Equal(wfEvent.EventRef.EventId, roundTripped.EventRef.EventId);
+        Assert.Equal(wfEvent.EventRef.EventType, roundTripped.EventRef.EventType);
+    }
+}

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -94,6 +94,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
                         "--dynamic-config-value", "history.enableTransitionHistory=true",
                         "--dynamic-config-value", "activity.startDelayEnabled=true",
                         // Enable standalone Nexus operations
+                        "--dynamic-config-value", "callback.allowedAddresses=[{\"Pattern\":\"*\",\"AllowInsecure\":true}]", // SDK tests use arbitrary callback URLs, permit that on the server
                         "--dynamic-config-value", "nexusoperation.enableStandalone=true",
                         "--dynamic-config-value", "history.enableChasmCallbacks=true",
                         // Enable Nexus cancellation types

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -67,7 +67,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
             {
                 DevServerOptions = new()
                 {
-                    DownloadVersion = "v1.7.1-standalone-nexus-operations",
+                    DownloadVersion = "v1.7.2-standalone-nexus-operations",
                     ExtraArgs = new List<string>
                     {
                         // Disable search attribute cache
@@ -94,6 +94,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
                         "--dynamic-config-value", "history.enableTransitionHistory=true",
                         "--dynamic-config-value", "activity.startDelayEnabled=true",
                         // Enable standalone Nexus operations
+                        "--dynamic-config-value", "callback.allowedAddresses=[{\"Pattern\":\"*\",\"AllowInsecure\":true}]", // SDK tests use arbitrary callback URLs, permit that on the server
                         "--dynamic-config-value", "nexusoperation.enableStandalone=true",
                         "--dynamic-config-value", "history.enableChasmCallbacks=true",
                         // Enable Nexus cancellation types


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add Standalone nexus operation links


## Why?
<!-- Tell your future self why have you made these changes -->

So SANO has nice links in the UI


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Nexus link propagation across worker, workflow start, and client RPC paths; incorrect conversion could break UI cross-links, though invalid links are dropped with warnings and coverage is expanded.
> 
> **Overview**
> Extends Nexus **link propagation** so standalone Nexus operations can round-trip both **workflow event** and **nexus operation** `common.v1.Link` variants, not only workflow-event-shaped links.
> 
> `ProtoLinkExtensions` gains bidirectional conversion (`ToProtoLink` / `ToNexusLink` on proto and `NexusLink`), nexus-operation URI encoding, shared path validation, and **canonical `temporal:///…` URIs** (replacing `UriBuilder` behavior that produced a non-standard single-slash form). Inbound links on workflow starts and Nexus tasks use `ToProtoLink()`; unsupported shapes are **logged and dropped** at conversion time.
> 
> `NexusOperationExecutionContext.TryAddResponseLink` now enqueues any non-null proto link; `NexusWorker` drains response links through `ToNexusLink()` and drops variants it cannot convert. Integration coverage asserts workflow-backed operations expose a workflow-event link on the operation and a **nexus-operation backlink** on the started workflow’s completion callback. Test env adds permissive **callback allowed addresses** for arbitrary callback URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1493b2e3ee123b3f0679d4020bb18fc41ad12f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->