### PR TITLE
refactor(lambda): align Lambda worker APIs with .NET naming conventions

### DIFF
--- a/src/Temporalio.Extensions.Aws.Lambda.OpenTelemetry/LambdaWorkerOpenTelemetryOptions.cs
+++ b/src/Temporalio.Extensions.Aws.Lambda.OpenTelemetry/LambdaWorkerOpenTelemetryOptions.cs
@@ -3,7 +3,7 @@ using System;
 namespace Temporalio.Extensions.Aws.Lambda.OpenTelemetry
 {
     /// <summary>
-    /// Options for <see cref="LambdaWorkerOpenTelemetry.ApplyDefaults"/>.
+    /// Options for <see cref="TemporalLambdaWorkerOptionsExtensions.ApplyOpenTelemetryDefaults"/>.
     /// </summary>
     public class LambdaWorkerOpenTelemetryOptions
     {

--- a/src/Temporalio.Extensions.Aws.Lambda.OpenTelemetry/README.md
+++ b/src/Temporalio.Extensions.Aws.Lambda.OpenTelemetry/README.md
@@ -10,7 +10,7 @@ Add the `Temporalio.Extensions.Aws.Lambda.OpenTelemetry` package from
 
 ## Quick Start
 
-Call `LambdaWorkerOpenTelemetry.ApplyDefaults` from the Lambda worker configure callback:
+Call `ApplyOpenTelemetryDefaults` from the Lambda worker configure callback:
 
 ```csharp
 using Amazon.Lambda.Core;
@@ -21,20 +21,20 @@ using Temporalio.Extensions.Aws.Lambda.OpenTelemetry;
 private static readonly Func<object?, ILambdaContext, Task> WorkerHandler =
     TemporalLambdaWorker.CreateHandler(
         new WorkerDeploymentVersion("payments-worker", "2026-05-27"),
-        config =>
+        options =>
         {
-            LambdaWorkerOpenTelemetry.ApplyDefaults(config);
+            options.ApplyOpenTelemetryDefaults();
 
-            config.WorkerOptions.TaskQueue = "payments";
-            config.WorkerOptions.AddWorkflow<PaymentWorkflow>();
-            config.WorkerOptions.AddActivity(PaymentActivities.ChargeAsync);
+            options.WorkerOptions.TaskQueue = "payments";
+            options.WorkerOptions.AddWorkflow<PaymentWorkflow>();
+            options.WorkerOptions.AddActivity(PaymentActivities.ChargeAsync);
         });
 ```
 
-`ApplyDefaults` configures Temporal tracing with `TracingInterceptor`, creates an OTLP trace exporter and tracer
+`ApplyOpenTelemetryDefaults` configures Temporal tracing with `TracingInterceptor`, creates an OTLP trace exporter and tracer
 provider, configures Core SDK metrics through a `TemporalRuntime`, and registers a per-invocation shutdown hook that
 force-flushes traces before the Lambda invocation ends.
-It replaces any runtime already set on `config.ClientOptions`.
+It replaces any runtime already set on `options.ClientOptions`.
 
 ## Defaults
 
@@ -50,8 +50,7 @@ increase the chance that at least one metrics export happens during each invocat
 periodically and do not have an explicit per-invocation flush API.
 
 ```csharp
-LambdaWorkerOpenTelemetry.ApplyDefaults(
-    config,
+options.ApplyOpenTelemetryDefaults(
     new LambdaWorkerOpenTelemetryOptions
     {
         CollectorEndpoint = "http://localhost:4317",

--- a/src/Temporalio.Extensions.Aws.Lambda.OpenTelemetry/TemporalLambdaWorkerOptionsExtensions.cs
+++ b/src/Temporalio.Extensions.Aws.Lambda.OpenTelemetry/TemporalLambdaWorkerOptionsExtensions.cs
@@ -14,9 +14,10 @@ using TemporalOpenTelemetry = Temporalio.Extensions.OpenTelemetry;
 namespace Temporalio.Extensions.Aws.Lambda.OpenTelemetry
 {
     /// <summary>
-    /// OpenTelemetry helpers for Temporal workers running inside AWS Lambda.
+    /// OpenTelemetry extensions for <see cref="TemporalLambdaWorkerOptions" /> for Temporal
+    /// workers running inside AWS Lambda.
     /// </summary>
-    public static class LambdaWorkerOpenTelemetry
+    public static class TemporalLambdaWorkerOptionsExtensions
     {
         private const string DefaultCollectorEndpoint = "http://localhost:4317";
         private const string DefaultServiceName = "temporal-lambda-worker";
@@ -30,8 +31,8 @@ namespace Temporalio.Extensions.Aws.Lambda.OpenTelemetry
         /// <summary>
         /// Configure OpenTelemetry metrics and tracing with AWS Lambda defaults.
         /// </summary>
-        /// <param name="config">Lambda worker configuration to mutate.</param>
-        /// <param name="options">Optional OpenTelemetry configuration.</param>
+        /// <param name="options">Lambda worker configuration to mutate.</param>
+        /// <param name="openTelemetryOptions">Optional OpenTelemetry configuration.</param>
         /// <remarks>
         /// This creates an OTLP trace exporter and tracer provider, configures Core SDK metrics
         /// through a Temporal runtime, adds the Temporal tracing interceptor, and registers a
@@ -40,24 +41,24 @@ namespace Temporalio.Extensions.Aws.Lambda.OpenTelemetry
         /// Any existing <see cref="Temporalio.Client.TemporalConnectionOptions.Runtime" /> is
         /// replaced.
         /// </remarks>
-        public static void ApplyDefaults(
-            TemporalLambdaWorkerOptions config,
-            LambdaWorkerOpenTelemetryOptions? options = null)
+        public static void ApplyOpenTelemetryDefaults(
+            this TemporalLambdaWorkerOptions options,
+            LambdaWorkerOpenTelemetryOptions? openTelemetryOptions = null)
         {
-            if (config == null)
+            if (options == null)
             {
-                throw new ArgumentNullException(nameof(config));
+                throw new ArgumentNullException(nameof(options));
             }
 
-            var resolvedOptions = ResolveOptions(options);
+            var resolvedOptions = ResolveOptions(openTelemetryOptions);
 #pragma warning disable CA2000 // The per-invocation shutdown hook owns provider disposal.
             var tracerProvider = CreateTracerProvider(resolvedOptions);
 #pragma warning restore CA2000
 
-            config.ClientOptions.Interceptors = AddTracingInterceptor(
-                config.ClientOptions.Interceptors);
-            config.ClientOptions.Runtime = CreateRuntime(resolvedOptions);
-            config.AddShutdownHook(
+            options.ClientOptions.Interceptors = AddTracingInterceptor(
+                options.ClientOptions.Interceptors);
+            options.ClientOptions.Runtime = CreateRuntime(resolvedOptions);
+            options.AddShutdownHook(
                 async cancellationToken =>
                 {
                     // CreateHandler runs configuration once per invocation, so this provider is
@@ -70,7 +71,7 @@ namespace Temporalio.Extensions.Aws.Lambda.OpenTelemetry
                     {
                         await ForceFlushAsync(
                             tracerProvider,
-                            config.ShutdownDeadlineBuffer,
+                            options.ShutdownDeadlineBuffer,
                             cancellationToken).ConfigureAwait(false);
                     }
                     finally

--- a/src/Temporalio.Extensions.Aws.Lambda/README.md
+++ b/src/Temporalio.Extensions.Aws.Lambda/README.md
@@ -21,11 +21,11 @@ public class Function
     private static readonly Func<object?, ILambdaContext, Task> WorkerHandler =
         TemporalLambdaWorker.CreateHandler(
             new WorkerDeploymentVersion("payments-worker", "2026-05-27"),
-            config =>
+            options =>
             {
-                config.WorkerOptions.TaskQueue = "payments";
-                config.WorkerOptions.AddWorkflow<PaymentWorkflow>();
-                config.WorkerOptions.AddActivity(PaymentActivities.ChargeAsync);
+                options.WorkerOptions.TaskQueue = "payments";
+                options.WorkerOptions.AddWorkflow<PaymentWorkflow>();
+                options.WorkerOptions.AddActivity(PaymentActivities.ChargeAsync);
             });
 
     public Task HandlerAsync(object? input, ILambdaContext context) =>
@@ -44,14 +44,14 @@ For setup that must be awaited per invocation, use the async overload:
 private static readonly Func<object?, ILambdaContext, Task> WorkerHandler =
     TemporalLambdaWorker.CreateHandler(
         new WorkerDeploymentVersion("payments-worker", "2026-05-27"),
-        async config =>
+        async options =>
         {
-            config.WorkerOptions.TaskQueue = "payments";
-            config.WorkerOptions.AddWorkflow<PaymentWorkflow>();
-            config.WorkerOptions.AddActivity(PaymentActivities.ChargeAsync);
+            options.WorkerOptions.TaskQueue = "payments";
+            options.WorkerOptions.AddWorkflow<PaymentWorkflow>();
+            options.WorkerOptions.AddActivity(PaymentActivities.ChargeAsync);
 
-            config.ClientOptions.ApiKey = await LoadTemporalApiKeyAsync();
-            config.AddShutdownHook(async cancellationToken =>
+            options.ClientOptions.ApiKey = await LoadTemporalApiKeyAsync();
+            options.AddShutdownHook(async cancellationToken =>
             {
                 await FlushPerInvocationResourceAsync(cancellationToken);
             });
@@ -75,7 +75,7 @@ The file is optional. If it does not exist, only environment variables are used.
 To bypass config loading, assign explicit client options in `configure`:
 
 ```csharp
-config.ClientOptions = new TemporalClientConnectOptions
+options.ClientOptions = new TemporalClientConnectOptions
 {
     TargetHost = "my-namespace.a1b2c.tmprl.cloud:7233",
     Namespace = "my-namespace.a1b2c",
@@ -91,7 +91,7 @@ with async configure, the invocation fails after the callback is awaited.
 `TemporalLambdaWorker.CreateHandler` requires a `WorkerDeploymentVersion` and always enables Worker Versioning by setting
 `WorkerOptions.DeploymentOptions` with `UseWorkerVersioning = true`. Use a deployment name and build ID that match your
 rollout process. The default versioning behavior is `AutoUpgrade`. If you need a different default versioning behavior,
-configure `config.WorkerOptions.DeploymentOptions.DefaultVersioningBehavior`; the handler preserves any non-`Unspecified`
+configure `options.WorkerOptions.DeploymentOptions.DefaultVersioningBehavior`; the handler preserves any non-`Unspecified`
 value while enforcing the deployment version passed to `CreateHandler`.
 
 The helper applies Lambda-oriented worker defaults before `configure`, including lower concurrency, a 5 second graceful
@@ -106,13 +106,13 @@ buffer if your worker needs more time to stop polling, finish shutdown hooks, or
 deadline. Set it in `configure`:
 
 ```csharp
-config.ShutdownDeadlineBuffer = TimeSpan.FromSeconds(15);
+options.ShutdownDeadlineBuffer = TimeSpan.FromSeconds(15);
 ```
 
 Add shutdown hooks for per-invocation cleanup:
 
 ```csharp
-config.AddShutdownHook(async cancellationToken =>
+options.AddShutdownHook(async cancellationToken =>
 {
     await FlushTelemetryAsync(cancellationToken);
 });
@@ -124,12 +124,12 @@ still run. Hooks added from async configure are scoped to that invocation.
 ## Observability
 
 For AWS Lambda OpenTelemetry defaults, add the `Temporalio.Extensions.Aws.Lambda.OpenTelemetry` package and call
-`LambdaWorkerOpenTelemetry.ApplyDefaults` in `configure`:
+`ApplyOpenTelemetryDefaults` in `configure`:
 
 ```csharp
 using Temporalio.Extensions.Aws.Lambda.OpenTelemetry;
 
-LambdaWorkerOpenTelemetry.ApplyDefaults(config);
+options.ApplyOpenTelemetryDefaults();
 ```
 
 This configures Temporal tracing, Core SDK OTLP metrics, AWS X-Ray-compatible trace IDs, and a per-invocation trace
@@ -140,8 +140,8 @@ You can still configure tracing and metrics manually using `Temporalio.Extension
 `TemporalRuntime`:
 
 ```csharp
-config.ClientOptions.Interceptors = new[] { new TracingInterceptor() };
-config.ClientOptions.Runtime = new TemporalRuntime(new TemporalRuntimeOptions
+options.ClientOptions.Interceptors = new[] { new TracingInterceptor() };
+options.ClientOptions.Runtime = new TemporalRuntime(new TemporalRuntimeOptions
 {
     Telemetry = new TelemetryOptions
     {

--- a/src/Temporalio.Extensions.Aws.Lambda/TemporalLambdaWorker.cs
+++ b/src/Temporalio.Extensions.Aws.Lambda/TemporalLambdaWorker.cs
@@ -101,9 +101,9 @@ namespace Temporalio.Extensions.Aws.Lambda
             ValidateCreateHandlerArgs(version, configure, nameof(configure), handlerOptions);
             var state = new ConfiguringLambdaWorkerHandlerState(
                 version,
-                config =>
+                options =>
                 {
-                    configure(config);
+                    configure(options);
                     return Task.CompletedTask;
                 },
                 handlerOptions);
@@ -156,63 +156,63 @@ namespace Temporalio.Extensions.Aws.Lambda
             }
         }
 
-        private static TemporalLambdaWorkerOptions CreateConfig(
+        private static TemporalLambdaWorkerOptions CreateOptions(
             WorkerDeploymentVersion version,
             TemporalLambdaWorkerHandlerOptions handlerOptions)
         {
             var loadClientConnectOptions = handlerOptions.LoadClientConnectOptions;
-            var config = new TemporalLambdaWorkerOptions(
+            var options = new TemporalLambdaWorkerOptions(
                 loadClientConnectOptions == null ?
                     null :
                     () => loadClientConnectOptions(null));
             var environmentTaskQueue = handlerOptions.GetEnvironmentVariable(TaskQueueEnvironmentVariable);
             if (environmentTaskQueue != null)
             {
-                config.WorkerOptions.TaskQueue = environmentTaskQueue;
+                options.WorkerOptions.TaskQueue = environmentTaskQueue;
             }
-            ApplyDeploymentVersion(config.WorkerOptions, version);
+            ApplyDeploymentVersion(options.WorkerOptions, version);
 
-            return config;
+            return options;
         }
 
         private static LambdaWorkerHandlerState PrepareHandlerState(
             WorkerDeploymentVersion version,
-            TemporalLambdaWorkerOptions config,
+            TemporalLambdaWorkerOptions options,
             TemporalLambdaWorkerHandlerOptions handlerOptions)
         {
-            if (config.ClientOptions == null)
+            if (options.ClientOptions == null)
             {
                 throw new InvalidOperationException("ClientOptions must be set");
             }
-            if (config.WorkerOptions == null)
+            if (options.WorkerOptions == null)
             {
                 throw new InvalidOperationException("WorkerOptions must be set");
             }
-            if (config.ShutdownDeadlineBuffer < TimeSpan.Zero)
+            if (options.ShutdownDeadlineBuffer < TimeSpan.Zero)
             {
                 throw new InvalidOperationException("ShutdownDeadlineBuffer cannot be negative");
             }
-            if (string.IsNullOrWhiteSpace(config.WorkerOptions.TaskQueue))
+            if (string.IsNullOrWhiteSpace(options.WorkerOptions.TaskQueue))
             {
                 throw new InvalidOperationException(
                     "WorkerOptions.TaskQueue must be set or TEMPORAL_TASK_QUEUE must be present");
             }
 
             AppendWorkerPlugin(
-                config.WorkerOptions,
+                options.WorkerOptions,
                 new InternalWorkerPlugin(
                     "Temporalio.Extensions.Aws.Lambda",
-                    options =>
+                    workerOptions =>
                     {
-                        ApplyDeploymentVersion(options, version);
-                        ClearConcurrencyLimitsIfTunerSet(options);
+                        ApplyDeploymentVersion(workerOptions, version);
+                        ClearConcurrencyLimitsIfTunerSet(workerOptions);
                     }));
 
             return new LambdaWorkerHandlerState(
-                (TemporalClientConnectOptions)config.ClientOptions.Clone(),
-                (TemporalWorkerOptions)config.WorkerOptions.Clone(),
-                config.ShutdownDeadlineBuffer,
-                new List<Func<CancellationToken, Task>>(config.ShutdownHooks),
+                (TemporalClientConnectOptions)options.ClientOptions.Clone(),
+                (TemporalWorkerOptions)options.WorkerOptions.Clone(),
+                options.ShutdownDeadlineBuffer,
+                new List<Func<CancellationToken, Task>>(options.ShutdownHooks),
                 handlerOptions);
         }
 
@@ -427,9 +427,9 @@ namespace Temporalio.Extensions.Aws.Lambda
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                var config = CreateConfig(version, handlerOptions);
-                await configureAsync(config).ConfigureAwait(false);
-                var state = PrepareHandlerState(version, config, handlerOptions);
+                var options = CreateOptions(version, handlerOptions);
+                await configureAsync(options).ConfigureAwait(false);
+                var state = PrepareHandlerState(version, options, handlerOptions);
                 await state.HandleAsync(input, context).ConfigureAwait(false);
             }
         }

--- a/tests/Temporalio.Tests/Extensions/Aws/Lambda/OpenTelemetry/TemporalLambdaWorkerOptionsExtensionsTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Aws/Lambda/OpenTelemetry/TemporalLambdaWorkerOptionsExtensionsTests.cs
@@ -9,7 +9,7 @@ using Temporalio.Extensions.Aws.Lambda.OpenTelemetry;
 using Xunit;
 using TemporalOpenTelemetry = Temporalio.Extensions.OpenTelemetry;
 
-public class LambdaWorkerOpenTelemetryTests
+public class TemporalLambdaWorkerOptionsExtensionsTests
 {
     private const string OTelExporterOtlpEndpointEnvironmentVariable =
         "OTEL_EXPORTER_OTLP_ENDPOINT";
@@ -18,10 +18,10 @@ public class LambdaWorkerOpenTelemetryTests
     private const string LambdaFunctionNameEnvironmentVariable = "AWS_LAMBDA_FUNCTION_NAME";
 
     [Fact]
-    public void ApplyDefaults_NullConfigThrows()
+    public void ApplyOpenTelemetryDefaults_NullConfigThrows()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            LambdaWorkerOpenTelemetry.ApplyDefaults(null!));
+            TemporalLambdaWorkerOptionsExtensions.ApplyOpenTelemetryDefaults(null!));
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class LambdaWorkerOpenTelemetryTests
             KeyValuePair.Create<string, string?>(
                 LambdaFunctionNameEnvironmentVariable,
                 "lambda-service"));
-        var resolved = LambdaWorkerOpenTelemetry.ResolveOptions(new LambdaWorkerOpenTelemetryOptions
+        var resolved = TemporalLambdaWorkerOptionsExtensions.ResolveOptions(new LambdaWorkerOpenTelemetryOptions
         {
             CollectorEndpoint = "http://explicit:4317",
             ServiceName = "explicit-service",
@@ -62,7 +62,7 @@ public class LambdaWorkerOpenTelemetryTests
             KeyValuePair.Create<string, string?>(
                 LambdaFunctionNameEnvironmentVariable,
                 "lambda-service"));
-        var resolved = LambdaWorkerOpenTelemetry.ResolveOptions();
+        var resolved = TemporalLambdaWorkerOptionsExtensions.ResolveOptions();
 
         Assert.Equal(new Uri("http://env:4317"), resolved.CollectorEndpoint);
         Assert.Equal("env-service", resolved.ServiceName);
@@ -82,7 +82,7 @@ public class LambdaWorkerOpenTelemetryTests
             KeyValuePair.Create<string, string?>(
                 LambdaFunctionNameEnvironmentVariable,
                 "lambda-service"));
-        var resolved = LambdaWorkerOpenTelemetry.ResolveOptions();
+        var resolved = TemporalLambdaWorkerOptionsExtensions.ResolveOptions();
 
         Assert.Equal(new Uri("http://localhost:4317"), resolved.CollectorEndpoint);
         Assert.Equal("lambda-service", resolved.ServiceName);
@@ -101,7 +101,7 @@ public class LambdaWorkerOpenTelemetryTests
             KeyValuePair.Create<string, string?>(
                 LambdaFunctionNameEnvironmentVariable,
                 null));
-        var resolved = LambdaWorkerOpenTelemetry.ResolveOptions();
+        var resolved = TemporalLambdaWorkerOptionsExtensions.ResolveOptions();
 
         Assert.Equal(new Uri("http://localhost:4317"), resolved.CollectorEndpoint);
         Assert.Equal("temporal-lambda-worker", resolved.ServiceName);
@@ -112,7 +112,7 @@ public class LambdaWorkerOpenTelemetryTests
     public void ResolveOptions_InvalidMetricsExportIntervalThrows()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            LambdaWorkerOpenTelemetry.ResolveOptions(
+            TemporalLambdaWorkerOptionsExtensions.ResolveOptions(
                 new LambdaWorkerOpenTelemetryOptions
                 {
                     MetricsExportInterval = TimeSpan.Zero,
@@ -120,7 +120,7 @@ public class LambdaWorkerOpenTelemetryTests
     }
 
     [Fact]
-    public void ApplyDefaults_PreservesInterceptorsAndAddsTracing()
+    public void ApplyOpenTelemetryDefaults_PreservesInterceptorsAndAddsTracing()
     {
         var existingInterceptor = new NoopClientInterceptor();
         var config = new TemporalLambdaWorkerOptions
@@ -131,7 +131,7 @@ public class LambdaWorkerOpenTelemetryTests
             },
         };
 
-        LambdaWorkerOpenTelemetry.ApplyDefaults(config);
+        config.ApplyOpenTelemetryDefaults();
 
         var interceptors = Assert.IsAssignableFrom<IReadOnlyCollection<IClientInterceptor>>(
             config.ClientOptions.Interceptors);
@@ -141,7 +141,7 @@ public class LambdaWorkerOpenTelemetryTests
     }
 
     [Fact]
-    public async Task ApplyDefaults_ConfiguresRuntimeAndShutdownHook()
+    public async Task ApplyOpenTelemetryDefaults_ConfiguresRuntimeAndShutdownHook()
     {
         var config = new TemporalLambdaWorkerOptions
         {
@@ -149,8 +149,7 @@ public class LambdaWorkerOpenTelemetryTests
         };
         config.AddShutdownHook(_ => Task.CompletedTask);
 
-        LambdaWorkerOpenTelemetry.ApplyDefaults(
-            config,
+        config.ApplyOpenTelemetryDefaults(
             new LambdaWorkerOpenTelemetryOptions
             {
                 CollectorEndpoint = "http://localhost:4317",
@@ -176,7 +175,7 @@ public class LambdaWorkerOpenTelemetryTests
 #pragma warning restore CA2000
 
 #pragma warning disable CA2025 // The task is completed before the provider exits scope.
-        var flushTask = LambdaWorkerOpenTelemetry.ForceFlushAsync(
+        var flushTask = TemporalLambdaWorkerOptionsExtensions.ForceFlushAsync(
             provider,
             TimeSpan.FromSeconds(10),
             CancellationToken.None);
@@ -209,7 +208,7 @@ public class LambdaWorkerOpenTelemetryTests
         using var cts = new CancellationTokenSource();
 
 #pragma warning disable CA2025 // The provider exits scope after the blocking flush is released.
-        var flushTask = LambdaWorkerOpenTelemetry.ForceFlushAsync(
+        var flushTask = TemporalLambdaWorkerOptionsExtensions.ForceFlushAsync(
             provider,
             TimeSpan.FromSeconds(10),
             cts.Token);

--- a/tests/Temporalio.Tests/Extensions/Aws/Lambda/TemporalLambdaWorkerTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Aws/Lambda/TemporalLambdaWorkerTests.cs
@@ -24,45 +24,45 @@ public class TemporalLambdaWorkerTests
         TemporalWorkerOptions? capturedWorkerOptions = null;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
                 configureCalls++;
-                Assert.Equal(2, config.WorkerOptions.MaxConcurrentActivities);
-                Assert.Equal(10, config.WorkerOptions.MaxConcurrentWorkflowTasks);
-                Assert.Equal(2, config.WorkerOptions.MaxConcurrentLocalActivities);
-                Assert.Equal(5, config.WorkerOptions.MaxConcurrentNexusTasks);
-                Assert.Equal(TimeSpan.FromSeconds(5), config.WorkerOptions.GracefulShutdownTimeout);
-                Assert.Equal(30, config.WorkerOptions.MaxCachedWorkflows);
-                Assert.Equal(2, config.WorkerOptions.MaxConcurrentWorkflowTaskPolls);
-                Assert.Equal(1, config.WorkerOptions.MaxConcurrentActivityTaskPolls);
-                Assert.Equal(1, config.WorkerOptions.MaxConcurrentNexusTaskPolls);
-                Assert.Null(config.WorkerOptions.WorkflowTaskPollerBehavior);
-                Assert.Null(config.WorkerOptions.ActivityTaskPollerBehavior);
-                Assert.Null(config.WorkerOptions.NexusTaskPollerBehavior);
-                Assert.True(config.WorkerOptions.DisableEagerActivityExecution);
-                Assert.NotNull(config.WorkerOptions.DeploymentOptions);
-                Assert.Equal(Version, config.WorkerOptions.DeploymentOptions.Version);
-                Assert.True(config.WorkerOptions.DeploymentOptions.UseWorkerVersioning);
+                Assert.Equal(2, options.WorkerOptions.MaxConcurrentActivities);
+                Assert.Equal(10, options.WorkerOptions.MaxConcurrentWorkflowTasks);
+                Assert.Equal(2, options.WorkerOptions.MaxConcurrentLocalActivities);
+                Assert.Equal(5, options.WorkerOptions.MaxConcurrentNexusTasks);
+                Assert.Equal(TimeSpan.FromSeconds(5), options.WorkerOptions.GracefulShutdownTimeout);
+                Assert.Equal(30, options.WorkerOptions.MaxCachedWorkflows);
+                Assert.Equal(2, options.WorkerOptions.MaxConcurrentWorkflowTaskPolls);
+                Assert.Equal(1, options.WorkerOptions.MaxConcurrentActivityTaskPolls);
+                Assert.Equal(1, options.WorkerOptions.MaxConcurrentNexusTaskPolls);
+                Assert.Null(options.WorkerOptions.WorkflowTaskPollerBehavior);
+                Assert.Null(options.WorkerOptions.ActivityTaskPollerBehavior);
+                Assert.Null(options.WorkerOptions.NexusTaskPollerBehavior);
+                Assert.True(options.WorkerOptions.DisableEagerActivityExecution);
+                Assert.NotNull(options.WorkerOptions.DeploymentOptions);
+                Assert.Equal(Version, options.WorkerOptions.DeploymentOptions.Version);
+                Assert.True(options.WorkerOptions.DeploymentOptions.UseWorkerVersioning);
                 Assert.Equal(
                     VersioningBehavior.AutoUpgrade,
-                    config.WorkerOptions.DeploymentOptions.DefaultVersioningBehavior);
-                Assert.Equal("env-task-queue", config.WorkerOptions.TaskQueue);
-                Assert.Equal("loaded-address", config.ClientOptions.TargetHost);
-                Assert.Equal("loaded-namespace", config.ClientOptions.Namespace);
+                    options.WorkerOptions.DeploymentOptions.DefaultVersioningBehavior);
+                Assert.Equal("env-task-queue", options.WorkerOptions.TaskQueue);
+                Assert.Equal("loaded-address", options.ClientOptions.TargetHost);
+                Assert.Equal("loaded-namespace", options.ClientOptions.Namespace);
 
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "configured-task-queue";
-                config.WorkerOptions.MaxConcurrentActivities = 8;
-                config.WorkerOptions.MaxConcurrentActivityTaskPolls = 4;
-                config.WorkerOptions.MaxCachedWorkflows = 12;
-                config.WorkerOptions.DisableEagerActivityExecution = false;
-                config.WorkerOptions.DeploymentOptions = new WorkerDeploymentOptions(
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "configured-task-queue";
+                options.WorkerOptions.MaxConcurrentActivities = 8;
+                options.WorkerOptions.MaxConcurrentActivityTaskPolls = 4;
+                options.WorkerOptions.MaxCachedWorkflows = 12;
+                options.WorkerOptions.DisableEagerActivityExecution = false;
+                options.WorkerOptions.DeploymentOptions = new WorkerDeploymentOptions(
                     new WorkerDeploymentVersion("ignored", "ignored"),
                     useWorkerVersioning: false)
                 {
                     DefaultVersioningBehavior = VersioningBehavior.Pinned,
                 };
-                config.WorkerOptions.Activities.Add(DummyActivity());
+                options.WorkerOptions.Activities.Add(DummyActivity());
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -121,9 +121,9 @@ public class TemporalLambdaWorkerTests
     [Fact]
     public void AddShutdownHook_NullHook_Throws()
     {
-        var config = new TemporalLambdaWorkerOptions();
+        var options = new TemporalLambdaWorkerOptions();
 
-        Assert.Throws<ArgumentNullException>(() => config.AddShutdownHook(null!));
+        Assert.Throws<ArgumentNullException>(() => options.AddShutdownHook(null!));
     }
 
     [Fact]
@@ -132,11 +132,11 @@ public class TemporalLambdaWorkerTests
         TemporalWorkerOptions? capturedWorkerOptions = null;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.WorkerOptions.AddWorkflow<WorkflowWithoutVersioningBehavior>();
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.WorkerOptions.AddWorkflow<WorkflowWithoutVersioningBehavior>();
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -166,9 +166,9 @@ public class TemporalLambdaWorkerTests
         TemporalClientConnectOptions? capturedClientOptions = null;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.WorkerOptions.TaskQueue = "task-queue";
+                options.WorkerOptions.TaskQueue = "task-queue";
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -203,14 +203,14 @@ public class TemporalLambdaWorkerTests
         TemporalClientConnectOptions? capturedClientOptions = null;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions = new TemporalClientConnectOptions
+                options.ClientOptions = new TemporalClientConnectOptions
                 {
                     TargetHost = "explicit-address",
                     Namespace = "explicit-namespace",
                 };
-                config.WorkerOptions.TaskQueue = "task-queue";
+                options.WorkerOptions.TaskQueue = "task-queue";
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -242,11 +242,11 @@ public class TemporalLambdaWorkerTests
         TemporalWorkerOptions? capturedWorkerOptions = null;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.WorkerOptions.Tuner = tuner;
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.WorkerOptions.Tuner = tuner;
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -279,11 +279,11 @@ public class TemporalLambdaWorkerTests
         TemporalWorkerOptions? capturedWorkerOptions = null;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.WorkerOptions.Plugins = new[] { new TunerPlugin(tuner) };
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.WorkerOptions.Plugins = new[] { new TunerPlugin(tuner) };
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -311,11 +311,11 @@ public class TemporalLambdaWorkerTests
         TemporalWorkerOptions? capturedWorkerOptions = null;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.WorkerOptions.Plugins = new[] { new VersioningPlugin() };
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.WorkerOptions.Plugins = new[] { new VersioningPlugin() };
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -372,7 +372,7 @@ public class TemporalLambdaWorkerTests
         TemporalWorkerOptions? capturedWorkerOptions = null;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config => config.ClientOptions.TargetHost = "localhost:7233",
+            options => options.ClientOptions.TargetHost = "localhost:7233",
             new TemporalLambdaWorkerHandlerOptions
             {
                 GetEnvironmentVariable = name =>
@@ -547,10 +547,10 @@ public class TemporalLambdaWorkerTests
             InvokedFunctionArn = "function-arn",
         };
         var handler = CreateCapturingHandler(
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
             },
             options => capturedClientOptions = options);
 
@@ -560,11 +560,11 @@ public class TemporalLambdaWorkerTests
         Assert.Equal("request-id@function-arn", capturedClientOptions.Identity);
 
         handler = CreateCapturingHandler(
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.ClientOptions.Identity = "user-identity";
-                config.WorkerOptions.TaskQueue = "task-queue";
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.ClientOptions.Identity = "user-identity";
+                options.WorkerOptions.TaskQueue = "task-queue";
             },
             options => capturedClientOptions = options);
 
@@ -581,12 +581,12 @@ public class TemporalLambdaWorkerTests
         CancellationToken workerToken = default;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.ShutdownDeadlineBuffer = TimeSpan.FromMilliseconds(10);
-                config.AddShutdownHook(_ =>
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.ShutdownDeadlineBuffer = TimeSpan.FromMilliseconds(10);
+                options.AddShutdownHook(_ =>
                 {
                     hookRan = true;
                     return Task.CompletedTask;
@@ -617,11 +617,11 @@ public class TemporalLambdaWorkerTests
             TimeSpan.FromSeconds(1));
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.ShutdownDeadlineBuffer = TimeSpan.FromMilliseconds(10);
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.ShutdownDeadlineBuffer = TimeSpan.FromMilliseconds(10);
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -652,11 +652,11 @@ public class TemporalLambdaWorkerTests
         var connectCalls = 0;
         var throwingHandler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.ShutdownDeadlineBuffer = TimeSpan.FromMilliseconds(100);
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.ShutdownDeadlineBuffer = TimeSpan.FromMilliseconds(100);
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -676,11 +676,11 @@ public class TemporalLambdaWorkerTests
         var warningContext = new FakeLambdaContext { RemainingTime = TimeSpan.FromMilliseconds(40) };
         var warningHandler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.ShutdownDeadlineBuffer = TimeSpan.FromMilliseconds(10);
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.ShutdownDeadlineBuffer = TimeSpan.FromMilliseconds(10);
             },
             new TemporalLambdaWorkerHandlerOptions
             {
@@ -705,21 +705,21 @@ public class TemporalLambdaWorkerTests
         var context = new FakeLambdaContext();
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.ClientOptions.TargetHost = "localhost:7233";
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.AddShutdownHook(_ =>
+                options.ClientOptions.TargetHost = "localhost:7233";
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.AddShutdownHook(_ =>
                 {
                     hookCalls.Add("first");
                     return Task.CompletedTask;
                 });
-                config.AddShutdownHook(_ =>
+                options.AddShutdownHook(_ =>
                 {
                     hookCalls.Add("second");
                     throw new InvalidOperationException("hook failed");
                 });
-                config.AddShutdownHook(_ =>
+                options.AddShutdownHook(_ =>
                 {
                     hookCalls.Add("third");
                     return Task.CompletedTask;
@@ -763,15 +763,15 @@ public class TemporalLambdaWorkerTests
         var hookCalls = new List<string>();
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
                 var call = ++configureCalls;
-                capturedConfigs.Add(config);
-                Assert.Equal("env-task-queue", config.WorkerOptions.TaskQueue);
+                capturedConfigs.Add(options);
+                Assert.Equal("env-task-queue", options.WorkerOptions.TaskQueue);
 
-                config.ClientOptions.TargetHost = $"target-{call}";
-                config.WorkerOptions.TaskQueue = $"task-queue-{call}";
-                config.AddShutdownHook(_ =>
+                options.ClientOptions.TargetHost = $"target-{call}";
+                options.WorkerOptions.TaskQueue = $"task-queue-{call}";
+                options.AddShutdownHook(_ =>
                 {
                     hookCalls.Add($"hook-{call}");
                     return Task.CompletedTask;
@@ -814,16 +814,16 @@ public class TemporalLambdaWorkerTests
         var hookCalls = new List<string>();
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            async config =>
+            async options =>
             {
                 await Task.Yield();
                 var call = ++configureCalls;
-                capturedConfigs.Add(config);
-                Assert.Equal("env-task-queue", config.WorkerOptions.TaskQueue);
+                capturedConfigs.Add(options);
+                Assert.Equal("env-task-queue", options.WorkerOptions.TaskQueue);
 
-                config.ClientOptions.TargetHost = $"target-{call}";
-                config.WorkerOptions.TaskQueue = $"task-queue-{call}";
-                config.AddShutdownHook(_ =>
+                options.ClientOptions.TargetHost = $"target-{call}";
+                options.WorkerOptions.TaskQueue = $"task-queue-{call}";
+                options.AddShutdownHook(_ =>
                 {
                     hookCalls.Add($"hook-{call}");
                     return Task.CompletedTask;
@@ -862,18 +862,18 @@ public class TemporalLambdaWorkerTests
         var configureCalls = 0;
         var handler = TemporalLambdaWorker.CreateHandler(
             Version,
-            async config =>
+            async options =>
             {
-                _ = config;
+                _ = options;
                 await Task.Yield();
                 configureCalls++;
-                throw new InvalidOperationException("bad config");
+                throw new InvalidOperationException("bad options");
             },
             new TemporalLambdaWorkerHandlerOptions());
 
         var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             handler(null, new FakeLambdaContext()));
-        Assert.Equal("bad config", error.Message);
+        Assert.Equal("bad options", error.Message);
         Assert.Equal(1, configureCalls);
     }
 
@@ -898,10 +898,10 @@ public class TemporalLambdaWorkerTests
         var hookCalls = new List<string>();
         var connectFailureHandler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.AddShutdownHook(_ =>
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.AddShutdownHook(_ =>
                 {
                     hookCalls.Add("connect");
                     return Task.CompletedTask;
@@ -919,10 +919,10 @@ public class TemporalLambdaWorkerTests
 
         var workerFailureHandler = TemporalLambdaWorker.CreateHandler(
             Version,
-            config =>
+            options =>
             {
-                config.WorkerOptions.TaskQueue = "task-queue";
-                config.AddShutdownHook(_ =>
+                options.WorkerOptions.TaskQueue = "task-queue";
+                options.AddShutdownHook(_ =>
                 {
                     hookCalls.Add("worker");
                     return Task.CompletedTask;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Converted `LambdaWorkerOpenTelemetry.ApplyDefaults` into an extension method.
- Renamed `LambdaWorkerOpenTelemetry` to `TemporalLambdaWorkerOptionsExtensions`
- Renamed `config` parameter to `options` for all `TemporalLambdaWorkerOptions` usage. Differentiate other `options` parameters as necessary.

## Why?

Make the APIs more aligned with .NET conventions and usage.

## Checklist

1. Any docs updates needed? No