### PR TITLE
chore(ci): use mise for installing protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,25 @@ jobs:
           # bad pre-installed .NET version
           dotnet-version: '10.x'
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+      - name: Read mise version
+        id: mise-version
+        shell: bash
+        run: |
+          version=$(sed -n 's/^min_version = "\([^"]*\)".*/\1/p' mise.toml)
+          if [ -z "$version" ]; then
+            echo "::error::Could not read min_version from mise.toml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Run mise install
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.mise-version.outputs.version }}
+
+      - name: Set PROTOC
+        shell: bash
+        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
 
       - name: Regen confirm unchanged
         if: ${{ matrix.checkTarget }}

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -6,8 +6,6 @@ on:
       - "releases/*"
   workflow_dispatch: {}
   workflow_call: {}
-  # TEMPORARY: run on PRs to validate the mise-based protoc setup (esp. container legs) end-to-end. Revert before merge.
-  pull_request:
 permissions:
   contents: read
 

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -6,6 +6,8 @@ on:
       - "releases/*"
   workflow_dispatch: {}
   workflow_call: {}
+  # TEMPORARY: run on PRs to validate the mise-based protoc setup (esp. container legs) end-to-end. Revert before merge.
+  pull_request:
 permissions:
   contents: read
 
@@ -31,27 +33,23 @@ jobs:
             out-prefix: linux-x64
             # We use the Python manylinux image for glibc compatibility
             container: quay.io/pypa/manylinux2014_x86_64
-            protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
           - os: ubuntu-arm
             out-file: libtemporalio_sdk_core_c_bridge.so
             out-prefix: linux-arm64
             runsOn: ubuntu-24.04-arm64-2-core
             # We use the Python manylinux image for glibc compatibility
             container: quay.io/pypa/manylinux2014_aarch64
-            protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
           - os: alpine-latest
             out-file: libtemporalio_sdk_core_c_bridge.so
             out-prefix: linux-musl-x64
             # Need Alpine container since GH runner doesn't have one
             container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
-            protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
             runsOn: ubuntu-latest
           - os: alpine-arm
             out-file: libtemporalio_sdk_core_c_bridge.so
             out-prefix: linux-musl-arm64
             # Need Alpine container since GH runner doesn't have one
             container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
-            protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
             runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-intel
             out-file: libtemporalio_sdk_core_c_bridge.dylib
@@ -75,6 +73,17 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Read mise version
+        id: mise-version
+        shell: bash
+        run: |
+          version=$(sed -n 's/^min_version = "\([^"]*\)".*/\1/p' mise.toml)
+          if [ -z "$version" ]; then
+            echo "::error::Could not read min_version from mise.toml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Install Rust
         if: ${{ !matrix.container }}
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -90,12 +99,16 @@ jobs:
           key: ${{ matrix.os }}
           cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
 
-      - name: Install protoc
+      - name: Run mise install
         if: ${{ !matrix.container }}
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.mise-version.outputs.version }}
+
+      - name: Set PROTOC
+        if: ${{ !matrix.container }}
+        shell: bash
+        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
 
       - name: Build (non-Docker)
         if: ${{ !matrix.container }}
@@ -104,14 +117,17 @@ jobs:
       - name: Build (Docker non-Alpine)
         if: ${{ matrix.container && matrix.os != 'alpine-latest' && matrix.os != 'alpine-arm' }}
         run: |
+          # MISE_INSTALL_MUSL forces the static musl mise; its gnu build needs glibc 2.18, newer than manylinux2014's 2.17.
           docker run --rm -v "$(pwd):/workspace" -w /workspace \
             ${{ matrix.container }} \
             sh -c ' \
                 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y \
              && . $HOME/.cargo/env \
-             && curl -LO ${{ matrix.protobuf-url }} \
-             && unzip protoc-*.zip -d /usr/local/protobuf \
-             && export PATH="$PATH:/usr/local/protobuf/bin" \
+             && curl https://mise.run | MISE_VERSION=v${{ steps.mise-version.outputs.version }} MISE_INSTALL_MUSL=1 sh \
+             && export PATH="$HOME/.local/bin:$PATH" \
+             && mise trust /workspace/mise.toml \
+             && mise install \
+             && export PROTOC="$(mise which protoc)" \
              && cargo build --manifest-path src/Temporalio/Bridge/sdk-core/crates/sdk-core-c-bridge/Cargo.toml --profile release-lto \
             '
 
@@ -124,9 +140,11 @@ jobs:
                 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y \
              && . $HOME/.cargo/env \
              && apk add --no-cache build-base \
-             && curl -LO ${{ matrix.protobuf-url }} \
-             && unzip protoc-*.zip -d /usr/local/protobuf \
-             && export PATH="$PATH:/usr/local/protobuf/bin" \
+             && curl https://mise.run | MISE_VERSION=v${{ steps.mise-version.outputs.version }} MISE_INSTALL_MUSL=1 sh \
+             && export PATH="$HOME/.local/bin:$PATH" \
+             && mise trust /workspace/mise.toml \
+             && mise install \
+             && export PROTOC="$(mise which protoc)" \
              && RUSTFLAGS="-C target-feature=-crt-static" cargo build --manifest-path src/Temporalio/Bridge/sdk-core/crates/sdk-core-c-bridge/Cargo.toml --profile release-lto \
             '
 

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -30,12 +30,25 @@ jobs:
         with:
           dotnet-version: '10.x'
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+      - name: Read mise version
+        id: mise-version
+        shell: bash
+        run: |
+          version=$(sed -n 's/^min_version = "\([^"]*\)".*/\1/p' mise.toml)
+          if [ -z "$version" ]; then
+            echo "::error::Could not read min_version from mise.toml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Run mise install
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: '23.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.mise-version.outputs.version }}
+
+      - name: Set PROTOC
+        shell: bash
+        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
 
       - name: Build
         run: dotnet build --configuration Release

--- a/README.md
+++ b/README.md
@@ -1374,9 +1374,9 @@ patch from the windows build when it fails because of a mismatch. It uploads the
 
 ### Regenerating protos
 
-Must have `protoc` on the `PATH`. Note, for now users should use `protoc` 23.x until
-[our GH action downloader](https://github.com/arduino/setup-protoc/issues/99) can support later versions.
-[Here](https://github.com/protocolbuffers/protobuf/releases/tag/v23.4) is the latest 23.x release as of this writing.
+Must have `protoc` on the `PATH`. This project uses [mise](https://mise.jdx.dev/) to manage the `protoc` version,
+matching what CI uses. After [installing mise](https://mise.jdx.dev/getting-started.html), run `mise install` in the
+repository root to install the version pinned in [`mise.toml`](mise.toml) and put `protoc` on your `PATH`.
 
 Then:
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+min_version = "2026.6.14"
+
+[tools]
+protoc = "23.4"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Use `mise` to install `protoc` tool.
- Single-source the versions of `mise` and `protoc` via the `mise.toml` file.

**Note:** As written, this requires local development to update their mise installations to at least to the `2026.6.14` version.

## Why?

- The `setup-protoc` action is no longer maintained and Node 20 GHA EOL is coming quick.
- Allow easier and more consistent maintenance of build tool acquisition and versioning.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: CI build and temporary inclusion of NuGet package build.
1. Any docs updates needed? No
