### PR TITLE
Preserve disabled TLS env config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to docs, or any other relevant information.
 
 - Fixed `ClientEnvConfig` empty `OverrideEnvVars` handling so an explicit empty dictionary no
   longer falls back to process environment variables.
+- Fixed `ClientEnvConfig` TLS-disabled profiles to preserve disabled TLS in connection options.
 
 ### [1.16.0] - 2026-07-01
 

--- a/src/Temporalio/Common/EnvConfig/ClientEnvConfig.cs
+++ b/src/Temporalio/Common/EnvConfig/ClientEnvConfig.cs
@@ -206,7 +206,7 @@ namespace Temporalio.Common.EnvConfig
             {
                 if (Disabled == true)
                 {
-                    return null;
+                    return new TlsOptions { Disabled = true };
                 }
 
                 return new TlsOptions

--- a/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
+++ b/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
@@ -480,7 +480,8 @@ api_key = ""my-api-key""
             Assert.True(profileDisabled.Tls.Disabled);
 
             var optionsDisabled = profileDisabled.ToClientConnectionOptions();
-            Assert.Null(optionsDisabled.Tls);
+            Assert.NotNull(optionsDisabled.Tls);
+            Assert.True(optionsDisabled.Tls.Disabled);
 
             // Test TLS with certs
             var profileCerts = ClientEnvConfig.Profile.Load(new ClientEnvConfig.ProfileLoadOptions
@@ -697,7 +698,9 @@ server_name = ""should-be-ignored""
                 ConfigSource = DataSource.FromUTF8String(tomlTrue),
             });
             Assert.True(profileTrue.Tls!.Disabled); // explicitly disabled=true
-            Assert.Null(profileTrue.ToClientConnectionOptions().Tls); // TLS disabled even with API key
+            var optionsTrue = profileTrue.ToClientConnectionOptions();
+            Assert.NotNull(optionsTrue.Tls);
+            Assert.True(optionsTrue.Tls.Disabled); // TLS disabled even with API key
         }
 
         // === ERROR HANDLING TESTS (4 tests) ===


### PR DESCRIPTION
Preserve disabled TLS from ClientEnvConfig profiles in connection options and update the existing env config tests. 