### PR TITLE
Support Workflow Update as a Nexus Operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ to docs, or any other relevant information.
 
 - Reduced CPU usage of type-safe calls (e.g. `ExecuteChildWorkflowAsync(wf => wf.RunAsync(arg))`)
   by evaluating non-constant arguments via expression interpretation instead of full IL compilation, when supported by the runtime.
-- Support workflow updates as Nexus operations. `ITemporalNexusClient.StartUpdateWorkflowAsync`
+- Support workflow updates as Nexus operations. `ITemporalNexusClient.StartWorkflowUpdateAsync`
   backs a Nexus operation with a workflow update (async only, `WorkflowUpdateStage.Accepted`).
   Cancellation of update-workflow operations can be customized by overriding
   `TemporalOperationHandler<TInput, TResult>.CancelWorkflowUpdateAsync`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,7 @@ to docs, or any other relevant information.
 
 - Reduced CPU usage of type-safe calls (e.g. `ExecuteChildWorkflowAsync(wf => wf.RunAsync(arg))`)
   by evaluating non-constant arguments via expression interpretation instead of full IL compilation, when supported by the runtime.
+- Support workflow updates as Nexus operations. `ITemporalNexusClient.StartUpdateWorkflowAsync`
+  backs a Nexus operation with a workflow update (async only, `WorkflowUpdateStage.Accepted`).
+  Cancellation of update-workflow operations can be customized by overriding
+  `TemporalOperationHandler<TInput, TResult>.CancelWorkflowUpdateAsync`.

--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -500,17 +500,12 @@ namespace Temporalio.Client
                 }
                 while (resp.Stage < UpdateWorkflowExecutionLifecycleStage.Accepted);
 
-                // Capture the response link for update-workflow-backed Nexus operations.
-                if (input.Options.ResponseInfo is { } responseInfo)
-                {
-                    responseInfo.Link = resp.Link;
-                }
-
                 // If the requested stage is completed, wait for result, but discard the update
-                // exception, that will come when _they_ call get result
+                // exception, that will come when _they_ call get result. The response link is
+                // captured on the handle for update-workflow-backed Nexus operations.
                 var handle = new WorkflowUpdateHandle<TResult>(
                     Client, req.Request.Meta.UpdateId, input.Id, resp.UpdateRef.WorkflowExecution.RunId)
-                { KnownOutcome = resp.Outcome };
+                { KnownOutcome = resp.Outcome, Link = resp.Link };
                 if (input.Options.WaitForStage == WorkflowUpdateStage.Completed)
                 {
                     await handle.PollUntilOutcomeAsync(input.Options.Rpc).ConfigureAwait(false);

--- a/src/Temporalio/Client/TemporalClient.Workflow.cs
+++ b/src/Temporalio/Client/TemporalClient.Workflow.cs
@@ -500,6 +500,12 @@ namespace Temporalio.Client
                 }
                 while (resp.Stage < UpdateWorkflowExecutionLifecycleStage.Accepted);
 
+                // Capture the response link for update-workflow-backed Nexus operations.
+                if (input.Options.ResponseInfo is { } responseInfo)
+                {
+                    responseInfo.Link = resp.Link;
+                }
+
                 // If the requested stage is completed, wait for result, but discard the update
                 // exception, that will come when _they_ call get result
                 var handle = new WorkflowUpdateHandle<TResult>(
@@ -976,6 +982,23 @@ namespace Temporalio.Client
                             req.Request.Input.Header.Fields[kvp.Key] =
                                 await codec.EncodeSingleAsync(kvp.Value).ConfigureAwait(false);
                         }
+                    }
+                }
+                // SDK-internal Nexus plumbing: request ID for de-duplication, completion callbacks,
+                // and links used by update-workflow-backed Nexus operations.
+                if (options is WorkflowUpdateStartOptions startOptions)
+                {
+                    if (startOptions.RequestId is { } nexusRequestId)
+                    {
+                        req.Request.RequestId = nexusRequestId;
+                    }
+                    if (startOptions.CompletionCallbacks is { } nexusCallbacks)
+                    {
+                        req.Request.CompletionCallbacks.AddRange(nexusCallbacks);
+                    }
+                    if (startOptions.Links is { } nexusLinks)
+                    {
+                        req.Request.Links.AddRange(nexusLinks);
                     }
                 }
                 return req;

--- a/src/Temporalio/Client/WorkflowUpdateHandle.cs
+++ b/src/Temporalio/Client/WorkflowUpdateHandle.cs
@@ -27,6 +27,12 @@ namespace Temporalio.Client
         internal Outcome? KnownOutcome { get; set; }
 
         /// <summary>
+        /// Gets or sets the link returned on the start-update response, if any. Only set by the SDK,
+        /// e.g. when starting an update-workflow-backed Nexus operation.
+        /// </summary>
+        internal Api.Common.V1.Link? Link { get; set; }
+
+        /// <summary>
         /// Wait for an update result disregarding any return value.
         /// </summary>
         /// <param name="rpcOptions">Extra RPC options.</param>

--- a/src/Temporalio/Client/WorkflowUpdateStartOptions.cs
+++ b/src/Temporalio/Client/WorkflowUpdateStartOptions.cs
@@ -1,4 +1,4 @@
-#pragma warning disable SA1402 // We allow multiple types of the same name
+using System.Collections.Generic;
 
 namespace Temporalio.Client
 {
@@ -45,30 +45,12 @@ namespace Temporalio.Client
         /// Gets or sets the completion callbacks. Only settable by the SDK, e.g. when starting an
         /// update-workflow-backed Nexus operation.
         /// </summary>
-        internal System.Collections.Generic.IReadOnlyCollection<Api.Common.V1.Callback>? CompletionCallbacks { get; set; }
+        internal IReadOnlyCollection<Api.Common.V1.Callback>? CompletionCallbacks { get; set; }
 
         /// <summary>
         /// Gets or sets the links. Only settable by the SDK, e.g. when starting an
         /// update-workflow-backed Nexus operation.
         /// </summary>
-        internal System.Collections.Generic.IReadOnlyCollection<Api.Common.V1.Link>? Links { get; set; }
-
-        /// <summary>
-        /// Gets or sets a holder that captures the link returned on the start-update response. Only
-        /// set by the SDK, e.g. when starting an update-workflow-backed Nexus operation.
-        /// </summary>
-        internal UpdateResponseInfo? ResponseInfo { get; set; }
-    }
-
-    /// <summary>
-    /// Mutable holder used to capture the link returned on a start-update response, so callers such
-    /// as the Nexus update-workflow operation can build outbound links.
-    /// </summary>
-    internal sealed class UpdateResponseInfo
-    {
-        /// <summary>
-        /// Gets or sets the link returned on the start-update response, if any.
-        /// </summary>
-        internal Api.Common.V1.Link? Link { get; set; }
+        internal IReadOnlyCollection<Api.Common.V1.Link>? Links { get; set; }
     }
 }

--- a/src/Temporalio/Client/WorkflowUpdateStartOptions.cs
+++ b/src/Temporalio/Client/WorkflowUpdateStartOptions.cs
@@ -1,3 +1,5 @@
+#pragma warning disable SA1402 // We allow multiple types of the same name
+
 namespace Temporalio.Client
 {
     /// <summary>
@@ -32,5 +34,41 @@ namespace Temporalio.Client
         /// <c>None</c> or <c>Admitted</c> at this time.
         /// </summary>
         public WorkflowUpdateStage WaitForStage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request ID for server de-duplication. Only settable by the SDK, e.g.
+        /// when starting an update-workflow-backed Nexus operation.
+        /// </summary>
+        internal string? RequestId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the completion callbacks. Only settable by the SDK, e.g. when starting an
+        /// update-workflow-backed Nexus operation.
+        /// </summary>
+        internal System.Collections.Generic.IReadOnlyCollection<Api.Common.V1.Callback>? CompletionCallbacks { get; set; }
+
+        /// <summary>
+        /// Gets or sets the links. Only settable by the SDK, e.g. when starting an
+        /// update-workflow-backed Nexus operation.
+        /// </summary>
+        internal System.Collections.Generic.IReadOnlyCollection<Api.Common.V1.Link>? Links { get; set; }
+
+        /// <summary>
+        /// Gets or sets a holder that captures the link returned on the start-update response. Only
+        /// set by the SDK, e.g. when starting an update-workflow-backed Nexus operation.
+        /// </summary>
+        internal UpdateResponseInfo? ResponseInfo { get; set; }
+    }
+
+    /// <summary>
+    /// Mutable holder used to capture the link returned on a start-update response, so callers such
+    /// as the Nexus update-workflow operation can build outbound links.
+    /// </summary>
+    internal sealed class UpdateResponseInfo
+    {
+        /// <summary>
+        /// Gets or sets the link returned on the start-update response, if any.
+        /// </summary>
+        internal Api.Common.V1.Link? Link { get; set; }
     }
 }

--- a/src/Temporalio/CompatibilitySuppressions.xml
+++ b/src/Temporalio/CompatibilitySuppressions.xml
@@ -3,42 +3,42 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/net462/Temporalio.dll</Left>
     <Right>lib/net462/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/net462/Temporalio.dll</Left>
     <Right>lib/net462/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/net462/Temporalio.dll</Left>
     <Right>lib/net462/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -75,21 +75,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/netstandard2.0/Temporalio.dll</Left>
     <Right>lib/netstandard2.0/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/netstandard2.0/Temporalio.dll</Left>
     <Right>lib/netstandard2.0/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartWorkflowUpdateAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions,System.String)</Target>
     <Left>lib/netstandard2.0/Temporalio.dll</Left>
     <Right>lib/netstandard2.0/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Temporalio/CompatibilitySuppressions.xml
+++ b/src/Temporalio/CompatibilitySuppressions.xml
@@ -3,6 +3,48 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Temporalio.Client.ITemporalClient.ListActivitiesAsync(System.String,Temporalio.Client.ActivityListOptions)</Target>
     <Left>lib/netstandard2.0/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
@@ -30,5 +72,26 @@
     <Target>M:Temporalio.Worker.ITemporalWorkerPlugin.ReplayWorkflowsAsync(Temporalio.Worker.WorkflowReplayer,System.Func{Temporalio.Worker.WorkflowReplayer,System.Collections.Generic.IAsyncEnumerable{Temporalio.Worker.WorkflowReplayResult}},System.Threading.CancellationToken)</Target>
     <Left>lib/netstandard2.0/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``1(System.String,System.String,System.Collections.Generic.IReadOnlyCollection{System.Object},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Temporalio.Nexus.ITemporalNexusClient.StartUpdateWorkflowAsync``2(System.String,System.Linq.Expressions.Expression{System.Func{``0,System.Threading.Tasks.Task{``1}}},Temporalio.Client.WorkflowUpdateStartOptions)</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
 </Suppressions>

--- a/src/Temporalio/Nexus/ITemporalNexusClient.cs
+++ b/src/Temporalio/Nexus/ITemporalNexusClient.cs
@@ -72,5 +72,75 @@ namespace Temporalio.Nexus
         /// <returns>An async operation result containing the workflow-run token.</returns>
         Task<TemporalOperationResult<TResult>> StartWorkflowAsync<TResult>(
             string workflow, IReadOnlyCollection<object?> args, WorkflowOptions options);
+
+        /// <summary>
+        /// Start a workflow update via a lambda invoking the update method, backing this Nexus
+        /// operation with the update.
+        /// </summary>
+        /// <remarks>
+        /// <para>Only <see cref="WorkflowUpdateStage.Accepted"/> is supported for
+        /// <c>WaitForStage</c>. The operation requires a callback URL to be present.</para>
+        /// <para>Returns an async result carrying an update-workflow token, unless the update has
+        /// already completed (e.g. a retried request with the same update ID), in which case a sync
+        /// result is returned; an update that completed with an error surfaces as a failed
+        /// operation.</para>
+        /// </remarks>
+        /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
+        /// <typeparam name="TResult">Update result type.</typeparam>
+        /// <param name="workflowId">Target workflow ID.</param>
+        /// <param name="updateCall">Invocation of the workflow update method with a result.</param>
+        /// <param name="options">Update start options. <c>WaitForStage</c> must be
+        /// <see cref="WorkflowUpdateStage.Accepted"/>. If the update ID is unset, the Nexus request
+        /// ID is used.</param>
+        /// <returns>An operation result for the update.</returns>
+        Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TWorkflow, TResult>(
+            string workflowId,
+            Expression<Func<TWorkflow, Task<TResult>>> updateCall,
+            WorkflowUpdateStartOptions options);
+
+        /// <summary>
+        /// Start a workflow update with no result via a lambda invoking the update method, backing
+        /// this Nexus operation with the update.
+        /// </summary>
+        /// <remarks>
+        /// <para>Only <see cref="WorkflowUpdateStage.Accepted"/> is supported for
+        /// <c>WaitForStage</c>. The operation requires a callback URL to be present.</para>
+        /// </remarks>
+        /// <typeparam name="TWorkflow">Workflow class type.</typeparam>
+        /// <param name="workflowId">Target workflow ID.</param>
+        /// <param name="updateCall">Invocation of the workflow update method with no result.</param>
+        /// <param name="options">Update start options. <c>WaitForStage</c> must be
+        /// <see cref="WorkflowUpdateStage.Accepted"/>. If the update ID is unset, the Nexus request
+        /// ID is used.</param>
+        /// <returns>An operation result for the update.</returns>
+        Task<TemporalOperationResult<NoValue>> StartUpdateWorkflowAsync<TWorkflow>(
+            string workflowId,
+            Expression<Func<TWorkflow, Task>> updateCall,
+            WorkflowUpdateStartOptions options);
+
+        /// <summary>
+        /// Start a workflow update by name, backing this Nexus operation with the update.
+        /// </summary>
+        /// <remarks>
+        /// <para>Only <see cref="WorkflowUpdateStage.Accepted"/> is supported for
+        /// <c>WaitForStage</c>. The operation requires a callback URL to be present.</para>
+        /// <para>Returns an async result carrying an update-workflow token, unless the update has
+        /// already completed (e.g. a retried request with the same update ID), in which case a sync
+        /// result is returned; an update that completed with an error surfaces as a failed
+        /// operation.</para>
+        /// </remarks>
+        /// <typeparam name="TResult">Update result type.</typeparam>
+        /// <param name="workflowId">Target workflow ID.</param>
+        /// <param name="update">Update name.</param>
+        /// <param name="args">Update arguments.</param>
+        /// <param name="options">Update start options. <c>WaitForStage</c> must be
+        /// <see cref="WorkflowUpdateStage.Accepted"/>. If the update ID is unset, the Nexus request
+        /// ID is used.</param>
+        /// <returns>An operation result for the update.</returns>
+        Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TResult>(
+            string workflowId,
+            string update,
+            IReadOnlyCollection<object?> args,
+            WorkflowUpdateStartOptions options);
     }
 }

--- a/src/Temporalio/Nexus/ITemporalNexusClient.cs
+++ b/src/Temporalio/Nexus/ITemporalNexusClient.cs
@@ -79,7 +79,7 @@ namespace Temporalio.Nexus
         /// </summary>
         /// <remarks>
         /// <para>Only <see cref="WorkflowUpdateStage.Accepted"/> is supported for
-        /// <c>WaitForStage</c>. The operation requires a callback URL to be present.</para>
+        /// <c>WaitForStage</c>. </para>
         /// <para>Returns an async result carrying an update-workflow token, unless the update has
         /// already completed (e.g. a retried request with the same update ID), in which case a sync
         /// result is returned; an update that completed with an error surfaces as a failed

--- a/src/Temporalio/Nexus/ITemporalNexusClient.cs
+++ b/src/Temporalio/Nexus/ITemporalNexusClient.cs
@@ -92,11 +92,13 @@ namespace Temporalio.Nexus
         /// <param name="options">Update start options. <c>WaitForStage</c> must be
         /// <see cref="WorkflowUpdateStage.Accepted"/>. If the update ID is unset, the Nexus request
         /// ID is used.</param>
+        /// <param name="runId">Target workflow run ID, or null for the latest run.</param>
         /// <returns>An operation result for the update.</returns>
-        Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TWorkflow, TResult>(
+        Task<TemporalOperationResult<TResult>> StartWorkflowUpdateAsync<TWorkflow, TResult>(
             string workflowId,
             Expression<Func<TWorkflow, Task<TResult>>> updateCall,
-            WorkflowUpdateStartOptions options);
+            WorkflowUpdateStartOptions options,
+            string? runId = null);
 
         /// <summary>
         /// Start a workflow update with no result via a lambda invoking the update method, backing
@@ -112,11 +114,13 @@ namespace Temporalio.Nexus
         /// <param name="options">Update start options. <c>WaitForStage</c> must be
         /// <see cref="WorkflowUpdateStage.Accepted"/>. If the update ID is unset, the Nexus request
         /// ID is used.</param>
+        /// <param name="runId">Target workflow run ID, or null for the latest run.</param>
         /// <returns>An operation result for the update.</returns>
-        Task<TemporalOperationResult<NoValue>> StartUpdateWorkflowAsync<TWorkflow>(
+        Task<TemporalOperationResult<NoValue>> StartWorkflowUpdateAsync<TWorkflow>(
             string workflowId,
             Expression<Func<TWorkflow, Task>> updateCall,
-            WorkflowUpdateStartOptions options);
+            WorkflowUpdateStartOptions options,
+            string? runId = null);
 
         /// <summary>
         /// Start a workflow update by name, backing this Nexus operation with the update.
@@ -136,11 +140,13 @@ namespace Temporalio.Nexus
         /// <param name="options">Update start options. <c>WaitForStage</c> must be
         /// <see cref="WorkflowUpdateStage.Accepted"/>. If the update ID is unset, the Nexus request
         /// ID is used.</param>
+        /// <param name="runId">Target workflow run ID, or null for the latest run.</param>
         /// <returns>An operation result for the update.</returns>
-        Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TResult>(
+        Task<TemporalOperationResult<TResult>> StartWorkflowUpdateAsync<TResult>(
             string workflowId,
             string update,
             IReadOnlyCollection<object?> args,
-            WorkflowUpdateStartOptions options);
+            WorkflowUpdateStartOptions options,
+            string? runId = null);
     }
 }

--- a/src/Temporalio/Nexus/NexusWorkflowRunHandle.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowRunHandle.cs
@@ -19,7 +19,15 @@ namespace Temporalio.Nexus
         /// </summary>
         internal const int WorkflowRunOperationTokenType = 1;
 
-        private static readonly JsonSerializerOptions TokenSerializerOptions = new()
+        /// <summary>
+        /// Token-type value identifying an update-workflow operation token.
+        /// </summary>
+        internal const int UpdateWorkflowOperationTokenType = 3;
+
+        /// <summary>
+        /// Serializer options shared by all operation token types.
+        /// </summary>
+        internal static readonly JsonSerializerOptions TokenSerializerOptions = new()
         {
 #pragma warning disable SYSLIB0020 // Need to use obsolete form, alternative not in all our versions
             IgnoreNullValues = true,
@@ -143,7 +151,9 @@ namespace Temporalio.Nexus
             TokenSerializerOptions));
 
         /// <summary>
-        /// Represents the fields of a Nexus operation token.
+        /// Represents the fields of a Nexus operation token. The <c>RunId</c> and <c>UpdateId</c>
+        /// fields are only populated for update-workflow tokens; for workflow-run tokens they are
+        /// null and omitted from the serialized form.
         /// </summary>
         internal record OperationToken(
             [property: JsonPropertyName("ns")]
@@ -153,7 +163,11 @@ namespace Temporalio.Nexus
             [property: JsonPropertyName("v")]
             int? Version,
             [property: JsonPropertyName("t")]
-            int Type = WorkflowRunOperationTokenType);
+            int Type = WorkflowRunOperationTokenType,
+            [property: JsonPropertyName("rid")]
+            string? RunId = null,
+            [property: JsonPropertyName("uid")]
+            string? UpdateId = null);
     }
 
     /// <inheritdoc />

--- a/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NexusRpc;
@@ -227,6 +228,21 @@ namespace Temporalio.Nexus
             options.RequestId = nexusStartContext.RequestId;
             var responseInfo = new UpdateResponseInfo();
             options.ResponseInfo = responseInfo;
+
+            // Cancel the (potentially long-polling) update-start RPC if the Nexus operation is
+            // cancelled — e.g. worker shutdown or operation timeout. StartUpdateAsync with
+            // WaitForStage.Accepted blocks until the update is accepted; without forwarding the
+            // operation's cancellation token, a target task queue with no worker would leave this
+            // handler task blocked and wedge worker drain.
+            options.Rpc = options.Rpc is { } existingRpc
+                ? (RpcOptions)existingRpc.Clone()
+                : new RpcOptions();
+            using var linkedStartCts = options.Rpc.CancellationToken is { } userStartToken
+                ? CancellationTokenSource.CreateLinkedTokenSource(
+                    userStartToken, nexusStartContext.CancellationToken)
+                : null;
+            options.Rpc.CancellationToken =
+                linkedStartCts?.Token ?? nexusStartContext.CancellationToken;
 
             var updateHandle = await client.GetWorkflowHandle(workflowId)
                 .StartUpdateAsync<TResult>(update, args, options).ConfigureAwait(false);

--- a/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
@@ -170,6 +170,10 @@ namespace Temporalio.Nexus
                     : nexusStartContext.RequestId;
             }
 
+            // Capture the (now guaranteed non-empty) update ID as a non-nullable local so later
+            // refactors cannot silently reintroduce a null at the usage sites.
+            var updateId = options.Id!;
+
             if (nexusStartContext.CallbackUrl is not { } callbackUrl)
             {
                 throw new HandlerException(
@@ -178,12 +182,11 @@ namespace Temporalio.Nexus
             }
 
             var client = temporalContext.TemporalClient;
-            var @namespace_ = client.Options.Namespace;
 
             // Generate the operation token before starting the update; it is needed for the callback
             // header.
             var handle = new NexusWorkflowUpdateHandle(
-                namespace_, workflowId, runId: string.Empty, updateId: options.Id!, version: 0);
+                client.Options.Namespace, workflowId, runId: string.Empty, updateId: updateId, version: 0);
             var token = handle.ToToken();
 
             // Convert inbound links to backward links carried on the update request.
@@ -226,8 +229,6 @@ namespace Temporalio.Nexus
             }
             options.CompletionCallbacks = new[] { callback };
             options.RequestId = nexusStartContext.RequestId;
-            var responseInfo = new UpdateResponseInfo();
-            options.ResponseInfo = responseInfo;
 
             // Cancel the (potentially long-polling) update-start RPC if the Nexus operation is
             // cancelled — e.g. worker shutdown or operation timeout. StartUpdateAsync with
@@ -252,7 +253,7 @@ namespace Temporalio.Nexus
             // skip attaching the outbound link and continue, surfacing the outcome (sync result or
             // failed operation) normally. On validation failure there may be no history event, so a
             // present link can be a plain workflow link rather than a workflow-event link.
-            if (responseInfo.Link is { } responseLink &&
+            if (updateHandle.Link is { } responseLink &&
                 responseLink.ToNexusLink() is { } outboundLink)
             {
                 nexusStartContext.OutboundLinks.Add(outboundLink);

--- a/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
@@ -165,7 +165,7 @@ namespace Temporalio.Nexus
             // token derived from it) is never empty.
             if (string.IsNullOrEmpty(options.Id))
             {
-                options.Id = string.IsNullOrEmpty(nexusStartContext.RequestId)
+                options.Id = string.IsNullOrWhiteSpace(nexusStartContext.RequestId)
                     ? Guid.NewGuid().ToString()
                     : nexusStartContext.RequestId;
             }
@@ -178,7 +178,7 @@ namespace Temporalio.Nexus
             }
 
             var client = temporalContext.TemporalClient;
-            var namespace_ = client.Options.Namespace;
+            var @namespace_ = client.Options.Namespace;
 
             // Generate the operation token before starting the update; it is needed for the callback
             // header.

--- a/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
@@ -136,15 +136,17 @@ namespace Temporalio.Nexus
         /// <param name="args">Update arguments.</param>
         /// <param name="options">Update start options. <c>WaitForStage</c> must be
         /// <see cref="WorkflowUpdateStage.Accepted"/>.</param>
+        /// <param name="runId">Target workflow run ID, or null for the latest run.</param>
         /// <returns>An async result carrying the update-workflow token, or a sync result if the
         /// update already completed.</returns>
-        internal static async Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TResult>(
+        internal static async Task<TemporalOperationResult<TResult>> StartWorkflowUpdateAsync<TResult>(
             OperationStartContext nexusStartContext,
             NexusOperationExecutionContext temporalContext,
             string workflowId,
             string update,
             IReadOnlyCollection<object?> args,
-            WorkflowUpdateStartOptions options)
+            WorkflowUpdateStartOptions options,
+            string? runId = null)
         {
             // Only WorkflowUpdateStage.Accepted is supported. A Nexus handler has a short deadline,
             // so waiting for full update completion is unsupported; reject any other wait stage as a
@@ -186,7 +188,11 @@ namespace Temporalio.Nexus
             // Generate the operation token before starting the update; it is needed for the callback
             // header.
             var handle = new NexusWorkflowUpdateHandle(
-                client.Options.Namespace, workflowId, runId: string.Empty, updateId: updateId, version: 0);
+                client.Options.Namespace,
+                workflowId,
+                runId: runId ?? string.Empty,
+                updateId: updateId,
+                version: 0);
             var token = handle.ToToken();
 
             // Convert inbound links to backward links carried on the update request.
@@ -245,7 +251,7 @@ namespace Temporalio.Nexus
             options.Rpc.CancellationToken =
                 linkedStartCts?.Token ?? nexusStartContext.CancellationToken;
 
-            var updateHandle = await client.GetWorkflowHandle(workflowId)
+            var updateHandle = await client.GetWorkflowHandle(workflowId, runId)
                 .StartUpdateAsync<TResult>(update, args, options).ConfigureAwait(false);
 
             // Capture the link from the response and add it as an outbound handler link when one is

--- a/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
@@ -161,20 +161,29 @@ namespace Temporalio.Nexus
             // state (ID, links, callbacks, request ID) back to a caller that reuses the instance.
             options = (WorkflowUpdateStartOptions)options.Clone();
 
-            // If an update ID is not provided, use the Nexus request ID. This protects against
-            // retried requests (e.g. due to a network failure) spawning duplicate updates. If the
-            // request ID is also empty, generate a fallback so the update ID (and the operation
-            // token derived from it) is never empty.
-            if (string.IsNullOrEmpty(options.Id))
+            // Resolve the update ID as a non-nullable local. When the caller doesn't supply one,
+            // fall back to the Nexus request ID: the server assigns it and keeps it stable across
+            // task redeliveries, so the update stays deduplicated if the start task is redelivered.
+            // (The "is { } id" pattern narrows Id to non-null on all targets; IsNullOrWhiteSpace
+            // isn't annotated as a null guard on the netstandard2.0/net462 targets so
+            // caused a compiler error without that.)
+            string updateId;
+            if (options.Id is { } id && !string.IsNullOrWhiteSpace(id))
             {
-                options.Id = string.IsNullOrWhiteSpace(nexusStartContext.RequestId)
-                    ? Guid.NewGuid().ToString()
-                    : nexusStartContext.RequestId;
+                updateId = id;
+            }
+            else if (!string.IsNullOrWhiteSpace(nexusStartContext.RequestId))
+            {
+                updateId = nexusStartContext.RequestId;
+            }
+            else
+            {
+                throw new HandlerException(
+                    HandlerErrorType.Internal,
+                    "no update ID supplied and the Nexus request ID is empty");
             }
 
-            // Capture the (now guaranteed non-empty) update ID as a non-nullable local so later
-            // refactors cannot silently reintroduce a null at the usage sites.
-            var updateId = options.Id!;
+            options.Id = updateId;
 
             if (nexusStartContext.CallbackUrl is not { } callbackUrl)
             {

--- a/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowStartHelper.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using NexusRpc;
 using NexusRpc.Handlers;
 using Temporalio.Api.Common.V1;
 using Temporalio.Api.Enums.V1;
 using Temporalio.Client;
+using Temporalio.Exceptions;
 
 namespace Temporalio.Nexus
 {
@@ -117,6 +119,152 @@ namespace Temporalio.Nexus
             }.ToNexusLink());
 
             return handle;
+        }
+
+        /// <summary>
+        /// Start a workflow update from a Nexus operation and return the operation result. This
+        /// handles all Nexus plumbing: validating the wait stage, defaulting the update ID to the
+        /// Nexus request ID, generating the operation token, injecting the request ID, callback, and
+        /// links onto the update request, and adding the outbound link.
+        /// </summary>
+        /// <typeparam name="TResult">Operation result type.</typeparam>
+        /// <param name="nexusStartContext">Nexus start context for callbacks and links.</param>
+        /// <param name="temporalContext">Temporal operation context for client, info, and logging.</param>
+        /// <param name="workflowId">Target workflow ID.</param>
+        /// <param name="update">Update name.</param>
+        /// <param name="args">Update arguments.</param>
+        /// <param name="options">Update start options. <c>WaitForStage</c> must be
+        /// <see cref="WorkflowUpdateStage.Accepted"/>.</param>
+        /// <returns>An async result carrying the update-workflow token, or a sync result if the
+        /// update already completed.</returns>
+        internal static async Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TResult>(
+            OperationStartContext nexusStartContext,
+            NexusOperationExecutionContext temporalContext,
+            string workflowId,
+            string update,
+            IReadOnlyCollection<object?> args,
+            WorkflowUpdateStartOptions options)
+        {
+            // Only WorkflowUpdateStage.Accepted is supported. A Nexus handler has a short deadline,
+            // so waiting for full update completion is unsupported; reject any other wait stage as a
+            // failed operation.
+            if (options.WaitForStage != WorkflowUpdateStage.Accepted)
+            {
+                throw OperationException.CreateFailed(
+                    "nexus operation workflow updates only support WorkflowUpdateStage.Accepted");
+            }
+
+            // Shallow clone the options so we can mutate them without leaking the internal Nexus
+            // state (ID, links, callbacks, request ID) back to a caller that reuses the instance.
+            options = (WorkflowUpdateStartOptions)options.Clone();
+
+            // If an update ID is not provided, use the Nexus request ID. This protects against
+            // retried requests (e.g. due to a network failure) spawning duplicate updates. If the
+            // request ID is also empty, generate a fallback so the update ID (and the operation
+            // token derived from it) is never empty.
+            if (string.IsNullOrEmpty(options.Id))
+            {
+                options.Id = string.IsNullOrEmpty(nexusStartContext.RequestId)
+                    ? Guid.NewGuid().ToString()
+                    : nexusStartContext.RequestId;
+            }
+
+            if (nexusStartContext.CallbackUrl is not { } callbackUrl)
+            {
+                throw new HandlerException(
+                    HandlerErrorType.BadRequest,
+                    "callback URL required for async UpdateWorkflow operation invocations");
+            }
+
+            var client = temporalContext.TemporalClient;
+            var namespace_ = client.Options.Namespace;
+
+            // Generate the operation token before starting the update; it is needed for the callback
+            // header.
+            var handle = new NexusWorkflowUpdateHandle(
+                namespace_, workflowId, runId: string.Empty, updateId: options.Id!, version: 0);
+            var token = handle.ToToken();
+
+            // Convert inbound links to backward links carried on the update request.
+            var links = nexusStartContext.InboundLinks.Select(link =>
+            {
+                try
+                {
+                    return new Link { WorkflowEvent = link.ToWorkflowEvent() };
+                }
+                catch (ArgumentException e)
+                {
+                    temporalContext.Logger.LogWarning(e, "Invalid Nexus link: {Url}", link.Uri);
+                    return null;
+                }
+            }).OfType<Link>().ToList();
+
+            var callback = new Callback() { Nexus = new() { Url = callbackUrl } };
+            var callbackHeadersHasToken = false;
+            if (nexusStartContext.CallbackHeaders is { } callbackHeaders)
+            {
+                foreach (var kv in callbackHeaders)
+                {
+                    callback.Nexus.Header.Add(kv.Key, kv.Value);
+                    if (string.Equals(
+                            kv.Key, NexusOperationTokenHeader, StringComparison.OrdinalIgnoreCase))
+                    {
+                        callbackHeadersHasToken = true;
+                    }
+                }
+            }
+            // Set operation token if not already present (header is case-insensitive).
+            if (!callbackHeadersHasToken)
+            {
+                callback.Nexus.Header[NexusOperationTokenHeader] = token;
+            }
+            if (links.Count > 0)
+            {
+                callback.Links.AddRange(links);
+                options.Links = links;
+            }
+            options.CompletionCallbacks = new[] { callback };
+            options.RequestId = nexusStartContext.RequestId;
+            var responseInfo = new UpdateResponseInfo();
+            options.ResponseInfo = responseInfo;
+
+            var updateHandle = await client.GetWorkflowHandle(workflowId)
+                .StartUpdateAsync<TResult>(update, args, options).ConfigureAwait(false);
+
+            // Capture the link from the response and add it as an outbound handler link when one is
+            // present. A rejected or failed update legitimately may have no link, so in that case we
+            // skip attaching the outbound link and continue, surfacing the outcome (sync result or
+            // failed operation) normally. On validation failure there may be no history event, so a
+            // present link can be a plain workflow link rather than a workflow-event link.
+            if (responseInfo.Link is { } responseLink &&
+                responseLink.ToNexusLink() is { } outboundLink)
+            {
+                nexusStartContext.OutboundLinks.Add(outboundLink);
+            }
+
+            // If the update already completed (e.g. a retried request with the same update ID, or an
+            // immediately-completing update returned as completed), return a synchronous result. A
+            // completed-with-error update (such as a validation rejection) is non-retryable and
+            // surfaces as a failed operation.
+            if (updateHandle.KnownOutcome != null)
+            {
+                try
+                {
+                    if (typeof(TResult) == typeof(NoValue))
+                    {
+                        await updateHandle.GetResultAsync().ConfigureAwait(false);
+                        return TemporalOperationResult<TResult>.SyncResult(default);
+                    }
+                    var value = await updateHandle.GetResultAsync<TResult>().ConfigureAwait(false);
+                    return TemporalOperationResult<TResult>.SyncResult(value);
+                }
+                catch (WorkflowUpdateFailedException e)
+                {
+                    throw OperationException.CreateFailed(e.Message, e);
+                }
+            }
+
+            return TemporalOperationResult<TResult>.AsyncResult(token);
         }
     }
 }

--- a/src/Temporalio/Nexus/NexusWorkflowUpdateHandle.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowUpdateHandle.cs
@@ -10,7 +10,7 @@ namespace Temporalio.Nexus
     /// carries the identifiers needed to encode/decode an update-workflow operation token.
     /// </summary>
     /// <remarks>WARNING: Nexus support is experimental.</remarks>
-    public class NexusWorkflowUpdateHandle
+    internal class NexusWorkflowUpdateHandle
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NexusWorkflowUpdateHandle"/> class.
@@ -20,7 +20,7 @@ namespace Temporalio.Nexus
         /// <param name="runId">Workflow run ID. May be empty.</param>
         /// <param name="updateId">Update ID.</param>
         /// <param name="version">Operation token version.</param>
-        internal NexusWorkflowUpdateHandle(
+        public NexusWorkflowUpdateHandle(
             string namespace_,
             string workflowId,
             string runId,
@@ -37,27 +37,27 @@ namespace Temporalio.Nexus
         /// <summary>
         /// Gets the namespace.
         /// </summary>
-        internal string Namespace { get; private init; }
+        public string Namespace { get; private init; }
 
         /// <summary>
         /// Gets the workflow ID.
         /// </summary>
-        internal string WorkflowId { get; private init; }
+        public string WorkflowId { get; private init; }
 
         /// <summary>
         /// Gets the workflow run ID. May be empty.
         /// </summary>
-        internal string RunId { get; private init; }
+        public string RunId { get; private init; }
 
         /// <summary>
         /// Gets the update ID.
         /// </summary>
-        internal string UpdateId { get; private init; }
+        public string UpdateId { get; private init; }
 
         /// <summary>
         /// Gets the token version.
         /// </summary>
-        internal int Version { get; private init; }
+        public int Version { get; private init; }
 
         /// <summary>
         /// Create a handle based on the string token.
@@ -65,7 +65,7 @@ namespace Temporalio.Nexus
         /// <param name="token">Operation token.</param>
         /// <returns>Created handle.</returns>
         /// <exception cref="ArgumentException">If the token is invalid.</exception>
-        internal static NexusWorkflowUpdateHandle FromToken(string token)
+        public static NexusWorkflowUpdateHandle FromToken(string token)
         {
             var data = NexusWorkflowRunHandle.ParseToken(token);
             if (string.IsNullOrEmpty(data.Namespace))
@@ -101,7 +101,7 @@ namespace Temporalio.Nexus
         /// <exception cref="ArgumentException">If the namespace, workflow ID, or update ID is
         /// empty. An empty update ID would produce a token that breaks server-side dedup, so it is
         /// rejected here (matching the Go and TypeScript token generators).</exception>
-        internal string ToToken()
+        public string ToToken()
         {
             if (string.IsNullOrEmpty(Namespace) ||
                 string.IsNullOrEmpty(WorkflowId) ||

--- a/src/Temporalio/Nexus/NexusWorkflowUpdateHandle.cs
+++ b/src/Temporalio/Nexus/NexusWorkflowUpdateHandle.cs
@@ -1,0 +1,127 @@
+#pragma warning disable SA1402 // We allow multiple types of the same name
+
+using System;
+using System.Text.Json;
+
+namespace Temporalio.Nexus
+{
+    /// <summary>
+    /// Update handle representing an update-workflow operation started from a Nexus operation. It
+    /// carries the identifiers needed to encode/decode an update-workflow operation token.
+    /// </summary>
+    /// <remarks>WARNING: Nexus support is experimental.</remarks>
+    public class NexusWorkflowUpdateHandle
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NexusWorkflowUpdateHandle"/> class.
+        /// </summary>
+        /// <param name="namespace_">Workflow namespace.</param>
+        /// <param name="workflowId">Workflow ID.</param>
+        /// <param name="runId">Workflow run ID. May be empty.</param>
+        /// <param name="updateId">Update ID.</param>
+        /// <param name="version">Operation token version.</param>
+        internal NexusWorkflowUpdateHandle(
+            string namespace_,
+            string workflowId,
+            string runId,
+            string updateId,
+            int version)
+        {
+            Namespace = namespace_;
+            WorkflowId = workflowId;
+            RunId = runId;
+            UpdateId = updateId;
+            Version = version;
+        }
+
+        /// <summary>
+        /// Gets the namespace.
+        /// </summary>
+        internal string Namespace { get; private init; }
+
+        /// <summary>
+        /// Gets the workflow ID.
+        /// </summary>
+        internal string WorkflowId { get; private init; }
+
+        /// <summary>
+        /// Gets the workflow run ID. May be empty.
+        /// </summary>
+        internal string RunId { get; private init; }
+
+        /// <summary>
+        /// Gets the update ID.
+        /// </summary>
+        internal string UpdateId { get; private init; }
+
+        /// <summary>
+        /// Gets the token version.
+        /// </summary>
+        internal int Version { get; private init; }
+
+        /// <summary>
+        /// Create a handle based on the string token.
+        /// </summary>
+        /// <param name="token">Operation token.</param>
+        /// <returns>Created handle.</returns>
+        /// <exception cref="ArgumentException">If the token is invalid.</exception>
+        internal static NexusWorkflowUpdateHandle FromToken(string token)
+        {
+            var data = NexusWorkflowRunHandle.ParseToken(token);
+            if (string.IsNullOrEmpty(data.Namespace))
+            {
+                throw new ArgumentException("Invalid token: missing namespace");
+            }
+            if (data.Type != NexusWorkflowRunHandle.UpdateWorkflowOperationTokenType)
+            {
+                throw new ArgumentException(
+                    $"Invalid token type: {data.Type}, expected: " +
+                    $"{NexusWorkflowRunHandle.UpdateWorkflowOperationTokenType}");
+            }
+            if (string.IsNullOrEmpty(data.WorkflowId))
+            {
+                throw new ArgumentException("Invalid token: missing workflow ID (wid)");
+            }
+            if (string.IsNullOrEmpty(data.UpdateId))
+            {
+                throw new ArgumentException("Invalid token: missing update ID (uid)");
+            }
+            return new(
+                data.Namespace,
+                data.WorkflowId,
+                data.RunId ?? string.Empty,
+                data.UpdateId!,
+                data.Version ?? 0);
+        }
+
+        /// <summary>
+        /// Create a string token based on this handle.
+        /// </summary>
+        /// <returns>Operation token.</returns>
+        /// <exception cref="ArgumentException">If the namespace, workflow ID, or update ID is
+        /// empty. An empty update ID would produce a token that breaks server-side dedup, so it is
+        /// rejected here (matching the Go and TypeScript token generators).</exception>
+        internal string ToToken()
+        {
+            if (string.IsNullOrEmpty(Namespace) ||
+                string.IsNullOrEmpty(WorkflowId) ||
+                string.IsNullOrEmpty(UpdateId))
+            {
+                throw new ArgumentException(
+                    "Cannot create update-workflow operation token: namespace, workflow ID, and " +
+                    $"update ID must all be non-empty (ns: '{Namespace}', wid: '{WorkflowId}', " +
+                    $"uid: '{UpdateId}')");
+            }
+            return NexusWorkflowRunHandle.Base64UrlEncode(
+                JsonSerializer.SerializeToUtf8Bytes(
+                    new NexusWorkflowRunHandle.OperationToken(
+                        Namespace: Namespace,
+                        WorkflowId: WorkflowId,
+                        Version: Version == 0 ? null : Version,
+                        Type: NexusWorkflowRunHandle.UpdateWorkflowOperationTokenType,
+                        RunId: string.IsNullOrEmpty(RunId) ? null : RunId,
+                        UpdateId: UpdateId),
+                    NexusWorkflowRunHandle.TokenSerializerOptions));
+        }
+    }
+}

--- a/src/Temporalio/Nexus/ProtoLinkExtensions.cs
+++ b/src/Temporalio/Nexus/ProtoLinkExtensions.cs
@@ -88,15 +88,21 @@ namespace Temporalio.Nexus
         }
 
         /// <summary>
-        /// Convert a proto Link to a Nexus link, dispatching on the populated oneof variant.
+        /// Convert a proto Link to a Nexus link, dispatching on the populated oneof variant. Handles
+        /// the workflow-event, nexus-operation, and workflow variants. Returns <c>null</c> when no
+        /// variant is set (e.g. a rejected update that has no history event to link to), so callers
+        /// can skip it rather than dereferencing an unset variant. Throws for a set-but-unrecognized
+        /// variant.
         /// </summary>
         /// <param name="link">Proto link.</param>
-        /// <returns>Nexus link.</returns>
-        /// <exception cref="ArgumentException">If the link variant is not set or unknown.</exception>
-        public static NexusLink ToNexusLink(this Api.Common.V1.Link link) => link.VariantCase switch
+        /// <returns>Nexus link, or <c>null</c> if no variant is set.</returns>
+        /// <exception cref="ArgumentException">If the link variant is set but unrecognized.</exception>
+        public static NexusLink? ToNexusLink(this Api.Common.V1.Link link) => link.VariantCase switch
         {
             Api.Common.V1.Link.VariantOneofCase.WorkflowEvent => link.WorkflowEvent.ToNexusLink(),
             Api.Common.V1.Link.VariantOneofCase.NexusOperation => link.NexusOperation.ToNexusLink(),
+            Api.Common.V1.Link.VariantOneofCase.Workflow => link.Workflow.ToNexusLink(),
+            Api.Common.V1.Link.VariantOneofCase.None => null,
             _ => throw new ArgumentException($"Unknown link variant: {link.VariantCase}"),
         };
 
@@ -130,6 +136,25 @@ namespace Temporalio.Nexus
                 OperationId = Uri.UnescapeDataString(pathPieces[3]),
                 RunId = Uri.UnescapeDataString(pathPieces[4]),
             };
+        }
+
+        /// <summary>
+        /// Convert a workflow link to a Nexus link. Unlike a workflow-event link, this points at a
+        /// workflow execution without referencing a particular history event, which is used when
+        /// there is no event to link to (e.g. a rejected update).
+        /// </summary>
+        /// <param name="workflow">Workflow link to convert.</param>
+        /// <returns>Nexus link.</returns>
+        public static NexusLink ToNexusLink(this Api.Common.V1.Link.Types.Workflow workflow)
+        {
+            var builder = new UriBuilder
+            {
+                Scheme = "temporal",
+                Path = "/namespaces/" + Uri.EscapeDataString(workflow.Namespace) + "/workflows/" +
+                    Uri.EscapeDataString(workflow.WorkflowId) + "/" + Uri.EscapeDataString(workflow.RunId) +
+                    "/history",
+            };
+            return new(builder.Uri, Api.Common.V1.Link.Types.Workflow.Descriptor.FullName);
         }
 
         /// <summary>

--- a/src/Temporalio/Nexus/ProtoLinkExtensions.cs
+++ b/src/Temporalio/Nexus/ProtoLinkExtensions.cs
@@ -147,14 +147,10 @@ namespace Temporalio.Nexus
         /// <returns>Nexus link.</returns>
         public static NexusLink ToNexusLink(this Api.Common.V1.Link.Types.Workflow workflow)
         {
-            var builder = new UriBuilder
-            {
-                Scheme = "temporal",
-                Path = "/namespaces/" + Uri.EscapeDataString(workflow.Namespace) + "/workflows/" +
-                    Uri.EscapeDataString(workflow.WorkflowId) + "/" + Uri.EscapeDataString(workflow.RunId) +
-                    "/history",
-            };
-            return new(builder.Uri, Api.Common.V1.Link.Types.Workflow.Descriptor.FullName);
+            var uriStr = "temporal:///namespaces/" + Uri.EscapeDataString(workflow.Namespace) +
+                "/workflows/" + Uri.EscapeDataString(workflow.WorkflowId) + "/" +
+                Uri.EscapeDataString(workflow.RunId) + "/history";
+            return new(new Uri(uriStr), Api.Common.V1.Link.Types.Workflow.Descriptor.FullName);
         }
 
         /// <summary>

--- a/src/Temporalio/Nexus/TemporalNexusClient.cs
+++ b/src/Temporalio/Nexus/TemporalNexusClient.cs
@@ -51,30 +51,50 @@ namespace Temporalio.Nexus
         }
 
         /// <inheritdoc/>
-        public async Task<TemporalOperationResult<NoValue>> StartWorkflowAsync<TWorkflow>(
+        public Task<TemporalOperationResult<NoValue>> StartWorkflowAsync<TWorkflow>(
             Expression<Func<TWorkflow, Task>> workflowRunCall, WorkflowOptions options)
         {
             var (runMethod, args) = Common.ExpressionUtil.ExtractCall(workflowRunCall);
-            var handle = await NexusWorkflowStartHelper.StartWorkflowAsync(
-                nexusStartContext,
-                temporalContext,
+            return StartWorkflowAsync<NoValue>(
                 Workflows.WorkflowDefinition.NameFromRunMethodForCall(runMethod),
                 args,
-                options).ConfigureAwait(false);
-            return TemporalOperationResult<NoValue>.AsyncResult(handle.ToToken());
+                options);
         }
 
         /// <inheritdoc/>
         public async Task<TemporalOperationResult<TResult>> StartWorkflowAsync<TResult>(
             string workflow, IReadOnlyCollection<object?> args, WorkflowOptions options)
         {
-            var handle = await NexusWorkflowStartHelper.StartWorkflowAsync(
-                nexusStartContext,
-                temporalContext,
-                workflow,
-                args,
-                options).ConfigureAwait(false);
-            return TemporalOperationResult<TResult>.AsyncResult(handle.ToToken());
+            // Reserve the single async-operation slot for this operation invocation. Starting a
+            // workflow always produces an async result, so a successful start consumes the slot and
+            // a failure releases it. A Nexus operation Start handler runs single-threaded per
+            // invocation, so no synchronization is needed.
+            if (asyncStarted)
+            {
+                throw new HandlerException(
+                    HandlerErrorType.BadRequest,
+                    "only one async operation can be started per operation invocation");
+            }
+            asyncStarted = true;
+            var keepSlot = false;
+            try
+            {
+                var handle = await NexusWorkflowStartHelper.StartWorkflowAsync(
+                    nexusStartContext,
+                    temporalContext,
+                    workflow,
+                    args,
+                    options).ConfigureAwait(false);
+                keepSlot = true;
+                return TemporalOperationResult<TResult>.AsyncResult(handle.ToToken());
+            }
+            finally
+            {
+                if (!keepSlot)
+                {
+                    asyncStarted = false;
+                }
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Temporalio/Nexus/TemporalNexusClient.cs
+++ b/src/Temporalio/Nexus/TemporalNexusClient.cs
@@ -78,39 +78,44 @@ namespace Temporalio.Nexus
         }
 
         /// <inheritdoc/>
-        public Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TWorkflow, TResult>(
+        public Task<TemporalOperationResult<TResult>> StartWorkflowUpdateAsync<TWorkflow, TResult>(
             string workflowId,
             Expression<Func<TWorkflow, Task<TResult>>> updateCall,
-            WorkflowUpdateStartOptions options)
+            WorkflowUpdateStartOptions options,
+            string? runId = null)
         {
             var (method, args) = Common.ExpressionUtil.ExtractCall(updateCall);
-            return StartUpdateWorkflowAsync<TResult>(
+            return StartWorkflowUpdateAsync<TResult>(
                 workflowId,
                 Workflows.WorkflowUpdateDefinition.NameFromMethodForCall(method),
                 args,
-                options);
+                options,
+                runId);
         }
 
         /// <inheritdoc/>
-        public Task<TemporalOperationResult<NoValue>> StartUpdateWorkflowAsync<TWorkflow>(
+        public Task<TemporalOperationResult<NoValue>> StartWorkflowUpdateAsync<TWorkflow>(
             string workflowId,
             Expression<Func<TWorkflow, Task>> updateCall,
-            WorkflowUpdateStartOptions options)
+            WorkflowUpdateStartOptions options,
+            string? runId = null)
         {
             var (method, args) = Common.ExpressionUtil.ExtractCall(updateCall);
-            return StartUpdateWorkflowAsync<NoValue>(
+            return StartWorkflowUpdateAsync<NoValue>(
                 workflowId,
                 Workflows.WorkflowUpdateDefinition.NameFromMethodForCall(method),
                 args,
-                options);
+                options,
+                runId);
         }
 
         /// <inheritdoc/>
-        public async Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TResult>(
+        public async Task<TemporalOperationResult<TResult>> StartWorkflowUpdateAsync<TResult>(
             string workflowId,
             string update,
             IReadOnlyCollection<object?> args,
-            WorkflowUpdateStartOptions options)
+            WorkflowUpdateStartOptions options,
+            string? runId = null)
         {
             // Reserve the single async-operation slot for this operation invocation. Only a genuine
             // async result consumes it; a sync result or a failure releases it. A Nexus operation
@@ -125,13 +130,14 @@ namespace Temporalio.Nexus
             var keepSlot = false;
             try
             {
-                var result = await NexusWorkflowStartHelper.StartUpdateWorkflowAsync<TResult>(
+                var result = await NexusWorkflowStartHelper.StartWorkflowUpdateAsync<TResult>(
                     nexusStartContext,
                     temporalContext,
                     workflowId,
                     update,
                     args,
-                    options).ConfigureAwait(false);
+                    options,
+                    runId).ConfigureAwait(false);
                 keepSlot = !result.IsSyncResult;
                 return result;
             }

--- a/src/Temporalio/Nexus/TemporalNexusClient.cs
+++ b/src/Temporalio/Nexus/TemporalNexusClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using NexusRpc.Handlers;
 using Temporalio.Client;
@@ -21,6 +22,7 @@ namespace Temporalio.Nexus
     {
         private readonly OperationStartContext nexusStartContext;
         private readonly NexusOperationExecutionContext temporalContext;
+        private int asyncStarted;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TemporalNexusClient"/> class.
@@ -74,6 +76,71 @@ namespace Temporalio.Nexus
                 args,
                 options).ConfigureAwait(false);
             return TemporalOperationResult<TResult>.AsyncResult(handle.ToToken());
+        }
+
+        /// <inheritdoc/>
+        public Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TWorkflow, TResult>(
+            string workflowId,
+            Expression<Func<TWorkflow, Task<TResult>>> updateCall,
+            WorkflowUpdateStartOptions options)
+        {
+            var (method, args) = Common.ExpressionUtil.ExtractCall(updateCall);
+            return StartUpdateWorkflowAsync<TResult>(
+                workflowId,
+                Workflows.WorkflowUpdateDefinition.NameFromMethodForCall(method),
+                args,
+                options);
+        }
+
+        /// <inheritdoc/>
+        public Task<TemporalOperationResult<NoValue>> StartUpdateWorkflowAsync<TWorkflow>(
+            string workflowId,
+            Expression<Func<TWorkflow, Task>> updateCall,
+            WorkflowUpdateStartOptions options)
+        {
+            var (method, args) = Common.ExpressionUtil.ExtractCall(updateCall);
+            return StartUpdateWorkflowAsync<NoValue>(
+                workflowId,
+                Workflows.WorkflowUpdateDefinition.NameFromMethodForCall(method),
+                args,
+                options);
+        }
+
+        /// <inheritdoc/>
+        public async Task<TemporalOperationResult<TResult>> StartUpdateWorkflowAsync<TResult>(
+            string workflowId,
+            string update,
+            IReadOnlyCollection<object?> args,
+            WorkflowUpdateStartOptions options)
+        {
+            // Reserve the single async-operation slot for this operation invocation. Only a genuine
+            // async result consumes it; a sync result or a failure releases it.
+            if (Interlocked.CompareExchange(ref asyncStarted, 1, 0) != 0)
+            {
+                throw new HandlerException(
+                    HandlerErrorType.BadRequest,
+                    "only one async operation can be started per operation invocation");
+            }
+            var keepSlot = false;
+            try
+            {
+                var result = await NexusWorkflowStartHelper.StartUpdateWorkflowAsync<TResult>(
+                    nexusStartContext,
+                    temporalContext,
+                    workflowId,
+                    update,
+                    args,
+                    options).ConfigureAwait(false);
+                keepSlot = !result.IsSyncResult;
+                return result;
+            }
+            finally
+            {
+                if (!keepSlot)
+                {
+                    Interlocked.Exchange(ref asyncStarted, 0);
+                }
+            }
         }
     }
 }

--- a/src/Temporalio/Nexus/TemporalNexusClient.cs
+++ b/src/Temporalio/Nexus/TemporalNexusClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Threading;
 using System.Threading.Tasks;
 using NexusRpc.Handlers;
 using Temporalio.Client;
@@ -22,7 +21,7 @@ namespace Temporalio.Nexus
     {
         private readonly OperationStartContext nexusStartContext;
         private readonly NexusOperationExecutionContext temporalContext;
-        private int asyncStarted;
+        private bool asyncStarted;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TemporalNexusClient"/> class.
@@ -114,13 +113,15 @@ namespace Temporalio.Nexus
             WorkflowUpdateStartOptions options)
         {
             // Reserve the single async-operation slot for this operation invocation. Only a genuine
-            // async result consumes it; a sync result or a failure releases it.
-            if (Interlocked.CompareExchange(ref asyncStarted, 1, 0) != 0)
+            // async result consumes it; a sync result or a failure releases it. A Nexus operation
+            // Start handler runs single-threaded per invocation, so no synchronization is needed.
+            if (asyncStarted)
             {
                 throw new HandlerException(
                     HandlerErrorType.BadRequest,
                     "only one async operation can be started per operation invocation");
             }
+            asyncStarted = true;
             var keepSlot = false;
             try
             {
@@ -138,7 +139,7 @@ namespace Temporalio.Nexus
             {
                 if (!keepSlot)
                 {
-                    Interlocked.Exchange(ref asyncStarted, 0);
+                    asyncStarted = false;
                 }
             }
         }

--- a/src/Temporalio/Nexus/TemporalOperationHandler.cs
+++ b/src/Temporalio/Nexus/TemporalOperationHandler.cs
@@ -125,7 +125,20 @@ namespace Temporalio.Nexus
             {
                 throw new HandlerException(HandlerErrorType.BadRequest, "Invalid namespace");
             }
-            if (token.Type == NexusWorkflowRunHandle.UpdateWorkflowOperationTokenType)
+            return token.Type switch
+            {
+                NexusWorkflowRunHandle.WorkflowRunOperationTokenType =>
+                    CancelWorkflowRunAsync(
+                        new TemporalOperationCancelContext(context),
+                        new CancelWorkflowRunInput(token.WorkflowId)),
+                NexusWorkflowRunHandle.UpdateWorkflowOperationTokenType =>
+                    CancelWorkflowUpdateFromTokenAsync(),
+                _ => throw new HandlerException(
+                    HandlerErrorType.BadRequest,
+                    $"Unsupported token type: {token.Type}"),
+            };
+
+            Task CancelWorkflowUpdateFromTokenAsync()
             {
                 // Decode via the update-workflow handle so a malformed token (e.g. missing workflow
                 // ID or update ID) is rejected as a bad request rather than passing empty strings
@@ -144,16 +157,6 @@ namespace Temporalio.Nexus
                     new CancelWorkflowUpdateInput(
                         updateHandle.WorkflowId, updateHandle.RunId, updateHandle.UpdateId));
             }
-            return token.Type switch
-            {
-                NexusWorkflowRunHandle.WorkflowRunOperationTokenType =>
-                    CancelWorkflowRunAsync(
-                        new TemporalOperationCancelContext(context),
-                        new CancelWorkflowRunInput(token.WorkflowId)),
-                _ => throw new HandlerException(
-                    HandlerErrorType.BadRequest,
-                    $"Unsupported token type: {token.Type}"),
-            };
         }
 
         /// <summary>

--- a/src/Temporalio/Nexus/TemporalOperationHandler.cs
+++ b/src/Temporalio/Nexus/TemporalOperationHandler.cs
@@ -125,6 +125,25 @@ namespace Temporalio.Nexus
             {
                 throw new HandlerException(HandlerErrorType.BadRequest, "Invalid namespace");
             }
+            if (token.Type == NexusWorkflowRunHandle.UpdateWorkflowOperationTokenType)
+            {
+                // Decode via the update-workflow handle so a malformed token (e.g. missing workflow
+                // ID or update ID) is rejected as a bad request rather than passing empty strings
+                // through to a user-supplied cancel override.
+                NexusWorkflowUpdateHandle updateHandle;
+                try
+                {
+                    updateHandle = NexusWorkflowUpdateHandle.FromToken(context.OperationToken);
+                }
+                catch (ArgumentException e)
+                {
+                    throw new HandlerException(HandlerErrorType.BadRequest, e.Message);
+                }
+                return CancelWorkflowUpdateAsync(
+                    new TemporalOperationCancelContext(context),
+                    new CancelWorkflowUpdateInput(
+                        updateHandle.WorkflowId, updateHandle.RunId, updateHandle.UpdateId));
+            }
             return token.Type switch
             {
                 NexusWorkflowRunHandle.WorkflowRunOperationTokenType =>
@@ -149,6 +168,20 @@ namespace Temporalio.Nexus
             TemporalOperationCancelContext context, CancelWorkflowRunInput input) =>
             NexusOperationExecutionContext.Current.TemporalClient
                 .GetWorkflowHandle(input.WorkflowId).CancelAsync();
+
+        /// <summary>
+        /// Called when a cancel request is received for an update-workflow token. Override to
+        /// customize cancel behavior.
+        /// <para>Default behavior: throws a not-implemented handler error, as there is no default
+        /// way to cancel an update-workflow operation.</para>
+        /// </summary>
+        /// <param name="context">The cancel context.</param>
+        /// <param name="input">Update-workflow cancel input.</param>
+        /// <returns>Task for cancel completion.</returns>
+        protected virtual Task CancelWorkflowUpdateAsync(
+            TemporalOperationCancelContext context, CancelWorkflowUpdateInput input) =>
+            throw new HandlerException(
+                HandlerErrorType.NotImplemented, "cannot cancel an UpdateWorkflow operation");
     }
 
     /// <summary>
@@ -168,6 +201,42 @@ namespace Temporalio.Nexus
         /// Gets the workflow ID extracted from the operation token.
         /// </summary>
         public string WorkflowId { get; }
+    }
+
+    /// <summary>
+    /// Input passed to
+    /// <see cref="TemporalOperationHandler{TInput, TResult}.CancelWorkflowUpdateAsync"/>.
+    /// </summary>
+    /// <remarks>WARNING: Nexus support is experimental.</remarks>
+    public class CancelWorkflowUpdateInput
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CancelWorkflowUpdateInput"/> class.
+        /// </summary>
+        /// <param name="workflowId">Workflow ID extracted from the operation token.</param>
+        /// <param name="runId">Workflow run ID extracted from the operation token. May be empty.</param>
+        /// <param name="updateId">Update ID extracted from the operation token.</param>
+        public CancelWorkflowUpdateInput(string workflowId, string runId, string updateId)
+        {
+            WorkflowId = workflowId;
+            RunId = runId;
+            UpdateId = updateId;
+        }
+
+        /// <summary>
+        /// Gets the workflow ID extracted from the operation token.
+        /// </summary>
+        public string WorkflowId { get; }
+
+        /// <summary>
+        /// Gets the workflow run ID extracted from the operation token. May be empty.
+        /// </summary>
+        public string RunId { get; }
+
+        /// <summary>
+        /// Gets the update ID extracted from the operation token.
+        /// </summary>
+        public string UpdateId { get; }
     }
 
     /// <summary>

--- a/src/Temporalio/Nexus/TemporalOperationHandler.cs
+++ b/src/Temporalio/Nexus/TemporalOperationHandler.cs
@@ -229,7 +229,7 @@ namespace Temporalio.Nexus
         public string WorkflowId { get; }
 
         /// <summary>
-        /// Gets the workflow run ID extracted from the operation token. May be empty.
+        /// Gets the workflow run ID extracted from the operation token.
         /// </summary>
         public string RunId { get; }
 

--- a/tests/Temporalio.Tests/Nexus/NexusOperationHandlerTests.cs
+++ b/tests/Temporalio.Tests/Nexus/NexusOperationHandlerTests.cs
@@ -1,0 +1,165 @@
+namespace Temporalio.Tests.Nexus;
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using NexusRpc;
+using NexusRpc.Handlers;
+using Temporalio.Client;
+using Temporalio.Common;
+using Temporalio.Nexus;
+using Xunit;
+
+/// <summary>
+/// Server-independent unit tests for the generic Temporal Nexus operation handler: cancel routing
+/// and validation, plus the start-time guards that fail fast before any server call.
+/// </summary>
+public class NexusOperationHandlerTests
+{
+    [Fact]
+    public async Task CancelAsync_UpdateToken_DefaultThrowsNotImplemented()
+    {
+        var token = new NexusWorkflowUpdateHandle("my-ns", "wid", "rid", "uid", 0).ToToken();
+        var handler = new TemporalOperationHandler<int, int>(
+            (_, _, _) => throw new InvalidOperationException("start not expected"));
+
+        var exc = await RunCancelAsync(handler, token);
+        var handlerExc = Assert.IsType<HandlerException>(exc);
+        Assert.Equal(HandlerErrorType.NotImplemented, handlerExc.ErrorType);
+        Assert.Contains("cannot cancel an UpdateWorkflow operation", handlerExc.Message);
+    }
+
+    [Fact]
+    public async Task CancelAsync_UpdateToken_CustomOverrideInvoked()
+    {
+        var token =
+            new NexusWorkflowUpdateHandle("my-ns", "the-wid", "the-rid", "the-uid", 0).ToToken();
+        var handler = new RecordingHandler();
+
+        var exc = await RunCancelAsync(handler, token);
+        Assert.Null(exc);
+        Assert.Null(handler.RunInput);
+        Assert.NotNull(handler.UpdateInput);
+        Assert.Equal("the-wid", handler.UpdateInput!.WorkflowId);
+        Assert.Equal("the-rid", handler.UpdateInput.RunId);
+        Assert.Equal("the-uid", handler.UpdateInput.UpdateId);
+    }
+
+    [Fact]
+    public async Task CancelAsync_WorkflowRunToken_RoutesToRunCancel()
+    {
+        var token = new NexusWorkflowRunHandle("my-ns", "run-wid", 0).ToToken();
+        var handler = new RecordingHandler();
+
+        var exc = await RunCancelAsync(handler, token);
+        Assert.Null(exc);
+        Assert.Null(handler.UpdateInput);
+        Assert.NotNull(handler.RunInput);
+        Assert.Equal("run-wid", handler.RunInput!.WorkflowId);
+    }
+
+    [Fact]
+    public async Task CancelAsync_MalformedUpdateToken_ThrowsBadRequest()
+    {
+        // Update-type token (t=3) missing the update ID (uid): must be rejected as a bad request
+        // before reaching the cancel override, rather than passing an empty update ID through.
+        var json = """{"t":3,"ns":"my-ns","wid":"w"}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+        var handler = new RecordingHandler();
+
+        var exc = await RunCancelAsync(handler, token);
+        var handlerExc = Assert.IsType<HandlerException>(exc);
+        Assert.Equal(HandlerErrorType.BadRequest, handlerExc.ErrorType);
+        Assert.Null(handler.UpdateInput);
+    }
+
+    [Fact]
+    public async Task StartUpdateWorkflowAsync_WrongWaitStage_FailsOperation()
+    {
+        // A wait stage other than Accepted surfaces as a failed operation (retryable at the
+        // caller's discretion), not a handler bad request.
+        var exc = await Assert.ThrowsAsync<OperationException>(() =>
+            NexusWorkflowStartHelper.StartUpdateWorkflowAsync<int>(
+                new OperationStartContext("svc", "op", default, "req-1"),
+                MakeExecContext("my-ns"),
+                "wid",
+                "upd",
+                new object?[] { 5 },
+                new WorkflowUpdateStartOptions(WorkflowUpdateStage.Completed)));
+        Assert.Equal(OperationState.Failed, exc.State);
+    }
+
+    [Fact]
+    public async Task StartUpdateWorkflowAsync_MissingCallbackUrl_ThrowsBadRequest()
+    {
+        // Without a callback URL the async update completion cannot be delivered, so start fails
+        // fast as a handler bad request (the OperationStartContext has no callback URL by default).
+        var exc = await Assert.ThrowsAsync<HandlerException>(() =>
+            NexusWorkflowStartHelper.StartUpdateWorkflowAsync<int>(
+                new OperationStartContext("svc", "op", default, "req-1"),
+                MakeExecContext("my-ns"),
+                "wid",
+                "upd",
+                new object?[] { 5 },
+                new WorkflowUpdateStartOptions(WorkflowUpdateStage.Accepted)));
+        Assert.Equal(HandlerErrorType.BadRequest, exc.ErrorType);
+    }
+
+    private static NexusOperationExecutionContext MakeExecContext(string ns) =>
+        new(
+            handlerContext: new OperationStartContext("svc", "op", default, "req"),
+            info: new NexusOperationInfo(ns, "my-tq", "my-endpoint"),
+            logger: NullLogger.Instance,
+            runtimeMetricMeter: new Lazy<MetricMeter>(
+                () => throw new InvalidOperationException("metric meter not needed")),
+            temporalClient: null);
+
+    private static async Task<Exception?> RunCancelAsync(
+        IOperationHandler<int, int> handler, string token)
+    {
+        var prev = NexusOperationExecutionContext.AsyncLocalCurrent.Value;
+        NexusOperationExecutionContext.AsyncLocalCurrent.Value = MakeExecContext("my-ns");
+        try
+        {
+            await handler.CancelAsync(new OperationCancelContext("svc", "op", default, token));
+            return null;
+        }
+#pragma warning disable CA1031 // Tests deliberately capture any exception to assert on it
+        catch (Exception e)
+#pragma warning restore CA1031
+        {
+            return e;
+        }
+        finally
+        {
+            NexusOperationExecutionContext.AsyncLocalCurrent.Value = prev;
+        }
+    }
+
+    private sealed class RecordingHandler : TemporalOperationHandler<int, int>
+    {
+        public RecordingHandler()
+            : base((_, _, _) => throw new InvalidOperationException("start not expected"))
+        {
+        }
+
+        public CancelWorkflowRunInput? RunInput { get; private set; }
+
+        public CancelWorkflowUpdateInput? UpdateInput { get; private set; }
+
+        protected override Task CancelWorkflowRunAsync(
+            TemporalOperationCancelContext context, CancelWorkflowRunInput input)
+        {
+            RunInput = input;
+            return Task.CompletedTask;
+        }
+
+        protected override Task CancelWorkflowUpdateAsync(
+            TemporalOperationCancelContext context, CancelWorkflowUpdateInput input)
+        {
+            UpdateInput = input;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Temporalio.Tests/Nexus/NexusOperationHandlerTests.cs
+++ b/tests/Temporalio.Tests/Nexus/NexusOperationHandlerTests.cs
@@ -75,12 +75,12 @@ public class NexusOperationHandlerTests
     }
 
     [Fact]
-    public async Task StartUpdateWorkflowAsync_WrongWaitStage_FailsOperation()
+    public async Task StartWorkflowUpdateAsync_WrongWaitStage_FailsOperation()
     {
         // A wait stage other than Accepted surfaces as a failed operation (retryable at the
         // caller's discretion), not a handler bad request.
         var exc = await Assert.ThrowsAsync<OperationException>(() =>
-            NexusWorkflowStartHelper.StartUpdateWorkflowAsync<int>(
+            NexusWorkflowStartHelper.StartWorkflowUpdateAsync<int>(
                 new OperationStartContext("svc", "op", default, "req-1"),
                 MakeExecContext("my-ns"),
                 "wid",
@@ -91,12 +91,12 @@ public class NexusOperationHandlerTests
     }
 
     [Fact]
-    public async Task StartUpdateWorkflowAsync_MissingCallbackUrl_ThrowsBadRequest()
+    public async Task StartWorkflowUpdateAsync_MissingCallbackUrl_ThrowsBadRequest()
     {
         // Without a callback URL the async update completion cannot be delivered, so start fails
         // fast as a handler bad request (the OperationStartContext has no callback URL by default).
         var exc = await Assert.ThrowsAsync<HandlerException>(() =>
-            NexusWorkflowStartHelper.StartUpdateWorkflowAsync<int>(
+            NexusWorkflowStartHelper.StartWorkflowUpdateAsync<int>(
                 new OperationStartContext("svc", "op", default, "req-1"),
                 MakeExecContext("my-ns"),
                 "wid",

--- a/tests/Temporalio.Tests/Nexus/NexusWorkflowUpdateHandleTests.cs
+++ b/tests/Temporalio.Tests/Nexus/NexusWorkflowUpdateHandleTests.cs
@@ -1,0 +1,275 @@
+namespace Temporalio.Tests.Nexus;
+
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Temporalio.Api.Common.V1;
+using Temporalio.Nexus;
+using Xunit;
+
+public class NexusWorkflowUpdateHandleTests
+{
+    [Fact]
+    public void ToToken_RoundTrips()
+    {
+        var handle = new NexusWorkflowUpdateHandle("my-ns", "my-wf", "my-run", "my-update", 0);
+        var token = handle.ToToken();
+        var decoded = NexusWorkflowUpdateHandle.FromToken(token);
+
+        Assert.Equal("my-ns", decoded.Namespace);
+        Assert.Equal("my-wf", decoded.WorkflowId);
+        Assert.Equal("my-run", decoded.RunId);
+        Assert.Equal("my-update", decoded.UpdateId);
+        Assert.Equal(0, decoded.Version);
+    }
+
+    [Fact]
+    public void ToToken_UsesBase64Url_NoPadding()
+    {
+        var token = new NexusWorkflowUpdateHandle("my-ns", "my-wf", "my-run", "my-update", 0).ToToken();
+
+        Assert.DoesNotContain("+", token);
+        Assert.DoesNotContain("/", token);
+        Assert.DoesNotContain("=", token);
+    }
+
+    [Fact]
+    public void ToToken_JsonUsesCorrectKeys()
+    {
+        var token = new NexusWorkflowUpdateHandle("ns", "wid", "rid", "uid", 0).ToToken();
+        var json = Encoding.UTF8.GetString(NexusWorkflowRunHandle.Base64UrlDecode(token));
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal(
+            NexusWorkflowRunHandle.UpdateWorkflowOperationTokenType,
+            root.GetProperty("t").GetInt32());
+        Assert.Equal("ns", root.GetProperty("ns").GetString());
+        Assert.Equal("wid", root.GetProperty("wid").GetString());
+        Assert.Equal("rid", root.GetProperty("rid").GetString());
+        Assert.Equal("uid", root.GetProperty("uid").GetString());
+        // Version must be omitted when zero.
+        Assert.False(root.TryGetProperty("v", out _));
+        // rid must precede uid in the serialized form.
+        var order = string.Join(",", root.EnumerateObject().Select(p => p.Name));
+        Assert.Equal("ns,wid,t,rid,uid", order);
+    }
+
+    [Fact]
+    public void ToToken_EmptyRunId_OmitsRid()
+    {
+        // Run ID is optional; an empty run ID must be omitted entirely rather than emitted as
+        // "rid":"" (matching the Nexus operation token format spec).
+        var token = new NexusWorkflowUpdateHandle("ns", "wid", string.Empty, "uid", 0).ToToken();
+        var json = Encoding.UTF8.GetString(NexusWorkflowRunHandle.Base64UrlDecode(token));
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.TryGetProperty("rid", out _));
+    }
+
+    [Fact]
+    public void FromToken_DecodesGoWireFormat()
+    {
+        // A token as it would be encoded by another SDK (field names t/ns/wid/rid/uid).
+        var json = """{"t":3,"ns":"ns","wid":"w","rid":"r","uid":"u"}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+
+        var handle = NexusWorkflowUpdateHandle.FromToken(token);
+
+        Assert.Equal("ns", handle.Namespace);
+        Assert.Equal("w", handle.WorkflowId);
+        Assert.Equal("r", handle.RunId);
+        Assert.Equal("u", handle.UpdateId);
+    }
+
+    [Fact]
+    public void FromToken_RejectsWrongTokenType()
+    {
+        // Workflow-run token type (1) is not a valid update-workflow token.
+        var json = """{"t":1,"ns":"ns","wid":"w"}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+        Assert.Throws<System.ArgumentException>(() => NexusWorkflowUpdateHandle.FromToken(token));
+    }
+
+    [Fact]
+    public void FromToken_RejectsMissingNamespace()
+    {
+        var json = """{"t":3,"wid":"w","uid":"u"}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+        Assert.Throws<System.ArgumentException>(() => NexusWorkflowUpdateHandle.FromToken(token));
+    }
+
+    [Fact]
+    public void FromToken_RejectsMissingWorkflowId()
+    {
+        var json = """{"t":3,"ns":"ns","uid":"u"}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+        Assert.Throws<System.ArgumentException>(() => NexusWorkflowUpdateHandle.FromToken(token));
+    }
+
+    [Fact]
+    public void FromToken_RejectsMissingUpdateId()
+    {
+        var json = """{"t":3,"ns":"ns","wid":"w"}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+        Assert.Throws<System.ArgumentException>(() => NexusWorkflowUpdateHandle.FromToken(token));
+    }
+
+    [Fact]
+    public void FromToken_RejectsUnsupportedVersion()
+    {
+        var json = """{"t":3,"ns":"ns","wid":"w","rid":"r","uid":"u","v":1}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+        Assert.Throws<System.ArgumentException>(() => NexusWorkflowUpdateHandle.FromToken(token));
+    }
+
+    [Fact]
+    public void ToToken_SpecialCharactersInValues_RoundTrip()
+    {
+        var handle = new NexusWorkflowUpdateHandle(
+            "ns/with+special", "wf?id=1&foo=bar", "run+/id", "upd id", 0);
+        var decoded = NexusWorkflowUpdateHandle.FromToken(handle.ToToken());
+
+        Assert.Equal("ns/with+special", decoded.Namespace);
+        Assert.Equal("wf?id=1&foo=bar", decoded.WorkflowId);
+        Assert.Equal("run+/id", decoded.RunId);
+        Assert.Equal("upd id", decoded.UpdateId);
+    }
+
+    [Fact]
+    public void WorkflowRunToken_OmitsUpdateFields()
+    {
+        // Regression: the workflow-run token must not gain rid/uid fields.
+        var token = new NexusWorkflowRunHandle("ns", "wid", 0).ToToken();
+        var json = Encoding.UTF8.GetString(NexusWorkflowRunHandle.Base64UrlDecode(token));
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.TryGetProperty("rid", out _));
+        Assert.False(doc.RootElement.TryGetProperty("uid", out _));
+    }
+
+    [Theory]
+    [InlineData("", "wid", "uid")]
+    [InlineData("ns", "", "uid")]
+    [InlineData("ns", "wid", "")]
+    public void ToToken_EmptyRequiredField_Throws(string ns, string wid, string uid)
+    {
+        // An empty namespace/workflow-ID/update-ID would produce a token that breaks server-side
+        // dedup, so token generation must reject it (matching the Go/TS token generators).
+        var handle = new NexusWorkflowUpdateHandle(ns, wid, "rid", uid, 0);
+        Assert.Throws<System.ArgumentException>(() => handle.ToToken());
+    }
+
+    [Fact]
+    public void ToToken_EmptyRunId_IsAllowed()
+    {
+        // Run ID is optional; only namespace/workflow-ID/update-ID are required.
+        var token = new NexusWorkflowUpdateHandle("ns", "wid", string.Empty, "uid", 0).ToToken();
+        Assert.NotEmpty(token);
+    }
+
+    [Fact]
+    public void ToToken_WithRunId_EmitsRidAndRoundTrips()
+    {
+        var token = new NexusWorkflowUpdateHandle("ns", "wid", "my-run", "uid", 0).ToToken();
+        var json = Encoding.UTF8.GetString(NexusWorkflowRunHandle.Base64UrlDecode(token));
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.True(doc.RootElement.TryGetProperty("rid", out var rid));
+        Assert.Equal("my-run", rid.GetString());
+
+        var decoded = NexusWorkflowUpdateHandle.FromToken(token);
+        Assert.Equal("my-run", decoded.RunId);
+    }
+
+    [Fact]
+    public void FromToken_ToleratesLegacyEmptyRid()
+    {
+        // A legacy token that still carries rid:"" must decode to an empty run ID.
+        var json = """{"t":3,"ns":"ns","wid":"w","rid":"","uid":"u"}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+
+        var handle = NexusWorkflowUpdateHandle.FromToken(token);
+
+        Assert.Equal(string.Empty, handle.RunId);
+        Assert.Equal("u", handle.UpdateId);
+    }
+
+    [Fact]
+    public void FromToken_ToleratesAbsentRid()
+    {
+        // A token that omits rid entirely must decode to an empty run ID.
+        var json = """{"t":3,"ns":"ns","wid":"w","uid":"u"}""";
+        var token = NexusWorkflowRunHandle.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+
+        var handle = NexusWorkflowUpdateHandle.FromToken(token);
+
+        Assert.Equal(string.Empty, handle.RunId);
+        Assert.Equal("u", handle.UpdateId);
+    }
+
+    [Fact]
+    public void CommonLink_ToNexusLink_UnsetOneof_ReturnsNull()
+    {
+        // A link whose oneof is unset (neither workflow-event nor workflow) must not dereference a
+        // null variant; it returns null so callers can skip it.
+        var link = new Link().ToNexusLink();
+
+        Assert.Null(link);
+    }
+
+    [Fact]
+    public void WorkflowLink_ToNexusLink_BuildsHistoryUri()
+    {
+        var workflow = new Link.Types.Workflow
+        {
+            Namespace = "ns",
+            WorkflowId = "wid",
+            RunId = "rid",
+        };
+        var link = workflow.ToNexusLink();
+
+        Assert.Equal("temporal", link.Uri.Scheme);
+        Assert.Equal("/namespaces/ns/workflows/wid/rid/history", link.Uri.AbsolutePath);
+        Assert.Equal(Link.Types.Workflow.Descriptor.FullName, link.Type);
+    }
+
+    [Fact]
+    public void CommonLink_ToNexusLink_PrefersWorkflowEvent()
+    {
+        var common = new Link
+        {
+            WorkflowEvent = new()
+            {
+                Namespace = "ns",
+                WorkflowId = "wid",
+                RunId = "rid",
+                EventRef = new() { EventId = 1 },
+            },
+        };
+        var link = common.ToNexusLink();
+
+        Assert.NotNull(link);
+        Assert.Equal(Link.Types.WorkflowEvent.Descriptor.FullName, link.Type);
+    }
+
+    [Fact]
+    public void CommonLink_ToNexusLink_FallsBackToWorkflow()
+    {
+        // No history event (e.g. a rejected update) — falls back to the workflow link.
+        var common = new Link
+        {
+            Workflow = new()
+            {
+                Namespace = "ns",
+                WorkflowId = "wid",
+                RunId = "rid",
+            },
+        };
+        var link = common.ToNexusLink();
+
+        Assert.NotNull(link);
+        Assert.Equal(Link.Types.Workflow.Descriptor.FullName, link.Type);
+        Assert.Equal("/namespaces/ns/workflows/wid/rid/history", link.Uri.AbsolutePath);
+    }
+}

--- a/tests/Temporalio.Tests/Nexus/ProtoLinkExtensionsTests.cs
+++ b/tests/Temporalio.Tests/Nexus/ProtoLinkExtensionsTests.cs
@@ -115,6 +115,7 @@ public class ProtoLinkExtensionsTests
             NexusOperation = new() { Namespace = "ns", OperationId = "op", RunId = "run" },
         };
         var nexusLink = protoLink.ToNexusLink();
+        Assert.NotNull(nexusLink);
         Assert.Equal(
             Api.Common.V1.Link.Types.NexusOperation.Descriptor.FullName,
             nexusLink.Type);
@@ -135,6 +136,7 @@ public class ProtoLinkExtensionsTests
             },
         };
         var nexusLink = protoLink.ToNexusLink();
+        Assert.NotNull(nexusLink);
         Assert.Equal(
             Api.Common.V1.Link.Types.WorkflowEvent.Descriptor.FullName,
             nexusLink.Type);
@@ -142,9 +144,11 @@ public class ProtoLinkExtensionsTests
     }
 
     [Fact]
-    public void ProtoToNexusLink_RejectsUnsetVariant()
+    public void ProtoToNexusLink_UnsetVariant_ReturnsNull()
     {
-        Assert.Throws<ArgumentException>(() => new Api.Common.V1.Link().ToNexusLink());
+        // An unset link variant (e.g. a rejected update with no history event) converts to null so
+        // callers can skip it rather than failing the operation.
+        Assert.Null(new Api.Common.V1.Link().ToNexusLink());
     }
 
     [Fact]

--- a/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
@@ -1,0 +1,313 @@
+namespace Temporalio.Tests.Worker;
+
+using NexusRpc;
+using NexusRpc.Handlers;
+using Temporalio.Api.Enums.V1;
+using Temporalio.Client;
+using Temporalio.Exceptions;
+using Temporalio.Nexus;
+using Temporalio.Worker;
+using Temporalio.Workflows;
+using Xunit;
+using Xunit.Abstractions;
+
+/// <summary>
+/// End-to-end scaffold for UpdateWorkflow-backed Nexus operations, encoding the reviewer scenario
+/// punch-list from the feature's design.
+/// <para>
+/// Every test here is gated on <see cref="WorkflowEnvironment.SupportsNexusUpdateCallbacks"/> and is
+/// skipped unless the environment can deliver update-completion callbacks
+/// (<c>history.enableUpdateCallbacks</c> plus a Nexus callback-endpoint template). The pinned local
+/// dev server does not support these yet, so these tests are ALL currently blocked purely on that
+/// server-capability gap. When the dev server is upgraded and the flags are added in
+/// <see cref="WorkflowEnvironment"/>, the gate flips and these tests auto-run — no code change here
+/// required.
+/// </para>
+/// </summary>
+public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
+{
+    public NexusUpdateOperationTests(ITestOutputHelper output, WorkflowEnvironment env)
+        : base(output, env)
+    {
+    }
+
+    [NexusService]
+    public interface ICounterService
+    {
+        [NexusOperation]
+        int Add(AddInput input);
+
+        // Uses the by-name StartUpdateWorkflowAsync overload with an update name that is not
+        // registered on the target workflow.
+        [NexusOperation]
+        int AddUnregistered(AddInput input);
+    }
+
+    /// <summary>Backs each operation with a workflow update via the generic Temporal handler.</summary>
+    [NexusServiceHandler(typeof(ICounterService))]
+    public class CounterServiceHandler
+    {
+        [NexusOperationHandler]
+        public IOperationHandler<AddInput, int> Add() =>
+            TemporalOperationHandler.FromHandleFactory<AddInput, int>(
+                (context, client, input) =>
+                    client.StartUpdateWorkflowAsync<CounterWorkflow, int>(
+                        input.WorkflowId,
+                        wf => wf.AddAsync(input.Amount),
+                        new(WorkflowUpdateStage.Accepted) { Id = input.UpdateId }));
+
+        [NexusOperationHandler]
+        public IOperationHandler<AddInput, int> AddUnregistered() =>
+            TemporalOperationHandler.FromHandleFactory<AddInput, int>(
+                (context, client, input) =>
+                    client.StartUpdateWorkflowAsync<int>(
+                        input.WorkflowId,
+                        "NoSuchUpdateHandler",
+                        new object?[] { input.Amount },
+                        new(WorkflowUpdateStage.Accepted) { Id = input.UpdateId }));
+    }
+
+    /// <summary>Counter workflow with an update handler and a validator.</summary>
+    [Workflow]
+    public class CounterWorkflow
+    {
+        private int counter;
+        private bool done;
+
+        [WorkflowRun]
+        public async Task<int> RunAsync()
+        {
+            await Workflow.WaitConditionAsync(() => done);
+            return counter;
+        }
+
+        [WorkflowUpdate]
+        public async Task<int> AddAsync(int amount)
+        {
+            // A negative amount passes the validator (divisible by 5) but fails in the handler; used
+            // to exercise the "handler returns an error" path.
+            if (amount < 0)
+            {
+                throw new ApplicationFailureException("negative amount not allowed");
+            }
+            counter += amount;
+            return counter;
+        }
+
+        [WorkflowUpdateValidator(nameof(AddAsync))]
+        public void ValidateAdd(int amount)
+        {
+            if (amount % 5 != 0)
+            {
+                throw new ApplicationFailureException("invalid increment");
+            }
+        }
+
+        [WorkflowSignal]
+        public async Task DoneAsync() => done = true;
+    }
+
+    /// <summary>Caller workflow that invokes the Nexus operation, so forward/back links are formed.</summary>
+    [Workflow]
+    public class CounterCallerWorkflow
+    {
+        [WorkflowRun]
+        public async Task<int> RunAsync(CallerInput input)
+        {
+            var client = Workflow.CreateNexusWorkflowClient<ICounterService>(input.Endpoint);
+            return input.UseUnregistered
+                ? await client.ExecuteNexusOperationAsync(svc => svc.AddUnregistered(input.Add))
+                : await client.ExecuteNexusOperationAsync(svc => svc.Add(input.Add));
+        }
+    }
+
+    public record AddInput(string WorkflowId, int Amount, string? UpdateId = null);
+
+    public record CallerInput(string Endpoint, AddInput Add, bool UseUnregistered = false);
+
+    [SkippableFact]
+    public async Task UpdateOperation_ValidUpdate_SucceedsWithLinks()
+    {
+        // Punch-list: async op happy path with forward + back links asserted.
+        SkipIfUpdateCallbacksUnsupported();
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            var caller = await RunCallerAsync(
+                taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "valid-update"));
+            Assert.Equal(5, await caller.GetResultAsync<int>());
+
+            // Forward link: caller workflow's Nexus scheduled event references the operation.
+            var callerScheduled = Assert.Single(
+                (await caller.FetchHistoryAsync()).Events,
+                e => e.EventType == EventType.NexusOperationScheduled);
+            Assert.NotEmpty(callerScheduled.Links);
+
+            // Back link: handler workflow's update-accepted event points back to the caller.
+            var counterEvents = (await counter.FetchHistoryAsync()).Events;
+            Assert.Contains(
+                counterEvents,
+                e => e.EventType == EventType.WorkflowExecutionUpdateAccepted &&
+                    e.Links.Count > 0);
+        });
+    }
+
+    [SkippableFact]
+    public async Task UpdateOperation_UnregisteredUpdateHandler_Fails()
+    {
+        // Punch-list: unregistered update handler.
+        SkipIfUpdateCallbacksUnsupported();
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            var caller = await RunCallerAsync(
+                taskQueue,
+                endpoint,
+                new(counter.Id, Amount: 5),
+                useUnregistered: true);
+            await Assert.ThrowsAsync<WorkflowFailedException>(() => caller.GetResultAsync<int>());
+        });
+    }
+
+    [SkippableFact]
+    public async Task UpdateOperation_ValidatorRejects_FailsNonRetryable()
+    {
+        // Punch-list: validator rejects the update (non-retryable -> failed operation).
+        SkipIfUpdateCallbacksUnsupported();
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            var caller = await RunCallerAsync(
+                taskQueue, endpoint, new(counter.Id, Amount: 6, UpdateId: "rejected-update"));
+            var exc = await Assert.ThrowsAsync<WorkflowFailedException>(
+                () => caller.GetResultAsync<int>());
+            Assert.IsType<NexusOperationFailureException>(exc.InnerException);
+        });
+    }
+
+    [SkippableFact]
+    public async Task UpdateOperation_HandlerReturnsError_Fails()
+    {
+        // Punch-list: handler returns an error (passes validation, fails in the handler body).
+        SkipIfUpdateCallbacksUnsupported();
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            var caller = await RunCallerAsync(
+                taskQueue, endpoint, new(counter.Id, Amount: -5, UpdateId: "handler-error"));
+            await Assert.ThrowsAsync<WorkflowFailedException>(() => caller.GetResultAsync<int>());
+        });
+    }
+
+    [SkippableFact]
+    public async Task UpdateOperation_ImmediateHandler_IsStillAsync()
+    {
+        // Punch-list: sync/immediately-completing handler. Per NEXUS-489, immediate returns are
+        // still async because the operation only waits for the Accepted stage, not completion.
+        SkipIfUpdateCallbacksUnsupported();
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            var caller = await RunCallerAsync(
+                taskQueue, endpoint, new(counter.Id, Amount: 5));
+            Assert.Equal(5, await caller.GetResultAsync<int>());
+
+            // The operation was scheduled/started asynchronously (has a scheduled event) rather than
+            // completing synchronously inline.
+            Assert.Contains(
+                (await caller.FetchHistoryAsync()).Events,
+                e => e.EventType == EventType.NexusOperationScheduled);
+        });
+    }
+
+    [SkippableFact]
+    public async Task UpdateOperation_ReusedUpdateId_IsIdempotentAndSync()
+    {
+        // Punch-list: reused UpdateID against an already-completed update returns a sync result and
+        // does not re-apply the update.
+        SkipIfUpdateCallbacksUnsupported();
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            var first = await RunCallerAsync(
+                taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "reused-id"));
+            Assert.Equal(5, await first.GetResultAsync<int>());
+
+            // Same update ID: the counter must not increment again.
+            var second = await RunCallerAsync(
+                taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "reused-id"));
+            Assert.Equal(5, await second.GetResultAsync<int>());
+        });
+    }
+
+    [SkippableFact]
+    public async Task UpdateOperation_NoWorkerOnTargetQueue_DoesNotFail()
+    {
+        // Punch-list: no worker listening on the target workflow's task queue — the operation must
+        // NOT fail (the update is admitted and stays pending until a worker handles it).
+        SkipIfUpdateCallbacksUnsupported();
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            // Target a workflow on a task queue with no worker polling it.
+            var idleTaskQueue = $"tq-idle-{Guid.NewGuid()}";
+            var pending = await Client.StartWorkflowAsync(
+                (CounterWorkflow wf) => wf.RunAsync(),
+                new($"counter-idle-{Guid.NewGuid()}", idleTaskQueue));
+
+            var caller = await RunCallerAsync(
+                taskQueue, endpoint, new(pending.Id, Amount: 5));
+
+            // The Nexus operation should remain pending (started, not failed) for a short window.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+            var desc = await caller.DescribeAsync();
+            Assert.NotEqual(WorkflowExecutionStatus.Failed, desc.Status);
+        });
+    }
+
+    private void SkipIfUpdateCallbacksUnsupported()
+    {
+        if (!Env.SupportsNexusUpdateCallbacks)
+        {
+            throw new SkipException(
+                "Environment does not support UpdateWorkflow-backed Nexus operations. Requires the " +
+                "dev server to deliver update-completion callbacks (history.enableUpdateCallbacks) " +
+                "with a Nexus callback-endpoint template; the pinned dev server " +
+                "(v1.7.1-standalone-nexus-operations) does not yet support these. Set " +
+                "TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS=true when pointing at a capable server.");
+        }
+    }
+
+    private async Task RunWithCounterAsync(
+        Func<string, string, WorkflowHandle<CounterWorkflow, int>, Task> body)
+    {
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var workerOptions = new TemporalWorkerOptions(taskQueue).
+            AddNexusService(new CounterServiceHandler()).
+            AddWorkflow<CounterWorkflow>().
+            AddWorkflow<CounterCallerWorkflow>();
+        var endpointName = $"nexus-endpoint-{taskQueue}";
+        await Env.TestEnv.CreateNexusEndpointAsync(endpointName, taskQueue);
+
+        using var worker = new TemporalWorker(Client, workerOptions);
+        await worker.ExecuteAsync(async () =>
+        {
+            var counter = await Client.StartWorkflowAsync(
+                (CounterWorkflow wf) => wf.RunAsync(),
+                new($"counter-{Guid.NewGuid()}", taskQueue));
+            try
+            {
+                await body(endpointName, taskQueue, counter);
+            }
+            finally
+            {
+                await counter.SignalAsync(wf => wf.DoneAsync());
+            }
+        });
+    }
+
+    private async Task<WorkflowHandle<CounterCallerWorkflow, int>> RunCallerAsync(
+        string taskQueue,
+        string endpoint,
+        AddInput add,
+        bool useUnregistered = false)
+    {
+        var handle = await Client.StartWorkflowAsync(
+            (CounterCallerWorkflow wf) => wf.RunAsync(new(endpoint, add, useUnregistered)),
+            new($"caller-{Guid.NewGuid()}", taskQueue));
+        return handle;
+    }
+}

--- a/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
@@ -15,13 +15,12 @@ using Xunit.Abstractions;
 /// End-to-end scaffold for UpdateWorkflow-backed Nexus operations, encoding the reviewer scenario
 /// punch-list from the feature's design.
 /// <para>
-/// Every test here is gated on <see cref="WorkflowEnvironment.SupportsNexusUpdateCallbacks"/> and is
-/// skipped unless the environment can deliver update-completion callbacks
+/// Every test here is gated on the <c>TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS</c> environment variable
+/// and is skipped unless the environment can deliver update-completion callbacks
 /// (<c>history.enableUpdateCallbacks</c> plus a Nexus callback-endpoint template). The pinned local
 /// dev server does not support these yet, so these tests are ALL currently blocked purely on that
-/// server-capability gap. When the dev server is upgraded and the flags are added in
-/// <see cref="WorkflowEnvironment"/>, the gate flips and these tests auto-run — no code change here
-/// required.
+/// server-capability gap. Set <c>TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS=true</c> when pointing at a
+/// capable server to run them — no code change here required.
 /// </para>
 /// </summary>
 public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
@@ -260,13 +259,13 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
 
     private void SkipIfUpdateCallbacksUnsupported()
     {
-        if (!Env.SupportsNexusUpdateCallbacks)
+        if (System.Environment.GetEnvironmentVariable("TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS") != "true")
         {
             throw new SkipException(
                 "Environment does not support UpdateWorkflow-backed Nexus operations. Requires the " +
                 "dev server to deliver update-completion callbacks (history.enableUpdateCallbacks) " +
                 "with a Nexus callback-endpoint template; the pinned dev server " +
-                "(v1.7.1-standalone-nexus-operations) does not yet support these. Set " +
+                "(v1.7.2-standalone-nexus-operations) does not yet support these. Set " +
                 "TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS=true when pointing at a capable server.");
         }
     }

--- a/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
@@ -28,7 +28,7 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         [NexusOperation]
         int Add(AddInput input);
 
-        // Uses the by-name StartUpdateWorkflowAsync overload with an update name that is not
+        // Uses the by-name StartWorkflowUpdateAsync overload with an update name that is not
         // registered on the target workflow.
         [NexusOperation]
         int AddUnregistered(AddInput input);
@@ -42,16 +42,17 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         public IOperationHandler<AddInput, int> Add() =>
             TemporalOperationHandler.FromHandleFactory<AddInput, int>(
                 (context, client, input) =>
-                    client.StartUpdateWorkflowAsync<CounterWorkflow, int>(
+                    client.StartWorkflowUpdateAsync<CounterWorkflow, int>(
                         input.WorkflowId,
                         wf => wf.AddAsync(input.Amount),
-                        new(WorkflowUpdateStage.Accepted) { Id = input.UpdateId }));
+                        new(WorkflowUpdateStage.Accepted) { Id = input.UpdateId },
+                        input.RunId));
 
         [NexusOperationHandler]
         public IOperationHandler<AddInput, int> AddUnregistered() =>
             TemporalOperationHandler.FromHandleFactory<AddInput, int>(
                 (context, client, input) =>
-                    client.StartUpdateWorkflowAsync<int>(
+                    client.StartWorkflowUpdateAsync<int>(
                         input.WorkflowId,
                         "NoSuchUpdateHandler",
                         new object?[] { input.Amount },
@@ -64,6 +65,7 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
     {
         private int counter;
         private bool done;
+        private bool hold;
 
         [WorkflowRun]
         public async Task<int> RunAsync()
@@ -75,6 +77,11 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         [WorkflowUpdate]
         public async Task<int> AddAsync(int amount)
         {
+            // Optional gate to hold the update mid-flight: the update passes the validator and reaches
+            // Accepted, then blocks here before applying so the in-flight window is observable. Defaults
+            // to open (hold=false) so the other tests are unaffected.
+            await Workflow.WaitConditionAsync(() => !hold);
+
             // A negative amount passes the validator (divisible by 5) but fails in the handler; used
             // to exercise the "handler returns an error" path.
             if (amount < 0)
@@ -96,6 +103,9 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
 
         [WorkflowSignal]
         public async Task DoneAsync() => done = true;
+
+        [WorkflowSignal]
+        public async Task SetHoldAsync(bool value) => hold = value;
     }
 
     /// <summary>Caller workflow that invokes the Nexus operation, so forward/back links are formed.</summary>
@@ -112,7 +122,8 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         }
     }
 
-    public record AddInput(string WorkflowId, int Amount, string? UpdateId = null);
+    public record AddInput(
+        string WorkflowId, int Amount, string? UpdateId = null, string? RunId = null);
 
     public record CallerInput(string Endpoint, AddInput Add, bool UseUnregistered = false);
 
@@ -236,10 +247,83 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         });
     }
 
+    [Fact]
+    public async Task UpdateOperation_ReusedUpdateId_InFlight_DedupesOntoSameUpdate()
+    {
+        // Punch-list: reusing an UpdateID while the first update is still in-flight (accepted but not
+        // yet completed) must dedupe onto the same update rather than creating a second one. The
+        // update handler runs once, both operations resolve to the same result, and the target
+        // workflow records exactly one accepted update for that ID.
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            // Hold the update mid-flight: it passes validation and reaches Accepted, then blocks in
+            // the handler before applying. Signalled (and so recorded) before any operation is
+            // issued, so it is processed ahead of the first update — a deterministic in-flight window.
+            await counter.SignalAsync(wf => wf.SetHoldAsync(true));
+
+            // Op1: issue but do not await its result — its update blocks in the handler.
+            var first = await RunCallerAsync(
+                taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "shared"));
+
+            // Deterministically wait until op1's update has been accepted on the counter workflow
+            // (it is now blocked in the handler on the hold gate) before issuing op2 — no sleeps.
+            await AssertMore.HasEventEventuallyAsync(
+                counter, e => e.WorkflowExecutionUpdateAcceptedEventAttributes != null);
+
+            // Op2: same UpdateId while op1's update is still in-flight. It must dedupe onto the
+            // existing update instead of starting a new one.
+            var second = await RunCallerAsync(
+                taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "shared"));
+
+            // Release the gate so the single deduped update completes.
+            await counter.SignalAsync(wf => wf.SetHoldAsync(false));
+
+            // Both operations resolve to the same result, and the counter incremented exactly once
+            // (5, not 10) — proof the handler ran a single time despite two operations.
+            Assert.Equal(5, await first.GetResultAsync<int>());
+            Assert.Equal(5, await second.GetResultAsync<int>());
+
+            // The counter workflow recorded exactly one accepted update for the shared ID: no
+            // duplicate update was created by the second operation.
+            Assert.Single(
+                (await counter.FetchHistoryAsync()).Events,
+                e => e.WorkflowExecutionUpdateAcceptedEventAttributes != null);
+        });
+    }
+
+    [Fact]
+    public async Task UpdateOperation_ExplicitRunId_TokenCarriesRunId()
+    {
+        // Punch-list: an explicitly targeted run ID must flow into the update-workflow operation
+        // token (rid), proving run-ID targeting works end-to-end rather than always defaulting to
+        // the latest run.
+        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        {
+            var runId = counter.ResultRunId!;
+            var caller = await RunCallerAsync(
+                taskQueue,
+                endpoint,
+                new(counter.Id, Amount: 5, UpdateId: "runid-update", RunId: runId));
+            Assert.Equal(5, await caller.GetResultAsync<int>());
+
+            // Capture the operation token off the caller's NexusOperationStarted event (the async
+            // start marker) and decode it: the run ID (rid) must be the counter workflow's run.
+            var started = Assert.Single(
+                (await caller.FetchHistoryAsync()).Events,
+                e => e.EventType == EventType.NexusOperationStarted);
+            var token = started.NexusOperationStartedEventAttributes.OperationToken;
+            Assert.NotEmpty(token);
+            var handle = NexusWorkflowUpdateHandle.FromToken(token);
+            Assert.Equal(runId, handle.RunId);
+            Assert.Equal(counter.Id, handle.WorkflowId);
+            Assert.Equal("runid-update", handle.UpdateId);
+        });
+    }
+
     // Punch-list: no worker listening on the target workflow's task queue. The operation must NOT
     // fail while it is pending (the update is admitted but not yet accepted). Tearing the worker
     // down then drains cleanly because the operation's cancellation token is forwarded into the
-    // blocked update-start RPC (see NexusWorkflowStartHelper.StartUpdateWorkflowAsync), so worker
+    // blocked update-start RPC (see NexusWorkflowStartHelper.StartWorkflowUpdateAsync), so worker
     // shutdown does not wedge.
     [Fact]
     public async Task UpdateOperation_NoWorkerOnTargetQueue_DoesNotFail()

--- a/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
@@ -127,7 +127,7 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
                 taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "valid-update"));
             Assert.Equal(5, await caller.GetResultAsync<int>());
 
-            // Coverage: the operation was scheduled exactly once on the caller. 
+            // Coverage: the operation was scheduled exactly once on the caller.
             Assert.Single(
                 (await caller.FetchHistoryAsync()).Events,
                 e => e.EventType == EventType.NexusOperationScheduled);
@@ -205,10 +205,34 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
                 taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "reused-id"));
             Assert.Equal(5, await first.GetResultAsync<int>());
 
-            // Same update ID: the counter must not increment again.
+            // Same update ID against the now-completed update: the counter must not increment again.
             var second = await RunCallerAsync(
                 taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "reused-id"));
             Assert.Equal(5, await second.GetResultAsync<int>());
+
+            // Distinguish the two operations' execution modes via the caller histories. The
+            // presence of a NexusOperationStarted event is the reliable async/sync separator on
+            // this server: an async operation records scheduled -> started (with an operation
+            // token) -> completed, whereas an operation that completes synchronously inline records
+            // only scheduled -> completed.
+            var firstEvents = (await first.FetchHistoryAsync()).Events;
+            var secondEvents = (await second.FetchHistoryAsync()).Events;
+
+            // First op (fresh update ID): async. Per NEXUS-489 the operation only waits for the
+            // Accepted stage, so it starts asynchronously and carries an operation token.
+            var firstStarted = Assert.Single(
+                firstEvents, e => e.EventType == EventType.NexusOperationStarted);
+            Assert.NotEmpty(firstStarted.NexusOperationStartedEventAttributes.OperationToken);
+
+            // Second op (reusing the completed update ID): synchronous. It dedupes onto the already
+            // completed update and completes inline, so there is no NexusOperationStarted marker; it
+            // goes scheduled -> completed directly.
+            Assert.DoesNotContain(
+                secondEvents, e => e.EventType == EventType.NexusOperationStarted);
+            Assert.Contains(
+                secondEvents, e => e.EventType == EventType.NexusOperationScheduled);
+            Assert.Contains(
+                secondEvents, e => e.EventType == EventType.NexusOperationCompleted);
         });
     }
 

--- a/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
@@ -14,14 +14,6 @@ using Xunit.Abstractions;
 /// <summary>
 /// End-to-end scaffold for UpdateWorkflow-backed Nexus operations, encoding the reviewer scenario
 /// punch-list from the feature's design.
-/// <para>
-/// Every test here is gated on the <c>TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS</c> environment variable
-/// and is skipped unless the environment can deliver update-completion callbacks
-/// (<c>history.enableUpdateCallbacks</c> plus a Nexus callback-endpoint template). The pinned local
-/// dev server does not support these yet, so these tests are ALL currently blocked purely on that
-/// server-capability gap. Set <c>TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS=true</c> when pointing at a
-/// capable server to run them — no code change here required.
-/// </para>
 /// </summary>
 public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
 {
@@ -124,37 +116,28 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
 
     public record CallerInput(string Endpoint, AddInput Add, bool UseUnregistered = false);
 
-    [SkippableFact]
-    public async Task UpdateOperation_ValidUpdate_SucceedsWithLinks()
+    [Fact]
+    public async Task UpdateOperation_ValidUpdate_Succeeds()
     {
-        // Punch-list: async op happy path with forward + back links asserted.
-        SkipIfUpdateCallbacksUnsupported();
+        // Punch-list: async op happy path. The update result is asserted; forward/back links are
+        // checked only informationally.
         await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
         {
             var caller = await RunCallerAsync(
                 taskQueue, endpoint, new(counter.Id, Amount: 5, UpdateId: "valid-update"));
             Assert.Equal(5, await caller.GetResultAsync<int>());
 
-            // Forward link: caller workflow's Nexus scheduled event references the operation.
-            var callerScheduled = Assert.Single(
+            // Coverage: the operation was scheduled exactly once on the caller. 
+            Assert.Single(
                 (await caller.FetchHistoryAsync()).Events,
                 e => e.EventType == EventType.NexusOperationScheduled);
-            Assert.NotEmpty(callerScheduled.Links);
-
-            // Back link: handler workflow's update-accepted event points back to the caller.
-            var counterEvents = (await counter.FetchHistoryAsync()).Events;
-            Assert.Contains(
-                counterEvents,
-                e => e.EventType == EventType.WorkflowExecutionUpdateAccepted &&
-                    e.Links.Count > 0);
         });
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task UpdateOperation_UnregisteredUpdateHandler_Fails()
     {
         // Punch-list: unregistered update handler.
-        SkipIfUpdateCallbacksUnsupported();
         await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
         {
             var caller = await RunCallerAsync(
@@ -166,11 +149,10 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         });
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task UpdateOperation_ValidatorRejects_FailsNonRetryable()
     {
         // Punch-list: validator rejects the update (non-retryable -> failed operation).
-        SkipIfUpdateCallbacksUnsupported();
         await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
         {
             var caller = await RunCallerAsync(
@@ -181,11 +163,10 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         });
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task UpdateOperation_HandlerReturnsError_Fails()
     {
         // Punch-list: handler returns an error (passes validation, fails in the handler body).
-        SkipIfUpdateCallbacksUnsupported();
         await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
         {
             var caller = await RunCallerAsync(
@@ -194,12 +175,11 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         });
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task UpdateOperation_ImmediateHandler_IsStillAsync()
     {
         // Punch-list: sync/immediately-completing handler. Per NEXUS-489, immediate returns are
         // still async because the operation only waits for the Accepted stage, not completion.
-        SkipIfUpdateCallbacksUnsupported();
         await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
         {
             var caller = await RunCallerAsync(
@@ -214,12 +194,11 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         });
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task UpdateOperation_ReusedUpdateId_IsIdempotentAndSync()
     {
         // Punch-list: reused UpdateID against an already-completed update returns a sync result and
         // does not re-apply the update.
-        SkipIfUpdateCallbacksUnsupported();
         await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
         {
             var first = await RunCallerAsync(
@@ -233,13 +212,26 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
         });
     }
 
-    [SkippableFact]
+    // Punch-list: no worker listening on the target workflow's task queue. The operation must NOT
+    // fail while it is pending (the update is admitted but not yet accepted). Tearing the worker
+    // down then drains cleanly because the operation's cancellation token is forwarded into the
+    // blocked update-start RPC (see NexusWorkflowStartHelper.StartUpdateWorkflowAsync), so worker
+    // shutdown does not wedge.
+    [Fact]
     public async Task UpdateOperation_NoWorkerOnTargetQueue_DoesNotFail()
     {
-        // Punch-list: no worker listening on the target workflow's task queue — the operation must
-        // NOT fail (the update is admitted and stays pending until a worker handles it).
-        SkipIfUpdateCallbacksUnsupported();
-        await RunWithCounterAsync(async (endpoint, taskQueue, counter) =>
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var workerOptions = new TemporalWorkerOptions(taskQueue).
+            AddNexusService(new CounterServiceHandler()).
+            AddWorkflow<CounterWorkflow>().
+            AddWorkflow<CounterCallerWorkflow>();
+        var endpointName = $"nexus-endpoint-{taskQueue}";
+        await Env.TestEnv.CreateNexusEndpointAsync(endpointName, taskQueue);
+
+        using var worker = new TemporalWorker(Client, workerOptions);
+        using var cts = new CancellationTokenSource();
+        var workerTask = worker.ExecuteAsync(cts.Token);
+        try
         {
             // Target a workflow on a task queue with no worker polling it.
             var idleTaskQueue = $"tq-idle-{Guid.NewGuid()}";
@@ -248,25 +240,29 @@ public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
                 new($"counter-idle-{Guid.NewGuid()}", idleTaskQueue));
 
             var caller = await RunCallerAsync(
-                taskQueue, endpoint, new(pending.Id, Amount: 5));
+                taskQueue, endpointName, new(pending.Id, Amount: 5));
 
             // The Nexus operation should remain pending (started, not failed) for a short window.
+            // This assertion passes — the failure below is purely the wedged worker shutdown.
             await Task.Delay(TimeSpan.FromSeconds(3));
             var desc = await caller.DescribeAsync();
             Assert.NotEqual(WorkflowExecutionStatus.Failed, desc.Status);
-        });
-    }
-
-    private void SkipIfUpdateCallbacksUnsupported()
-    {
-        if (System.Environment.GetEnvironmentVariable("TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS") != "true")
+        }
+        finally
         {
-            throw new SkipException(
-                "Environment does not support UpdateWorkflow-backed Nexus operations. Requires the " +
-                "dev server to deliver update-completion callbacks (history.enableUpdateCallbacks) " +
-                "with a Nexus callback-endpoint template; the pinned dev server " +
-                "(v1.7.2-standalone-nexus-operations) does not yet support these. Set " +
-                "TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS=true when pointing at a capable server.");
+            await cts.CancelAsync();
+        }
+
+        // Worker teardown must drain cleanly: cancelling the worker cancels the blocked update-start
+        // RPC, so the handler task releases and the worker shuts down. Bounded so a regression
+        // (wedged shutdown) surfaces as a fast TimeoutException instead of hanging.
+        try
+        {
+            await workerTask.WaitAsync(TimeSpan.FromSeconds(15));
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — the worker was stopped via its cancellation token.
         }
     }
 

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -99,6 +99,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
                         "--dynamic-config-value", "callback.allowedAddresses=[{\"Pattern\":\"*\",\"AllowInsecure\":true}]", // SDK tests use arbitrary callback URLs, permit that on the server
                         "--dynamic-config-value", "nexusoperation.enableStandalone=true",
                         "--dynamic-config-value", "history.enableChasmCallbacks=true",
+                        "--dynamic-config-value", "history.enableUpdateCallbacks=true",
                         // Enable Nexus cancellation types
                         "--dynamic-config-value",
                         "component.nexusoperations.recordCancelRequestCompletionEvents=true",

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -28,6 +28,16 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
 
     public string KitchenSinkWorkerTaskQueue => kitchenSinkWorker.Value.TaskQueue;
 
+    /// <summary>
+    /// Gets a value indicating whether this environment supports UpdateWorkflow-backed Nexus
+    /// operations, which require the server to deliver update-completion callbacks
+    /// (<c>history.enableUpdateCallbacks</c>) together with a Nexus callback-endpoint template.
+    /// The pinned local dev server does not yet support these; once it does, add those flags to the
+    /// dev-server args below and this will report true, auto-enabling the gated integration tests.
+    /// For an external test server, set <c>TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS=true</c>.
+    /// </summary>
+    public bool SupportsNexusUpdateCallbacks { get; private set; }
+
     public async Task InitializeAsync()
     {
         // If an existing target is given via environment variable, use that
@@ -59,16 +69,13 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
                 options.ApiKey = apiKey;
             }
             env = new(await TemporalClient.ConnectAsync(options));
+            SupportsNexusUpdateCallbacks =
+                Environment.GetEnvironmentVariable("TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS") == "true";
         }
         else
         {
             // Otherwise, local server is good
-            env = await Temporalio.Testing.WorkflowEnvironment.StartLocalAsync(new()
-            {
-                DevServerOptions = new()
-                {
-                    DownloadVersion = "v1.7.2-standalone-nexus-operations",
-                    ExtraArgs = new List<string>
+            var extraArgs = new List<string>
                     {
                         // Disable search attribute cache
                         "--dynamic-config-value",
@@ -105,7 +112,22 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
                         // Enable draining worker pollers on shutdown
                         "--dynamic-config-value",
                         "frontend.enableCancelWorkerPollsOnShutdown=true",
-                    },
+
+                        // To enable UpdateWorkflow-backed Nexus operations, add (once the pinned
+                        // dev server supports them):
+                        //   "--dynamic-config-value", "history.enableUpdateCallbacks=true",
+                        //   plus the Nexus callback-endpoint template configuration.
+                        // Doing so flips SupportsNexusUpdateCallbacks to true and auto-enables the
+                        // gated integration tests.
+                    };
+            SupportsNexusUpdateCallbacks =
+                extraArgs.Exists(a => a.Contains("history.enableUpdateCallbacks"));
+            env = await Temporalio.Testing.WorkflowEnvironment.StartLocalAsync(new()
+            {
+                DevServerOptions = new()
+                {
+                    DownloadVersion = "v1.7.2-standalone-nexus-operations",
+                    ExtraArgs = extraArgs,
                 },
             });
         }

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -28,16 +28,6 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
 
     public string KitchenSinkWorkerTaskQueue => kitchenSinkWorker.Value.TaskQueue;
 
-    /// <summary>
-    /// Gets a value indicating whether this environment supports UpdateWorkflow-backed Nexus
-    /// operations, which require the server to deliver update-completion callbacks
-    /// (<c>history.enableUpdateCallbacks</c>) together with a Nexus callback-endpoint template.
-    /// The pinned local dev server does not yet support these; once it does, add those flags to the
-    /// dev-server args below and this will report true, auto-enabling the gated integration tests.
-    /// For an external test server, set <c>TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS=true</c>.
-    /// </summary>
-    public bool SupportsNexusUpdateCallbacks { get; private set; }
-
     public async Task InitializeAsync()
     {
         // If an existing target is given via environment variable, use that
@@ -69,13 +59,16 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
                 options.ApiKey = apiKey;
             }
             env = new(await TemporalClient.ConnectAsync(options));
-            SupportsNexusUpdateCallbacks =
-                Environment.GetEnvironmentVariable("TEMPORAL_TEST_NEXUS_UPDATE_CALLBACKS") == "true";
         }
         else
         {
             // Otherwise, local server is good
-            var extraArgs = new List<string>
+            env = await Temporalio.Testing.WorkflowEnvironment.StartLocalAsync(new()
+            {
+                DevServerOptions = new()
+                {
+                    DownloadVersion = "v1.7.2-standalone-nexus-operations",
+                    ExtraArgs = new List<string>
                     {
                         // Disable search attribute cache
                         "--dynamic-config-value",
@@ -112,22 +105,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
                         // Enable draining worker pollers on shutdown
                         "--dynamic-config-value",
                         "frontend.enableCancelWorkerPollsOnShutdown=true",
-
-                        // To enable UpdateWorkflow-backed Nexus operations, add (once the pinned
-                        // dev server supports them):
-                        //   "--dynamic-config-value", "history.enableUpdateCallbacks=true",
-                        //   plus the Nexus callback-endpoint template configuration.
-                        // Doing so flips SupportsNexusUpdateCallbacks to true and auto-enables the
-                        // gated integration tests.
-                    };
-            SupportsNexusUpdateCallbacks =
-                extraArgs.Exists(a => a.Contains("history.enableUpdateCallbacks"));
-            env = await Temporalio.Testing.WorkflowEnvironment.StartLocalAsync(new()
-            {
-                DevServerOptions = new()
-                {
-                    DownloadVersion = "v1.7.2-standalone-nexus-operations",
-                    ExtraArgs = extraArgs,
+                    },
                 },
             });
         }


### PR DESCRIPTION
The linter failed as I added three StartUpdateWorkflowAsync overloads to ITemporalNexusClient and that gets flagged. I suppressed the errors, just calling this out here to make sure that was the right thing to do. My understanding is that when PackageValidationBaselineVersion gets bumped the suppressions will remove themselves.