### PR TITLE
chore: freeze Amazon.Lambda.Core version in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,11 @@ updates:
     # Security updates still flow through, since update-types ignores don't
     # apply to them. Build- and test-only dependencies are left updatable.
     ignore:
+      - dependency-name: "Amazon.Lambda.Core"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
       - dependency-name: "Google.Protobuf"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Freeze the `Amazon.Lambda.Core` version in the dependabot config so it is not updated for every version except for security updates.

## Why?

Less churn in the package version.