### PR TITLE
perf: use interpreted expression compilation on more targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,8 @@ to docs, or any other relevant information.
   signaled event is attached to the caller workflow's Nexus operation history event. This makes the
   caller and callee mutually navigable in the UI for signal-based Nexus operations.
 - Exposed `BackoffStartInterval` for continue-as-new, to allow the new workflow to start after a delay.
+
+### Changed
+
+- Reduced CPU usage of type-safe calls (e.g. `ExecuteChildWorkflowAsync(wf => wf.RunAsync(arg))`)
+  by evaluating non-constant arguments via expression interpretation instead of full IL compilation, when supported by the runtime.

--- a/src/Temporalio/Common/ExpressionUtil.cs
+++ b/src/Temporalio/Common/ExpressionUtil.cs
@@ -113,8 +113,10 @@ namespace Temporalio.Common
                 }
                 var expr = Expression.Lambda<Func<object?>>(Expression.Convert(e, typeof(object)));
 
-                // For our use case, we always want to use interpretation if we can
-#if NET471_OR_GREATER
+                // Prefer interpretation over full IL compilation: it is far cheaper for these
+                // single-use lambdas by avoiding Reflection.Emit + JIT work. The compile targets
+                // for net470 and lower lack the overload.
+#if NETSTANDARD2_0 || NETCOREAPP || NET471_OR_GREATER
                 return expr.Compile(true)();
 #else
                 return expr.Compile()();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Include more compilation targets in the interpreted expression compilation path. This does not guarantee that the expressions will use a lightweight interpreter but does enable it if the runtime supports it. See https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions.expression-1.compile?view=net-10.0#system-linq-expressions-expression-1-compile(system-boolean)

## Why?

Better CPU performance; do not need to pay for full IL compilation (Reflection.Emit and JIT) for single-use expressions.

## Checklist

1. Closes #751 

2. How was this tested: Build and use existing tests; tested that a .NET Standard 2.0 library with interpreted expression compilation will load and execute on a .NET Framework 4.6.2 container on Windows.

3. Any docs updates needed? No
