### PR TITLE
Align bridge env config loading behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ClientEnvConfig` empty `OverrideEnvVars` handling so an explicit empty dictionary no
+  longer falls back to process environment variables.
+
 ### [1.16.0] - 2026-07-01
 
 ### Added

--- a/src/Temporalio/Bridge/EnvConfig.cs
+++ b/src/Temporalio/Bridge/EnvConfig.cs
@@ -24,7 +24,7 @@ namespace Temporalio.Bridge
 
             try
             {
-                var envVarsRef = options.OverrideEnvVars?.Count > 0
+                var envVarsRef = options.OverrideEnvVars != null
                     ? scope.ByteArray(JsonSerializer.Serialize(options.OverrideEnvVars))
                     : ByteArrayRef.Empty.Ref;
 
@@ -60,7 +60,7 @@ namespace Temporalio.Bridge
 
             try
             {
-                var envVarsRef = options.OverrideEnvVars?.Count > 0
+                var envVarsRef = options.OverrideEnvVars != null
                     ? scope.ByteArray(JsonSerializer.Serialize(options.OverrideEnvVars))
                     : ByteArrayRef.Empty.Ref;
 

--- a/src/Temporalio/Bridge/EnvConfig.cs
+++ b/src/Temporalio/Bridge/EnvConfig.cs
@@ -24,9 +24,7 @@ namespace Temporalio.Bridge
 
             try
             {
-                var envVarsRef = options.OverrideEnvVars != null
-                    ? scope.ByteArray(JsonSerializer.Serialize(options.OverrideEnvVars))
-                    : ByteArrayRef.Empty.Ref;
+                var envVarsRef = ToEnvVarsRef(scope, options.OverrideEnvVars);
 
                 unsafe
                 {
@@ -60,9 +58,7 @@ namespace Temporalio.Bridge
 
             try
             {
-                var envVarsRef = options.OverrideEnvVars != null
-                    ? scope.ByteArray(JsonSerializer.Serialize(options.OverrideEnvVars))
-                    : ByteArrayRef.Empty.Ref;
+                var envVarsRef = ToEnvVarsRef(scope, options.OverrideEnvVars);
 
                 unsafe
                 {
@@ -86,6 +82,18 @@ namespace Temporalio.Bridge
                 throw new InvalidOperationException($"Failed to deserialize client config profile: {ex.Message}", ex);
             }
         }
+
+        /// <summary>
+        /// Convert environment variable overrides into the byte array reference sent to core.
+        /// </summary>
+        /// <param name="scope">Scope owning the created byte array reference.</param>
+        /// <param name="overrideEnvVars">Environment variable overrides, or null to use the process environment.</param>
+        /// <returns>Byte array reference for the core load options.</returns>
+        internal static Interop.TemporalCoreByteArrayRef ToEnvVarsRef(
+            Scope scope, IReadOnlyDictionary<string, string>? overrideEnvVars) =>
+            overrideEnvVars == null ?
+                ByteArrayRef.Empty.Ref :
+                scope.ByteArray(JsonSerializer.Serialize(overrideEnvVars));
 
         /// <summary>
         /// Creates a ClientConfigProfile from typed JSON data.

--- a/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
+++ b/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Temporalio.Common.EnvConfig;
 using Xunit;
 using Xunit.Abstractions;
@@ -47,6 +48,8 @@ server_ca_cert_data = ""ca-pem-data""
 client_cert_data = ""client-crt-data""
 client_key_data = ""client-key-data""
 ";
+
+        private const string EmptyEnvOverrideChild = "TEMPORAL_TEST_EMPTY_ENV_OVERRIDE_CHILD";
 
         public ClientConfigTests(ITestOutputHelper output)
             : base(output)
@@ -196,7 +199,7 @@ client_key_data = ""client-key-data""
             Assert.Equal("test-namespace", options.Namespace);
         }
 
-        // === ENVIRONMENT VARIABLES TESTS (4 tests) ===
+        // === ENVIRONMENT VARIABLES TESTS (5 tests) ===
         [Fact]
         public void Test_Load_Profile_Grpc_Meta_Env_Overrides()
         {
@@ -285,6 +288,60 @@ x-custom-header = ""custom-value""
             });
 
             Assert.Equal("default-address", profile.Address);
+        }
+
+        [Fact]
+        public async Task Test_Load_Profile_Empty_Env_Override_Uses_Explicit_Empty_Environment()
+        {
+            if (Environment.GetEnvironmentVariable(EmptyEnvOverrideChild) == "1")
+            {
+                var systemProfile = ClientEnvConfig.Profile.Load(new ClientEnvConfig.ProfileLoadOptions
+                {
+                    Profile = "default",
+                    DisableFile = true,
+                });
+                Assert.Equal("process-env-address", systemProfile.Address);
+                Assert.Equal("process-env-namespace", systemProfile.Namespace);
+
+                var emptyOverrideProfile = ClientEnvConfig.Profile.Load(new ClientEnvConfig.ProfileLoadOptions
+                {
+                    Profile = "default",
+                    DisableFile = true,
+                    OverrideEnvVars = new Dictionary<string, string>(),
+                });
+                Assert.Null(emptyOverrideProfile.Address);
+                Assert.Null(emptyOverrideProfile.Namespace);
+                return;
+            }
+
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = Directory.GetCurrentDirectory(),
+                },
+            };
+            process.StartInfo.ArgumentList.Add(typeof(Program).Assembly.Location);
+            process.StartInfo.ArgumentList.Add("-method");
+            process.StartInfo.ArgumentList.Add(
+                $"{typeof(ClientConfigTests).FullName}.{nameof(Test_Load_Profile_Empty_Env_Override_Uses_Explicit_Empty_Environment)}");
+            process.StartInfo.Environment[EmptyEnvOverrideChild] = "1";
+            process.StartInfo.Environment["TEMPORAL_ADDRESS"] = "process-env-address";
+            process.StartInfo.Environment["TEMPORAL_NAMESPACE"] = "process-env-namespace";
+
+            Assert.True(process.Start());
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+            Assert.True(
+                process.ExitCode == 0,
+                $"Child process failed with exit code {process.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{stdout}{Environment.NewLine}STDERR:{Environment.NewLine}{stderr}");
         }
 
         // === CONTROL FLAGS TESTS (3 tests) ===

--- a/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
+++ b/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
@@ -1,7 +1,9 @@
-using System.Diagnostics;
 using Temporalio.Common.EnvConfig;
 using Xunit;
 using Xunit.Abstractions;
+using BridgeByteArrayRef = Temporalio.Bridge.ByteArrayRef;
+using BridgeEnvConfig = Temporalio.Bridge.EnvConfig;
+using BridgeScope = Temporalio.Bridge.Scope;
 
 namespace Temporalio.Tests.Common.EnvConfig
 {
@@ -48,8 +50,6 @@ server_ca_cert_data = ""ca-pem-data""
 client_cert_data = ""client-crt-data""
 client_key_data = ""client-key-data""
 ";
-
-        private const string EmptyEnvOverrideChild = "TEMPORAL_TEST_EMPTY_ENV_OVERRIDE_CHILD";
 
         public ClientConfigTests(ITestOutputHelper output)
             : base(output)
@@ -291,57 +291,15 @@ x-custom-header = ""custom-value""
         }
 
         [Fact]
-        public async Task Test_Load_Profile_Empty_Env_Override_Uses_Explicit_Empty_Environment()
+        public unsafe void Test_Load_Profile_Empty_Env_Override_Uses_Explicit_Empty_Environment()
         {
-            if (Environment.GetEnvironmentVariable(EmptyEnvOverrideChild) == "1")
-            {
-                var systemProfile = ClientEnvConfig.Profile.Load(new ClientEnvConfig.ProfileLoadOptions
-                {
-                    Profile = "default",
-                    DisableFile = true,
-                });
-                Assert.Equal("process-env-address", systemProfile.Address);
-                Assert.Equal("process-env-namespace", systemProfile.Namespace);
+            using var scope = new BridgeScope();
 
-                var emptyOverrideProfile = ClientEnvConfig.Profile.Load(new ClientEnvConfig.ProfileLoadOptions
-                {
-                    Profile = "default",
-                    DisableFile = true,
-                    OverrideEnvVars = new Dictionary<string, string>(),
-                });
-                Assert.Null(emptyOverrideProfile.Address);
-                Assert.Null(emptyOverrideProfile.Namespace);
-                return;
-            }
+            var unsetEnvVars = BridgeEnvConfig.ToEnvVarsRef(scope, null);
+            var emptyEnvVars = BridgeEnvConfig.ToEnvVarsRef(scope, new Dictionary<string, string>());
 
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "dotnet",
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false,
-                    WorkingDirectory = Directory.GetCurrentDirectory(),
-                },
-            };
-            process.StartInfo.ArgumentList.Add(typeof(Program).Assembly.Location);
-            process.StartInfo.ArgumentList.Add("-method");
-            process.StartInfo.ArgumentList.Add(
-                $"{typeof(ClientConfigTests).FullName}.{nameof(Test_Load_Profile_Empty_Env_Override_Uses_Explicit_Empty_Environment)}");
-            process.StartInfo.Environment[EmptyEnvOverrideChild] = "1";
-            process.StartInfo.Environment["TEMPORAL_ADDRESS"] = "process-env-address";
-            process.StartInfo.Environment["TEMPORAL_NAMESPACE"] = "process-env-namespace";
-
-            Assert.True(process.Start());
-            var stdoutTask = process.StandardOutput.ReadToEndAsync();
-            var stderrTask = process.StandardError.ReadToEndAsync();
-            await process.WaitForExitAsync();
-            var stdout = await stdoutTask;
-            var stderr = await stderrTask;
-            Assert.True(
-                process.ExitCode == 0,
-                $"Child process failed with exit code {process.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{stdout}{Environment.NewLine}STDERR:{Environment.NewLine}{stderr}");
+            Assert.Equal(UIntPtr.Zero, unsetEnvVars.size);
+            Assert.Equal("{}", BridgeByteArrayRef.ToUtf8(emptyEnvVars));
         }
 
         // === CONTROL FLAGS TESTS (3 tests) ===


### PR DESCRIPTION
## What was changed
Pass empty `OverrideEnvVars` through to bridge environment config loading instead of treating an empty override dictionary as unset.

## Why?
This keeps bridge config-loading behavior aligned with other SDKs and lets an explicit empty override suppress the process environment. This PR was split out from `ea/aws-lambda` so the `EnvConfig.cs` change can be reviewed independently.

## Checklist

1. Closes N/A

2. How was this tested:
Not run; branch split only.

3. Any docs updates needed?
No.