### PR TITLE
Add patch activation callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ to docs, or any other relevant information.
   connections now compress outbound requests and accept gzip-compressed responses by default. If the remote
   service does not support gzip compression, the connection is downgraded to uncompressed requests. Set it
   to `GrpcCompression.None` to opt out.
+- Added AWS Lambda worker support packages, including OpenTelemetry helpers for Lambda workers.
+- Added the experimental `TemporalWorkerOptions.PatchActivationCallback`, allowing workers to
+  decide whether a first non-replay `Workflow.Patched` call should activate a patch during rolling
+  deployments.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Added
+
+- Added the experimental `TemporalWorkerOptions.PatchActivationCallback`, allowing workers to
+  decide whether a first non-replay `Workflow.Patched` call should activate a patch during rolling
+  deployments.
+
+### Changed
+
+- Hardened read-only workflow context enforcement so queries, update validators, and patch activation
+  callbacks cannot mutate handlers or workflow details, invoke patches, or schedule workflow work.
+  Patch activation callbacks also cannot use workflow randomness or issue workflow commands.
+
 ### [1.17.0] - 2026-07-13
 
 ### Added
@@ -32,10 +44,6 @@ to docs, or any other relevant information.
   connections now compress outbound requests and accept gzip-compressed responses by default. If the remote
   service does not support gzip compression, the connection is downgraded to uncompressed requests. Set it
   to `GrpcCompression.None` to opt out.
-- Added AWS Lambda worker support packages, including OpenTelemetry helpers for Lambda workers.
-- Added the experimental `TemporalWorkerOptions.PatchActivationCallback`, allowing workers to
-  decide whether a first non-replay `Workflow.Patched` call should activate a patch during rolling
-  deployments.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -681,7 +681,9 @@ can be used from workflows including:
     workflow calls elsewhere.
   * `GetExternalWorkflowHandle` - Get a handle to an external workflow to issue cancellation requests and signals.
   * `NewGuid` - Create a deterministically random UUIDv4 GUID.
-  * `Patched` and `DeprecatePatch` - Support for patch-based versioning inside the workflow.
+  * `Patched` and `DeprecatePatch` - Support for patch-based versioning inside the workflow. Workers
+    can set `PatchActivationCallback` to decide whether a newly introduced patch should activate
+    during rolling deployments.
   * `UpsertMemo` - Update the memo values for the workflow.
   * `UpsertTypedSearchAttributes` - Update the search attributes for the workflow.
 

--- a/src/Temporalio/Worker/NotifyOnSetDictionary.cs
+++ b/src/Temporalio/Worker/NotifyOnSetDictionary.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Temporalio.Worker
 {
     /// <summary>
-    /// Specialized dictionary that invokes a callback on each value set (but not value delete).
+    /// Specialized dictionary that invokes callbacks before mutation and after each value set.
     /// </summary>
     /// <typeparam name="TKey">Dictionary key type.</typeparam>
     /// <typeparam name="TValue">Dictionary value type.</typeparam>
@@ -18,18 +18,23 @@ namespace Temporalio.Worker
     {
         private readonly Dictionary<TKey, TValue> dict;
         private readonly Action<TKey, TValue> callback;
+        private readonly Action beforeMutation;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NotifyOnSetDictionary{TKey, TValue}"/> class.
         /// </summary>
         /// <param name="copyFrom">Dictionary to copy existing values from.</param>
         /// <param name="callback">Callback to invoke on value set.</param>
+        /// <param name="beforeMutation">Callback to invoke before any mutation.</param>
         public NotifyOnSetDictionary(
-            IEnumerable<KeyValuePair<TKey, TValue>> copyFrom, Action<TKey, TValue> callback)
+            IEnumerable<KeyValuePair<TKey, TValue>> copyFrom,
+            Action<TKey, TValue> callback,
+            Action beforeMutation)
         {
             // Can't use kvp enumerable constructor on Dictionary, too new
             dict = copyFrom.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             this.callback = callback;
+            this.beforeMutation = beforeMutation;
         }
 
         /// <inheritdoc />
@@ -71,7 +76,11 @@ namespace Temporalio.Worker
         public void Add(KeyValuePair<TKey, TValue> item) => Add(item.Key, item.Value);
 
         /// <inheritdoc />
-        public void Clear() => dict.Clear();
+        public void Clear()
+        {
+            beforeMutation();
+            dict.Clear();
+        }
 
         /// <inheritdoc />
         public bool Contains(KeyValuePair<TKey, TValue> item) =>
@@ -88,11 +97,18 @@ namespace Temporalio.Worker
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => dict.GetEnumerator();
 
         /// <inheritdoc />
-        public bool Remove(TKey key) => dict.Remove(key);
+        public bool Remove(TKey key)
+        {
+            beforeMutation();
+            return dict.Remove(key);
+        }
 
         /// <inheritdoc />
-        public bool Remove(KeyValuePair<TKey, TValue> item) =>
-            ((ICollection<KeyValuePair<TKey, TValue>>)dict).Remove(item);
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            beforeMutation();
+            return ((ICollection<KeyValuePair<TKey, TValue>>)dict).Remove(item);
+        }
 
         /// <inheritdoc />
         public bool TryGetValue(TKey key, out TValue value) =>
@@ -105,6 +121,7 @@ namespace Temporalio.Worker
 
         private void Set(TKey key, TValue value, bool overwrite)
         {
+            beforeMutation();
             if (!overwrite && ContainsKey(key))
             {
                 throw new ArgumentException("Key already exists");

--- a/src/Temporalio/Worker/PatchActivationInput.cs
+++ b/src/Temporalio/Worker/PatchActivationInput.cs
@@ -1,0 +1,18 @@
+using Temporalio.Workflows;
+
+namespace Temporalio.Worker
+{
+    /// <summary>
+    /// Input for <see cref="TemporalWorkerOptions.PatchActivationCallback" />.
+    /// </summary>
+    /// <param name="WorkflowInfo">Information about the workflow execution calling
+    /// <see cref="Workflow.Patched" />.</param>
+    /// <param name="PatchId">Patch ID passed to <see cref="Workflow.Patched" />.</param>
+    /// <remarks>
+    /// WARNING: This constructor may have required properties added. Do not rely on the exact
+    /// constructor, only use "with" clauses.
+    /// </remarks>
+    public record PatchActivationInput(
+        WorkflowInfo WorkflowInfo,
+        string PatchId);
+}

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -121,6 +121,7 @@ namespace Temporalio.Worker
                         RuntimeMetricMeter: MetricMeter,
                         WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
                         DisableEagerActivityExecution: options.DisableEagerActivityExecution,
+                        PatchActivationCallback: options.PatchActivationCallback,
                         AssertValidLocalActivity: (activityType) => (activityWorker ??
                                                                      throw new InvalidOperationException(
                                                                          $"Activity {activityType} is not registered on this worker," +

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -295,7 +295,9 @@ namespace Temporalio.Worker
         /// <remarks>
         /// The callback is only invoked for a newly encountered patch. Existing history markers,
         /// replay, and <see cref="Workflow.DeprecatePatch" /> bypass the callback. Returning <c>false</c>
-        /// leaves the patch inactive and does not record a patch marker.
+        /// leaves the patch inactive and does not record a patch marker. The callback runs in a
+        /// read-only workflow context and therefore cannot use workflow randomness, wait, or
+        /// schedule workflow commands.
         /// </remarks>
         /// <remarks>WARNING: This property is experimental and may change in the future.</remarks>
         public Func<PatchActivationInput, bool>? PatchActivationCallback { get; set; }

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -289,6 +289,18 @@ namespace Temporalio.Worker
         public IReadOnlyCollection<Type>? WorkflowFailureExceptionTypes { get; set; }
 
         /// <summary>
+        /// Gets or sets the callback that decides whether the first non-replay call to
+        /// <see cref="Workflow.Patched" /> for a patch ID should activate that patch.
+        /// </summary>
+        /// <remarks>
+        /// The callback is only invoked for a newly encountered patch. Existing history markers,
+        /// replay, and <see cref="Workflow.DeprecatePatch" /> bypass the callback. Returning <c>false</c>
+        /// leaves the patch inactive and does not record a patch marker.
+        /// </remarks>
+        /// <remarks>WARNING: This property is experimental and may change in the future.</remarks>
+        public Func<PatchActivationInput, bool>? PatchActivationCallback { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether deadlock detection will be disabled for all
         /// workflows. If unset, this value defaults to true only if
         /// <see cref="Debugger.IsAttached" /> is <c>true</c> or the <c>TEMPORAL_DEBUG</c>

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -76,6 +76,7 @@ namespace Temporalio.Worker
         private readonly Action<WorkflowInstance, Exception?> onTaskCompleted;
         private readonly IReadOnlyCollection<Type>? workerLevelFailureExceptionTypes;
         private readonly bool disableEagerActivityExecution;
+        private readonly Func<PatchActivationInput, bool>? patchActivationCallback;
         private readonly Handlers inProgressHandlers = new();
         private readonly WorkflowDefinitionOptions definitionOptions;
         private WorkflowActivationCompletion? completion;
@@ -221,6 +222,7 @@ namespace Temporalio.Worker
             TracingEventsEnabled = !details.DisableTracingEvents;
             workerLevelFailureExceptionTypes = details.WorkerLevelFailureExceptionTypes;
             disableEagerActivityExecution = details.DisableEagerActivityExecution;
+            patchActivationCallback = details.PatchActivationCallback;
             AssertValidLocalActivity = details.AssertValidLocalActivity;
             definitionOptions = new()
             {
@@ -450,7 +452,17 @@ namespace Temporalio.Worker
             {
                 return patched;
             }
-            patched = !IsReplaying || patchesNotified.Contains(patchId);
+            // Replay and history markers already determine the branch, and deprecation must keep
+            // existing patch semantics, so only a genuinely new patch consults the callback.
+            if (!deprecated && !IsReplaying && !patchesNotified.Contains(patchId) &&
+                patchActivationCallback != null)
+            {
+                patched = patchActivationCallback(new(Info, patchId));
+            }
+            else
+            {
+                patched = !IsReplaying || patchesNotified.Contains(patchId);
+            }
             patchesMemoized[patchId] = patched;
             if (patched)
             {

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -494,7 +494,7 @@ namespace Temporalio.Worker
         /// <inheritdoc />
         public bool Patch(string patchId, bool deprecated)
         {
-            AssertNotReadOnly("patch");
+            AssertNotReadOnly(deprecated ? "deprecate patch" : "create patch");
             // Use memoized result if present. If this is being deprecated, we can still use
             // memoized result and skip the command.
             if (patchesMemoized.TryGetValue(patchId, out var patched))

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -79,6 +79,7 @@ namespace Temporalio.Worker
         private readonly Func<PatchActivationInput, bool>? patchActivationCallback;
         private readonly Handlers inProgressHandlers = new();
         private readonly WorkflowDefinitionOptions definitionOptions;
+        private DeterministicRandom random;
         private WorkflowActivationCompletion? completion;
         // Will be set to null after last use (i.e. when workflow actually started)
         private Lazy<object?[]>? startArgs;
@@ -97,6 +98,8 @@ namespace Temporalio.Worker
         private bool applyModernEventLoopLogic;
         private bool dynamicOptionsGetterInvoked;
         private bool inQueryOrValidator;
+        private bool contextFrozen;
+        private string currentDetails = string.Empty;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkflowInstance"/> class.
@@ -133,9 +136,24 @@ namespace Temporalio.Worker
                     return rootInbound.Outbound!;
                 },
                 false);
-            mutableQueries = new(() => new(Definition.Queries, OnQueryDefinitionAdded), false);
-            mutableSignals = new(() => new(Definition.Signals, OnSignalDefinitionAdded), false);
-            mutableUpdates = new(() => new(Definition.Updates, OnUpdateDefinitionAdded), false);
+            mutableQueries = new(
+                () => new(
+                    Definition.Queries,
+                    OnQueryDefinitionAdded,
+                    () => AssertNotReadOnly("modify workflow handlers")),
+                false);
+            mutableSignals = new(
+                () => new(
+                    Definition.Signals,
+                    OnSignalDefinitionAdded,
+                    () => AssertNotReadOnly("modify workflow handlers")),
+                false);
+            mutableUpdates = new(
+                () => new(
+                    Definition.Updates,
+                    OnUpdateDefinitionAdded,
+                    () => AssertNotReadOnly("modify workflow handlers")),
+                false);
             var initialMemo = details.Init.Memo;
             memo = new(
                 () => initialMemo == null ? new Dictionary<string, IRawValue>(0) :
@@ -218,7 +236,7 @@ namespace Temporalio.Worker
             replaySafeLogger = new(logger);
             onTaskStarting = details.OnTaskStarting;
             onTaskCompleted = details.OnTaskCompleted;
-            Random = new(details.Init.RandomnessSeed);
+            random = new(details.Init.RandomnessSeed);
             TracingEventsEnabled = !details.DisableTracingEvents;
             workerLevelFailureExceptionTypes = details.WorkerLevelFailureExceptionTypes;
             disableEagerActivityExecution = details.DisableEagerActivityExecution;
@@ -260,7 +278,15 @@ namespace Temporalio.Worker
         public WorkerDeploymentVersion? CurrentDeploymentVersion { get; private set; }
 
         /// <inheritdoc />
-        public string CurrentDetails { get; set; } = string.Empty;
+        public string CurrentDetails
+        {
+            get => currentDetails;
+            set
+            {
+                AssertNotReadOnly("set current details");
+                currentDetails = value;
+            }
+        }
 
         /// <inheritdoc />
         public int CurrentHistoryLength { get; private set; }
@@ -284,6 +310,7 @@ namespace Temporalio.Worker
             get => dynamicQuery;
             set
             {
+                AssertNotReadOnly("modify workflow handlers");
                 if (value != null && !value.Dynamic)
                 {
                     throw new ArgumentException("Query is not dynamic");
@@ -298,6 +325,7 @@ namespace Temporalio.Worker
             get => dynamicSignal;
             set
             {
+                AssertNotReadOnly("modify workflow handlers");
                 if (value != null && !value.Dynamic)
                 {
                     throw new ArgumentException("Signal is not dynamic");
@@ -320,6 +348,7 @@ namespace Temporalio.Worker
             get => dynamicUpdate;
             set
             {
+                AssertNotReadOnly("modify workflow handlers");
                 if (value != null && !value.Dynamic)
                 {
                     throw new ArgumentException("Update is not dynamic");
@@ -381,7 +410,14 @@ namespace Temporalio.Worker
         public IDictionary<string, WorkflowQueryDefinition> Queries => mutableQueries.Value;
 
         /// <inheritdoc />
-        public DeterministicRandom Random { get; private set; }
+        public DeterministicRandom Random
+        {
+            get
+            {
+                ThrowIfContextFrozen("use workflow randomness");
+                return random;
+            }
+        }
 
         /// <inheritdoc />
         public IDictionary<string, WorkflowSignalDefinition> Signals => mutableSignals.Value;
@@ -406,13 +442,25 @@ namespace Temporalio.Worker
         internal Action<string> AssertValidLocalActivity { get; private init; }
 
         /// <inheritdoc/>
+        public void AssertNotReadOnly(string operation)
+        {
+            if (contextFrozen || inQueryOrValidator)
+            {
+                throw new InvalidOperationException($"Cannot {operation} in this context");
+            }
+        }
+
+        /// <inheritdoc/>
         public ContinueAsNewException CreateContinueAsNewException(
-            string workflow, IReadOnlyCollection<object?> args, ContinueAsNewOptions? options) =>
-            outbound.Value.CreateContinueAsNewException(new(
+            string workflow, IReadOnlyCollection<object?> args, ContinueAsNewOptions? options)
+        {
+            ThrowIfContextFrozen("continue as new");
+            return outbound.Value.CreateContinueAsNewException(new(
                 Workflow: workflow,
                 Args: args,
                 Options: options,
                 Headers: null));
+        }
 
         /// <inheritdoc/>
         public NexusWorkflowClient CreateNexusWorkflowClient(string service, NexusWorkflowClientOptions options) =>
@@ -424,19 +472,19 @@ namespace Temporalio.Worker
 
         /// <inheritdoc/>
         public Task DelayWithOptionsAsync(DelayOptions options) =>
-            outbound.Value.DelayAsync(new(options));
+            ContextFrozenChecked(() => outbound.Value.DelayAsync(new(options)));
 
         /// <inheritdoc/>
         public Task<TResult> ExecuteActivityAsync<TResult>(
             string activity, IReadOnlyCollection<object?> args, ActivityOptions options) =>
-            outbound.Value.ScheduleActivityAsync<TResult>(
-                new(Activity: activity, Args: args, Options: options, Headers: null));
+            ContextFrozenChecked(() => outbound.Value.ScheduleActivityAsync<TResult>(
+                new(Activity: activity, Args: args, Options: options, Headers: null)));
 
         /// <inheritdoc/>
         public Task<TResult> ExecuteLocalActivityAsync<TResult>(
             string activity, IReadOnlyCollection<object?> args, LocalActivityOptions options) =>
-            outbound.Value.ScheduleLocalActivityAsync<TResult>(
-                new(Activity: activity, Args: args, Options: options, Headers: null));
+            ContextFrozenChecked(() => outbound.Value.ScheduleLocalActivityAsync<TResult>(
+                new(Activity: activity, Args: args, Options: options, Headers: null)));
 
         /// <inheritdoc/>
         public ExternalWorkflowHandle<TWorkflow> GetExternalWorkflowHandle<TWorkflow>(
@@ -446,6 +494,7 @@ namespace Temporalio.Worker
         /// <inheritdoc />
         public bool Patch(string patchId, bool deprecated)
         {
+            AssertNotReadOnly("patch");
             // Use memoized result if present. If this is being deprecated, we can still use
             // memoized result and skip the command.
             if (patchesMemoized.TryGetValue(patchId, out var patched))
@@ -457,7 +506,16 @@ namespace Temporalio.Worker
             if (!deprecated && !IsReplaying && !patchesNotified.Contains(patchId) &&
                 patchActivationCallback != null)
             {
-                patched = patchActivationCallback(new(Info, patchId));
+                var previousContextFrozen = contextFrozen;
+                try
+                {
+                    contextFrozen = true;
+                    patched = patchActivationCallback(new(Info, patchId));
+                }
+                finally
+                {
+                    contextFrozen = previousContextFrozen;
+                }
             }
             else
             {
@@ -477,12 +535,13 @@ namespace Temporalio.Worker
         /// <inheritdoc/>
         public Task<ChildWorkflowHandle<TWorkflow, TResult>> StartChildWorkflowAsync<TWorkflow, TResult>(
             string workflow, IReadOnlyCollection<object?> args, ChildWorkflowOptions options) =>
-            outbound.Value.StartChildWorkflowAsync<TWorkflow, TResult>(
-                new(Workflow: workflow, Args: args, Options: options, Headers: null));
+            ContextFrozenChecked(() => outbound.Value.StartChildWorkflowAsync<TWorkflow, TResult>(
+                new(Workflow: workflow, Args: args, Options: options, Headers: null)));
 
         /// <inheritdoc />
         public void UpsertMemo(IReadOnlyCollection<MemoUpdate> updates)
         {
+            ThrowIfContextFrozen("issue workflow commands");
             if (updates.Count == 0)
             {
                 throw new ArgumentException("At least one update required", nameof(updates));
@@ -529,6 +588,7 @@ namespace Temporalio.Worker
         /// <inheritdoc/>
         public void UpsertTypedSearchAttributes(IReadOnlyCollection<SearchAttributeUpdate> updates)
         {
+            ThrowIfContextFrozen("issue workflow commands");
             if (updates.Count == 0)
             {
                 throw new ArgumentException("At least one update required", nameof(updates));
@@ -556,6 +616,7 @@ namespace Temporalio.Worker
         /// <inheritdoc/>
         public Task<bool> WaitConditionWithOptionsAsync(WaitConditionOptions options)
         {
+            AssertNotReadOnly("wait or schedule workflow work");
             var source = new TaskCompletionSource<object?>();
             var node = conditions.AddLast(Tuple.Create(options.ConditionCheck, source));
             var token = options.CancellationToken ?? CancellationToken;
@@ -860,6 +921,7 @@ namespace Temporalio.Worker
         /// <inheritdoc/>
         protected override void QueueTask(Task task)
         {
+            ThrowIfContextFrozen("wait or schedule workflow work");
             // Only queue if not already done
             if (!scheduledTaskNodes.ContainsKey(task))
             {
@@ -943,12 +1005,27 @@ namespace Temporalio.Worker
 
         private void AddCommand(WorkflowCommand cmd)
         {
+            ThrowIfContextFrozen("issue workflow commands");
             if (completion == null)
             {
                 throw new InvalidOperationException("No completion available");
             }
             // We only add the command if we're still successful
             completion.Successful?.Commands.Add(cmd);
+        }
+
+        private T ContextFrozenChecked<T>(Func<T> func)
+        {
+            ThrowIfContextFrozen("wait or schedule workflow work");
+            return func();
+        }
+
+        private void ThrowIfContextFrozen(string operation)
+        {
+            if (contextFrozen)
+            {
+                throw new InvalidOperationException($"Cannot {operation} in this context");
+            }
         }
 
 #pragma warning disable CA2008 // We don't have to pass a scheduler, factory already implies one
@@ -1646,7 +1723,7 @@ namespace Temporalio.Worker
         }
 
         private void ApplyUpdateRandomSeed(UpdateRandomSeed update) =>
-            Random = new(update.RandomnessSeed);
+            random = new(update.RandomnessSeed);
 
         private void InitializeWorkflow()
         {

--- a/src/Temporalio/Worker/WorkflowInstanceDetails.cs
+++ b/src/Temporalio/Worker/WorkflowInstanceDetails.cs
@@ -29,6 +29,7 @@ namespace Temporalio.Worker
     /// <param name="RuntimeMetricMeter">Lazy runtime-level metric meter.</param>
     /// <param name="WorkerLevelFailureExceptionTypes">Failure exception types at worker level.</param>
     /// <param name="DisableEagerActivityExecution">Whether to disable eager at the worker level.</param>
+    /// <param name="PatchActivationCallback">Callback for deciding whether to activate a patch.</param>
     /// <param name="AssertValidLocalActivity">Checks the validity of the local activity and throws if it is invalid.</param>
     internal record WorkflowInstanceDetails(
         string Namespace,
@@ -49,5 +50,6 @@ namespace Temporalio.Worker
         Lazy<MetricMeter> RuntimeMetricMeter,
         IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
         bool DisableEagerActivityExecution,
+        Func<PatchActivationInput, bool>? PatchActivationCallback,
         Action<string> AssertValidLocalActivity);
 }

--- a/src/Temporalio/Worker/WorkflowReplayer.cs
+++ b/src/Temporalio/Worker/WorkflowReplayer.cs
@@ -230,6 +230,7 @@ namespace Temporalio.Worker
                             RuntimeMetricMeter: new(() => runtime.MetricMeter),
                             WorkerLevelFailureExceptionTypes: options.WorkflowFailureExceptionTypes,
                             DisableEagerActivityExecution: false,
+                            PatchActivationCallback: null,
                             AssertValidLocalActivity: _ => { },
                             DefaultVersioningBehavior: null,
                             DeploymentOptions: null),

--- a/src/Temporalio/Worker/WorkflowWorker.cs
+++ b/src/Temporalio/Worker/WorkflowWorker.cs
@@ -363,6 +363,7 @@ namespace Temporalio.Worker
                     RuntimeMetricMeter: options.RuntimeMetricMeter,
                     WorkerLevelFailureExceptionTypes: options.WorkerLevelFailureExceptionTypes,
                     DisableEagerActivityExecution: options.DisableEagerActivityExecution,
+                    PatchActivationCallback: options.PatchActivationCallback,
                     AssertValidLocalActivity: options.AssertValidLocalActivity));
         }
     }

--- a/src/Temporalio/Worker/WorkflowWorkerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowWorkerOptions.cs
@@ -23,6 +23,7 @@ namespace Temporalio.Worker
         Lazy<MetricMeter> RuntimeMetricMeter,
         IReadOnlyCollection<Type>? WorkerLevelFailureExceptionTypes,
         bool DisableEagerActivityExecution,
+        Func<PatchActivationInput, bool>? PatchActivationCallback,
         Action<string> AssertValidLocalActivity,
         VersioningBehavior? DefaultVersioningBehavior,
         WorkerDeploymentOptions? DeploymentOptions);

--- a/src/Temporalio/Workflows/IWorkflowContext.cs
+++ b/src/Temporalio/Workflows/IWorkflowContext.cs
@@ -154,6 +154,12 @@ namespace Temporalio.Workflows
         DateTime UtcNow { get; }
 
         /// <summary>
+        /// Throws if the workflow context is currently read-only.
+        /// </summary>
+        /// <param name="operation">Operation being attempted.</param>
+        void AssertNotReadOnly(string operation);
+
+        /// <summary>
         /// Backing call for
         /// <see cref="Workflow.CreateContinueAsNewException(string, IReadOnlyCollection{object?}, ContinueAsNewOptions?)" />.
         /// </summary>

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -1139,12 +1139,15 @@ namespace Temporalio.Workflows
         /// <returns>A task for the running task (but not necessarily the task that is returned
         /// from the function).</returns>
         public static Task RunTaskAsync(
-            Func<Task> function, CancellationToken? cancellationToken = null) =>
-            Task.Factory.StartNew(
+            Func<Task> function, CancellationToken? cancellationToken = null)
+        {
+            Context.AssertNotReadOnly("wait or schedule workflow work");
+            return Task.Factory.StartNew(
                 function,
                 cancellationToken ?? CancellationToken,
                 TaskCreationOptions.None,
                 TaskScheduler.Current).Unwrap();
+        }
 
         /// <summary>
         /// Workflow-safe form of <see cref="Task.Run{TResult}(Func{TResult}, CancellationToken)" />.
@@ -1156,12 +1159,15 @@ namespace Temporalio.Workflows
         /// <returns>A task for the running task (but not necessarily the task that is returned
         /// from the function).</returns>
         public static Task<TResult> RunTaskAsync<TResult>(
-            Func<Task<TResult>> function, CancellationToken? cancellationToken = null) =>
-            Task.Factory.StartNew(
+            Func<Task<TResult>> function, CancellationToken? cancellationToken = null)
+        {
+            Context.AssertNotReadOnly("wait or schedule workflow work");
+            return Task.Factory.StartNew(
                 function,
                 cancellationToken ?? CancellationToken,
                 TaskCreationOptions.None,
                 TaskScheduler.Current).Unwrap();
+        }
 
         /// <summary>
         /// Start a child workflow via lambda invoking the run method.

--- a/tests/Temporalio.Tests/Worker/NotifyOnSetDictionaryTests.cs
+++ b/tests/Temporalio.Tests/Worker/NotifyOnSetDictionaryTests.cs
@@ -1,0 +1,34 @@
+namespace Temporalio.Tests.Worker;
+
+using Temporalio.Worker;
+using Xunit;
+
+public class NotifyOnSetDictionaryTests
+{
+    [Fact]
+    public void MutationGuard_AppliesToEveryMutation()
+    {
+        var mutationAllowed = true;
+        var dictionary = new NotifyOnSetDictionary<string, string>(
+            new Dictionary<string, string> { ["existing"] = "value" },
+            (_, _) => { },
+            () =>
+            {
+                if (!mutationAllowed)
+                {
+                    throw new InvalidOperationException("Mutation not allowed");
+                }
+            });
+        mutationAllowed = false;
+
+        Assert.Throws<InvalidOperationException>(() => dictionary["existing"] = "new-value");
+        Assert.Throws<InvalidOperationException>(() => dictionary.Add("new", "value"));
+        Assert.Throws<InvalidOperationException>(() =>
+            dictionary.Add(new KeyValuePair<string, string>("new", "value")));
+        Assert.Throws<InvalidOperationException>(() => dictionary.Remove("existing"));
+        Assert.Throws<InvalidOperationException>(() =>
+            dictionary.Remove(new KeyValuePair<string, string>("existing", "value")));
+        Assert.Throws<InvalidOperationException>(() => dictionary.Clear());
+        Assert.Equal("value", dictionary["existing"]);
+    }
+}

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -2969,12 +2969,21 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
         [WorkflowQuery]
         public bool FirstPatchResult() => firstPatchResult;
 
+        [WorkflowQuery]
+        public bool PatchFromQuery(string patchId) => Workflow.Patched(patchId);
+
         [WorkflowSignal]
         public Task ReleaseAsync()
         {
             released = true;
             return Task.CompletedTask;
         }
+
+        [WorkflowUpdate]
+        public Task PatchFromUpdateAsync(string patchId) => Task.CompletedTask;
+
+        [WorkflowUpdateValidator(nameof(PatchFromUpdateAsync))]
+        public void ValidatePatchFromUpdate(string patchId) => _ = Workflow.Patched(patchId);
     }
 
     [Workflow]
@@ -3139,6 +3148,108 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             {
                 PatchActivationCallback = _ => throw new InvalidOperationException("Unexpected callback"),
             });
+    }
+
+    [Theory]
+    [InlineData("command", "Cannot issue workflow commands in this context")]
+    [InlineData("wait", "Cannot wait or schedule workflow work in this context")]
+    [InlineData("run-task", "Cannot wait or schedule workflow work in this context")]
+    [InlineData("random", "Cannot use workflow randomness in this context")]
+    [InlineData("patch", "Cannot patch in this context")]
+    [InlineData("current-details", "Cannot set current details in this context")]
+    [InlineData("handler-add", "Cannot modify workflow handlers in this context")]
+    [InlineData("handler-remove", "Cannot modify workflow handlers in this context")]
+    [InlineData("dynamic-handler", "Cannot modify workflow handlers in this context")]
+    [InlineData("continue-as-new", "Cannot continue as new in this context")]
+    public async Task ExecuteWorkflowAsync_PatchActivationCallback_RunsReadOnly(
+        string operation,
+        string expectedError)
+    {
+        await ExecuteWorkerAsync<PatchActivationWorkflow>(
+            async worker =>
+            {
+                var handle = await Client.StartWorkflowAsync(
+                    (PatchActivationWorkflow wf) => wf.RunAsync(operation, false),
+                    new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
+                await AssertTaskFailureContainsEventuallyAsync(handle, expectedError);
+            },
+            new TemporalWorkerOptions
+            {
+                PatchActivationCallback = input =>
+                {
+                    switch (input.PatchId)
+                    {
+                        case "command":
+                            Workflow.UpsertMemo(MemoUpdate.ValueSet("key", "value"));
+                            break;
+                        case "wait":
+                            _ = Workflow.WaitConditionAsync(() => true);
+                            break;
+                        case "run-task":
+                            _ = Workflow.RunTaskAsync(() => Task.CompletedTask);
+                            break;
+                        case "random":
+                            _ = Workflow.Random.Next();
+                            break;
+                        case "patch":
+                            _ = Workflow.Patched("nested-patch");
+                            break;
+                        case "current-details":
+                            Workflow.CurrentDetails = "changed in callback";
+                            break;
+                        case "handler-add":
+                            Workflow.Queries["callback-query"] =
+                                WorkflowQueryDefinition.CreateWithoutAttribute(
+                                    "callback-query", () => true);
+                            break;
+                        case "handler-remove":
+                            Workflow.Queries.Remove(nameof(PatchActivationWorkflow.FirstPatchResult));
+                            break;
+                        case "dynamic-handler":
+                            Workflow.DynamicQuery = WorkflowQueryDefinition.CreateWithoutAttribute(
+                                null, (string _queryName, IRawValue[] _args) => true);
+                            break;
+                        case "continue-as-new":
+                            throw Workflow.CreateContinueAsNewException(
+                                (PatchActivationWorkflow wf) => wf.RunAsync("continued", false));
+                    }
+                    return true;
+                },
+            });
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_PatchActivationCallback_RejectsReadOnlyCallsFromQueryAndValidator()
+    {
+        var calls = 0;
+        await ExecuteWorkerAsync<PatchActivationWorkflow>(
+            async worker =>
+            {
+                var handle = await Client.StartWorkflowAsync(
+                    (PatchActivationWorkflow wf) => wf.RunAsync("main-patch", true),
+                    new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
+                Assert.False(await handle.QueryAsync(wf => wf.FirstPatchResult()));
+
+                var queryExc = await Assert.ThrowsAsync<WorkflowQueryFailedException>(
+                    () => handle.QueryAsync(wf => wf.PatchFromQuery("query-patch")));
+                Assert.Contains("Cannot patch in this context", queryExc.Message);
+
+                var updateExc = await Assert.ThrowsAsync<WorkflowUpdateFailedException>(
+                    () => handle.ExecuteUpdateAsync(wf => wf.PatchFromUpdateAsync("validator-patch")));
+                Assert.Contains("Cannot patch in this context", updateExc.InnerException?.Message);
+
+                await handle.SignalAsync(wf => wf.ReleaseAsync());
+                Assert.Equal([false, false], await handle.GetResultAsync());
+            },
+            new TemporalWorkerOptions
+            {
+                PatchActivationCallback = _ =>
+                {
+                    Interlocked.Increment(ref calls);
+                    return false;
+                },
+            });
+        Assert.Equal(1, calls);
     }
 
     [Fact]

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -3155,7 +3155,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     [InlineData("wait", "Cannot wait or schedule workflow work in this context")]
     [InlineData("run-task", "Cannot wait or schedule workflow work in this context")]
     [InlineData("random", "Cannot use workflow randomness in this context")]
-    [InlineData("patch", "Cannot patch in this context")]
+    [InlineData("patch", "Cannot create patch in this context")]
     [InlineData("current-details", "Cannot set current details in this context")]
     [InlineData("handler-add", "Cannot modify workflow handlers in this context")]
     [InlineData("handler-remove", "Cannot modify workflow handlers in this context")]
@@ -3232,11 +3232,11 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
 
                 var queryExc = await Assert.ThrowsAsync<WorkflowQueryFailedException>(
                     () => handle.QueryAsync(wf => wf.PatchFromQuery("query-patch")));
-                Assert.Contains("Cannot patch in this context", queryExc.Message);
+                Assert.Contains("Cannot create patch in this context", queryExc.Message);
 
                 var updateExc = await Assert.ThrowsAsync<WorkflowUpdateFailedException>(
                     () => handle.ExecuteUpdateAsync(wf => wf.PatchFromUpdateAsync("validator-patch")));
-                Assert.Contains("Cannot patch in this context", updateExc.InnerException?.Message);
+                Assert.Contains("Cannot create patch in this context", updateExc.InnerException?.Message);
 
                 await handle.SignalAsync(wf => wf.ReleaseAsync());
                 Assert.Equal([false, false], await handle.GetResultAsync());

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -2950,6 +2950,287 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Workflow]
+    public class PatchActivationWorkflow
+    {
+        private bool released;
+        private bool firstPatchResult;
+
+        [WorkflowRun]
+        public async Task<IReadOnlyCollection<bool>> RunAsync(string patchId, bool waitForRelease)
+        {
+            firstPatchResult = Workflow.Patched(patchId);
+            if (waitForRelease)
+            {
+                await Workflow.WaitConditionAsync(() => released);
+            }
+            return new[] { firstPatchResult, Workflow.Patched(patchId) };
+        }
+
+        [WorkflowQuery]
+        public bool FirstPatchResult() => firstPatchResult;
+
+        [WorkflowSignal]
+        public Task ReleaseAsync()
+        {
+            released = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Workflow]
+    public class PatchActivationDeprecateWorkflow
+    {
+        [WorkflowRun]
+        public Task<bool> RunAsync(string patchId)
+        {
+            Workflow.DeprecatePatch(patchId);
+            return Task.FromResult(Workflow.Patched(patchId));
+        }
+    }
+
+    [Workflow("PatchActivationRolloutWorkflow")]
+    public class PatchActivationRolloutWorkflow
+    {
+        private bool released;
+
+        [WorkflowRun]
+        public async Task<string> RunAsync()
+        {
+            Workflow.Patched("rollout-patch");
+            await Workflow.WaitConditionAsync(() => released);
+            return Workflow.Patched("rollout-patch") ? "new" : "old";
+        }
+
+        [WorkflowQuery]
+        public string State() => "new";
+
+        [WorkflowSignal]
+        public Task ReleaseAsync()
+        {
+            released = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Workflow("PatchActivationRolloutWorkflow")]
+    public class PatchActivationOldRolloutWorkflow
+    {
+        private bool released;
+
+        [WorkflowRun]
+        public async Task<string> RunAsync()
+        {
+            await Workflow.WaitConditionAsync(() => released);
+            return "old";
+        }
+
+        [WorkflowQuery]
+        public string State() => "old";
+
+        [WorkflowSignal]
+        public Task ReleaseAsync()
+        {
+            released = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_PatchActivationCallback_ActivatesAndMemoizes()
+    {
+        var calls = new ConcurrentQueue<PatchActivationInput>();
+        var workflowId = $"workflow-{Guid.NewGuid()}";
+        await ExecuteWorkerAsync<PatchActivationWorkflow>(
+            async worker =>
+            {
+                var result = await Client.ExecuteWorkflowAsync(
+                    (PatchActivationWorkflow wf) => wf.RunAsync("my-patch", false),
+                    new(workflowId, worker.Options.TaskQueue!));
+                Assert.Equal([true, true], result);
+            },
+            new TemporalWorkerOptions
+            {
+                PatchActivationCallback = input =>
+                {
+                    calls.Enqueue(input);
+                    return true;
+                },
+            });
+        var call = Assert.Single(calls);
+        Assert.Equal(workflowId, call.WorkflowInfo.WorkflowId);
+        Assert.Equal("my-patch", call.PatchId);
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_PatchActivationCallback_DeclinesWithoutMarker()
+    {
+        var calls = 0;
+        await ExecuteWorkerAsync<PatchActivationWorkflow>(
+            async worker =>
+            {
+                var handle = await Client.StartWorkflowAsync(
+                    (PatchActivationWorkflow wf) => wf.RunAsync("my-patch", false),
+                    new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
+                Assert.Equal([false, false], await handle.GetResultAsync());
+                Assert.DoesNotContain(
+                    (await handle.FetchHistoryAsync()).Events,
+                    evt => evt.MarkerRecordedEventAttributes != null);
+            },
+            new TemporalWorkerOptions
+            {
+                PatchActivationCallback = _ =>
+                {
+                    Interlocked.Increment(ref calls);
+                    return false;
+                },
+            });
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_WithoutPatchActivationCallback_ActivatesWithMarker()
+    {
+        await ExecuteWorkerAsync<PatchActivationWorkflow>(async worker =>
+        {
+            var handle = await Client.StartWorkflowAsync(
+                (PatchActivationWorkflow wf) => wf.RunAsync("my-patch", false),
+                new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
+            Assert.Equal([true, true], await handle.GetResultAsync());
+            Assert.Contains(
+                (await handle.FetchHistoryAsync()).Events,
+                evt => evt.MarkerRecordedEventAttributes != null);
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_PatchActivationCallback_NotCalledOnUncachedReplay()
+    {
+        var calls = 0;
+        await ExecuteWorkerAsync<PatchActivationWorkflow>(
+            async worker =>
+            {
+                var handle = await Client.StartWorkflowAsync(
+                    (PatchActivationWorkflow wf) => wf.RunAsync("my-patch", true),
+                    new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!));
+                Assert.False(await handle.QueryAsync(wf => wf.FirstPatchResult()));
+                await handle.SignalAsync(wf => wf.ReleaseAsync());
+                Assert.Equal([false, false], await handle.GetResultAsync());
+            },
+            new TemporalWorkerOptions
+            {
+                MaxCachedWorkflows = 0,
+                PatchActivationCallback = _ =>
+                {
+                    Interlocked.Increment(ref calls);
+                    return false;
+                },
+            });
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_PatchActivationCallback_NotCalledForDeprecatePatch()
+    {
+        await ExecuteWorkerAsync<PatchActivationDeprecateWorkflow>(
+            async worker => Assert.True(await Client.ExecuteWorkflowAsync(
+                (PatchActivationDeprecateWorkflow wf) => wf.RunAsync("my-patch"),
+                new($"workflow-{Guid.NewGuid()}", worker.Options.TaskQueue!))),
+            new TemporalWorkerOptions
+            {
+                PatchActivationCallback = _ => throw new InvalidOperationException("Unexpected callback"),
+            });
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_DeclinedPatch_RollsOutToOldWorker()
+    {
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var calls = 0;
+        WorkflowHandle<PatchActivationRolloutWorkflow, string>? handle = null;
+        using (var worker = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions(taskQueue)
+            {
+                MaxCachedWorkflows = 0,
+                PatchActivationCallback = _ =>
+                {
+                    Interlocked.Increment(ref calls);
+                    return false;
+                },
+            }.AddWorkflow<PatchActivationRolloutWorkflow>()))
+        {
+            await worker.ExecuteAsync(async () =>
+            {
+                handle = await Client.StartWorkflowAsync(
+                    (PatchActivationRolloutWorkflow wf) => wf.RunAsync(),
+                    new($"workflow-{Guid.NewGuid()}", taskQueue));
+                Assert.Equal("new", await handle.QueryAsync(wf => wf.State()));
+            });
+        }
+        Assert.Equal(1, calls);
+        Assert.NotNull(handle);
+
+        using var oldWorker = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions(taskQueue) { MaxCachedWorkflows = 0 }.
+                AddWorkflow<PatchActivationOldRolloutWorkflow>());
+        await oldWorker.ExecuteAsync(async () =>
+        {
+            await handle.SignalAsync(wf => wf.ReleaseAsync());
+            Assert.Equal("old", await handle.GetResultAsync());
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteWorkflowAsync_ActivatedPatch_ReplaysWithoutCallback()
+    {
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var activatedCalls = 0;
+        WorkflowHandle<PatchActivationRolloutWorkflow, string>? handle = null;
+        using (var worker = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions(taskQueue)
+            {
+                MaxCachedWorkflows = 0,
+                PatchActivationCallback = _ =>
+                {
+                    Interlocked.Increment(ref activatedCalls);
+                    return true;
+                },
+            }.AddWorkflow<PatchActivationRolloutWorkflow>()))
+        {
+            await worker.ExecuteAsync(async () =>
+            {
+                handle = await Client.StartWorkflowAsync(
+                    (PatchActivationRolloutWorkflow wf) => wf.RunAsync(),
+                    new($"workflow-{Guid.NewGuid()}", taskQueue));
+                Assert.Equal("new", await handle.QueryAsync(wf => wf.State()));
+            });
+        }
+        Assert.Equal(1, activatedCalls);
+        Assert.NotNull(handle);
+
+        var declinedCalls = 0;
+        using var declinedWorker = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions(taskQueue)
+            {
+                MaxCachedWorkflows = 0,
+                PatchActivationCallback = _ =>
+                {
+                    Interlocked.Increment(ref declinedCalls);
+                    return false;
+                },
+            }.AddWorkflow<PatchActivationRolloutWorkflow>());
+        await declinedWorker.ExecuteAsync(async () =>
+        {
+            await handle.SignalAsync(wf => wf.ReleaseAsync());
+            Assert.Equal("new", await handle.GetResultAsync());
+        });
+        Assert.Equal(0, declinedCalls);
+    }
+
+    [Workflow]
     public class HeadersWithCodecWorkflow
     {
         public enum Kind


### PR DESCRIPTION
## What was changed

Added an experimental `TemporalWorkerOptions.PatchActivationCallback` that lets a worker decide whether the first newly encountered, non-replay `Workflow.Patched` call activates a patch.

The callback receives workflow information and the patch ID. Its boolean decision is memoized for the workflow run. Declined patches return `false` without recording a marker, while replay, existing history markers, and deprecated patches retain their existing behavior.

This ports the behavior introduced by https://github.com/temporalio/sdk-ruby/pull/481.

The work is intentionally split into two commits:

1. `Add patch activation callback` contains only the callback API, plumbing, activation semantics, and rollout tests.
2. `Harden read-only workflow contexts` makes the callback read-only and completes the workflow context's read-only enforcement. This includes guarding nested patches, workflow metadata and handler mutation, continue-as-new, and patch calls from queries and update validators.

> [!NOTE]
> We can drop the second commit if it feels like too much to put in the PR, but, it's done and I think adds some nice safety. 

## Why?

This allows workflow changes using `Workflow.Patched` to roll out gradually without every new-code worker immediately recording a marker that older workers cannot replay.

Keeping the read-only hardening in a subsequent commit separates the callback's intended behavior from the broader workflow-context consistency fixes discovered during review.

## Testing

- .NET SDK build across all target frameworks with zero warnings
- First callback-only commit independently formatted and tested
- 21 focused callback, read-only, mutation, handler, query, and update-validator cases
- Changed-file formatting verification
- Diff and sdk-core submodule cleanliness checks
