### PR TITLE
set grpc compression default to none

### DIFF
--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -79,10 +79,11 @@ namespace Temporalio.Client
         /// Gets or sets the transport-level gRPC compression for this connection.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="GrpcCompression.Gzip"/>, which compresses outbound requests and
-        /// accepts compressed responses. Set to <see cref="GrpcCompression.None"/> to opt out.
+        /// Defaults to <see cref="GrpcCompression.None"/>, which does not compress requests or
+        /// advertise acceptance of compressed responses. Set to <see cref="GrpcCompression.Gzip"/>
+        /// to compress outbound requests and accept compressed responses.
         /// </remarks>
-        public GrpcCompression GrpcCompression { get; set; } = new GrpcCompression.Gzip();
+        public GrpcCompression GrpcCompression { get; set; } = new GrpcCompression.None();
 
         /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).

--- a/tests/Temporalio.Tests/Client/TemporalConnectionOptionsTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalConnectionOptionsTests.cs
@@ -244,7 +244,7 @@ public unsafe class TemporalConnectionOptionsTests
         var interopOptions = options.ToInteropOptions(scope);
 
         Assert.Equal(
-            Bridge.Interop.TemporalCoreClientGrpcCompression.Gzip,
+            Bridge.Interop.TemporalCoreClientGrpcCompression.None,
             interopOptions.grpc_compression);
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Set gRPC compression to None by default.

## Why?

Set default None and allow customers to opt into gRPC compression. Likely to flip to gzip on by default at later release.