### PR TITLE
chore: pin .NET SDK with latest patch

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -23,10 +23,6 @@ inputs:
     description: "Set to 'true' to also run the net462 smoke test (Windows x64 only)."
     required: false
     default: "false"
-  dotnet-version:
-    description: ".NET SDK version to install on non-Alpine runners."
-    required: false
-    default: "10.x"
 
 runs:
   using: composite
@@ -35,9 +31,7 @@ runs:
       if: ${{ inputs.is-alpine != 'true' }}
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
-        # Specific .NET version required because GitHub macos ARM image has
-        # bad pre-installed .NET version
-        dotnet-version: ${{ inputs.dotnet-version }}
+        global-json-file: global.json
 
     - name: Run smoke test (Alpine)
       if: ${{ inputs.is-alpine == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
-          # Specific .NET version required because GitHub macos ARM image has
-          # bad pre-installed .NET version
-          dotnet-version: '10.x'
+          global-json-file: global.json
 
       - name: Read mise version
         id: mise-version

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -6,10 +6,6 @@ on:
       - "releases/*"
   workflow_dispatch: {}
   workflow_call: {}
-  # Temporary PR trigger for testing workflow changes. Remove before merging.
-  pull_request:
-    branches:
-      - main
 permissions:
   contents: read
 

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -6,6 +6,10 @@ on:
       - "releases/*"
   workflow_dispatch: {}
   workflow_call: {}
+  # Temporary PR trigger for testing workflow changes. Remove before merging.
+  pull_request:
+    branches:
+      - main
 permissions:
   contents: read
 
@@ -173,7 +177,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
-          dotnet-version: 10.x
+          global-json-file: global.json
 
       - name: Build package
         run: dotnet pack -c Release /p:BridgeLibraryRoot=${{ github.workspace }}/bridge-libraries

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
-          dotnet-version: 10.x
+          global-json-file: global.json
 
       # Request the short-lived (~1h, single-use) API key immediately before the
       # push so it cannot expire in transit.

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
-          dotnet-version: '10.x'
+          global-json-file: global.json
 
       - name: Read mise version
         id: mise-version

--- a/README.md
+++ b/README.md
@@ -1297,7 +1297,7 @@ To fix this, the `WEBSITE_LOAD_USER_PROFILE` environment can be set to `1` to lo
 
 Prerequisites:
 
-* [.NET](https://learn.microsoft.com/en-us/dotnet/core/install/)
+* [.NET SDK](https://learn.microsoft.com/en-us/dotnet/core/install/) — version pinned in [`global.json`](global.json)
 * [Rust](https://www.rust-lang.org/) (i.e. `cargo` on the `PATH`)
 * [Protobuf Compiler](https://protobuf.dev/) (i.e. `protoc` on the `PATH`)
 * This repository, cloned recursively

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Pin the .NET SDK using global.json file.

## Why?

Naturally define the minimum .NET SDK needed to build the product in one place.

## Checklist
<!--- add/delete as needed --->

1. Closes #563 
1. How was this tested: CI build
1. Any docs updates needed? No