### PR TITLE
Expose continue-as-new backoff start interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ to docs, or any other relevant information.
   workflow so its history events link back to the caller, and the link the server returns for the
   signaled event is attached to the caller workflow's Nexus operation history event. This makes the
   caller and callee mutually navigable in the UI for signal-based Nexus operations.
+- Exposed `BackoffStartInterval` for continue-as-new, to allow the new workflow to start after a delay.

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -1008,6 +1008,11 @@ namespace Temporalio.Worker
                     {
                         cmd.WorkflowTaskTimeout = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(taskTimeout);
                     }
+                    if (e.Input.Options?.BackoffStartInterval is TimeSpan backoffStartInterval)
+                    {
+                        cmd.BackoffStartInterval =
+                            Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(backoffStartInterval);
+                    }
                     if (e.Input.Options?.Memo is IReadOnlyDictionary<string, object> memo)
                     {
                         cmd.Memo.Add(memo.ToDictionary(

--- a/src/Temporalio/Workflows/ContinueAsNewOptions.cs
+++ b/src/Temporalio/Workflows/ContinueAsNewOptions.cs
@@ -28,6 +28,11 @@ namespace Temporalio.Workflows
         public TimeSpan? TaskTimeout { get; set; }
 
         /// <summary>
+        /// Gets or sets the delay before the first workflow task of the continued run is scheduled.
+        /// </summary>
+        public TimeSpan? BackoffStartInterval { get; set; }
+
+        /// <summary>
         /// Gets or sets the retry policy for continue as new. If unset, defaults to the current
         /// workflow's retry policy.
         /// </summary>

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -1667,6 +1667,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                         ["PastRunIdCount"] = pastRunIds.Count,
                     },
                     RetryPolicy = new() { MaximumAttempts = pastRunIds.Count + 1000 },
+                    BackoffStartInterval = TimeSpan.FromMilliseconds(1),
                 });
         }
     }
@@ -1686,6 +1687,12 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             var result = await handle.GetResultAsync();
             Assert.Equal(5, result.Count);
             Assert.Equal(handle.FirstExecutionRunId, result[0]);
+            var firstRunHandle = handle with { RunId = handle.FirstExecutionRunId };
+            var continuedEvent = (await firstRunHandle.FetchHistoryAsync()).Events.First(
+                evt => evt.WorkflowExecutionContinuedAsNewEventAttributes != null);
+            Assert.Equal(
+                TimeSpan.FromMilliseconds(1),
+                continuedEvent.WorkflowExecutionContinuedAsNewEventAttributes.BackoffStartInterval.ToTimeSpan());
         });
     }
 


### PR DESCRIPTION
Expose the continue-as-new `BackoffStartInterval` option and pass it through to the Core bridge command.

Also updates the Core submodule to pick up the bridge proto field.

Validation:
- `dotnet build src/Temporalio/Temporalio.csproj`
- `dotnet test tests/Temporalio.Tests/Temporalio.Tests.csproj --filter FullyQualifiedName~ExecuteWorkflowAsync_ContinueAsNew_ProperlyContinues`