### PR TITLE
feat(client): default gRPC compression to gzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ to docs, or any other relevant information.
 - Added experimental AWS Lambda worker support packages, including OpenTelemetry helpers for Lambda workers.
 - Added experimental workflow-side `Workflow.SignalWithStartWorkflowAsync` support.
 
+### Changed
+
+- Changed the default `TemporalConnectionOptions.GrpcCompression` to `GrpcCompression.Gzip`, so
+  connections now compress outbound requests and accept gzip-compressed responses by default. If the remote
+  service does not support gzip compression, the connection is downgraded to uncompressed requests. Set it
+  to `GrpcCompression.None` to opt out.
+
 ### Fixed
 
 - Fixed `ClientEnvConfig` empty `OverrideEnvVars` handling so an explicit empty dictionary no

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -79,11 +79,12 @@ namespace Temporalio.Client
         /// Gets or sets the transport-level gRPC compression for this connection.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="GrpcCompression.None"/>, which does not compress requests or
-        /// advertise acceptance of compressed responses. Set to <see cref="GrpcCompression.Gzip"/>
-        /// to compress outbound requests and accept compressed responses.
+        /// Defaults to <see cref="GrpcCompression.Gzip"/>, which compresses outbound requests and
+        /// advertises acceptance of gzip-compressed responses. If the remote service does not support
+        /// gzip compression, the connection is downgraded to uncompressed requests. Set to
+        /// <see cref="GrpcCompression.None"/> to opt out of compression.
         /// </remarks>
-        public GrpcCompression GrpcCompression { get; set; } = new GrpcCompression.None();
+        public GrpcCompression GrpcCompression { get; set; } = new GrpcCompression.Gzip();
 
         /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).

--- a/tests/Temporalio.Tests/Client/TemporalConnectionOptionsTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalConnectionOptionsTests.cs
@@ -244,7 +244,7 @@ public unsafe class TemporalConnectionOptionsTests
         var interopOptions = options.ToInteropOptions(scope);
 
         Assert.Equal(
-            Bridge.Interop.TemporalCoreClientGrpcCompression.None,
+            Bridge.Interop.TemporalCoreClientGrpcCompression.Gzip,
             interopOptions.grpc_compression);
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Update gRPC compression default to `Gzip`.

## Why?

Use gzip compression by default. Can opt-out by setting to `None`.