### PR TITLE
:boom: feature: payloads/memo size validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ to docs, or any other relevant information.
 
 ### Breaking Changes
 
-- Payload/memo size-limit enforcement (experimental) is now on by default. Workers proactively validate outbound
-  payload/memo sizes before sending: a field over the warn threshold is logged (`[TMPRL1103]` at
+- By default, workers now proactively validate outbound payload/memo sizes before sending: a field
+  over the warn threshold is logged (`[TMPRL1103]` at
   `WARN`) but still sent, while a task completion over the error limit is failed retryably
   (`[TMPRL1103]` at `ERROR`) instead of sent. Previously these reached the server, which terminated
   the workflow or failed the activity non-retryably; failing retryably instead lets a corrected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Payload/memo size-limit enforcement (experimental) is now on by default. Workers proactively validate outbound
+  payload/memo sizes before sending: a field over the warn threshold is logged (`[TMPRL1103]` at
+  `WARN`) but still sent, while a task completion over the error limit is failed retryably
+  (`[TMPRL1103]` at `ERROR`) instead of sent. Previously these reached the server, which terminated
+  the workflow or failed the activity non-retryably; failing retryably instead lets a corrected
+  workflow or activity be redeployed and recover. Tune warn thresholds via
+  `TemporalConnectionOptions.PayloadLimits`. If you use a proxy between the worker and server that
+  alters the size of payloads (e.g. compression, encryption, external storage), it is advised that
+  you disable size enforcement by setting `DisablePayloadErrorLimit` to `true` on the worker.
+
 ### [1.17.0] - 2026-07-13
 
 ### Added

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -245,6 +245,12 @@ namespace Temporalio.Bridge.Interop
 
         [NativeTypeName("enum TemporalCoreClientGrpcCompression")]
         public TemporalCoreClientGrpcCompression grpc_compression;
+
+        [NativeTypeName("uint64_t")]
+        public ulong payloads_warn_size;
+
+        [NativeTypeName("uint64_t")]
+        public ulong memo_warn_size;
     }
 
     internal unsafe partial struct TemporalCoreByteArray
@@ -1223,6 +1229,9 @@ namespace Temporalio.Bridge.Interop
 
         [NativeTypeName("struct TemporalCoreByteArrayRefArray")]
         public TemporalCoreByteArrayRefArray storage_drivers;
+
+        [NativeTypeName("bool")]
+        public byte disable_payload_error_limit;
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -730,7 +730,7 @@ namespace Temporalio.Bridge.Interop
     {
         public TemporalCoreWorkerVersioningStrategy_Tag tag;
 
-        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L580_C3")]
+        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L592_C3")]
         public _Anonymous_e__Union Anonymous;
 
         internal ref TemporalCoreWorkerVersioningNone none
@@ -770,15 +770,15 @@ namespace Temporalio.Bridge.Interop
         internal unsafe partial struct _Anonymous_e__Union
         {
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L581_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L593_C5")]
             public _Anonymous1_1_e__Struct Anonymous1_1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L584_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L596_C5")]
             public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L587_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L599_C5")]
             public _Anonymous3_1_e__Struct Anonymous3_1;
 
             internal partial struct _Anonymous1_1_e__Struct
@@ -899,7 +899,7 @@ namespace Temporalio.Bridge.Interop
     {
         public TemporalCoreSlotInfo_Tag tag;
 
-        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L654_C3")]
+        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L666_C3")]
         public _Anonymous_e__Union Anonymous;
 
         internal ref TemporalCoreWorkflowSlotInfo_Body workflow_slot_info
@@ -1040,7 +1040,7 @@ namespace Temporalio.Bridge.Interop
     {
         public TemporalCoreSlotSupplier_Tag tag;
 
-        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L760_C3")]
+        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L772_C3")]
         public _Anonymous_e__Union Anonymous;
 
         internal ref TemporalCoreFixedSizeSlotSupplier fixed_size
@@ -1080,15 +1080,15 @@ namespace Temporalio.Bridge.Interop
         internal unsafe partial struct _Anonymous_e__Union
         {
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L761_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L773_C5")]
             public _Anonymous1_1_e__Struct Anonymous1_1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L764_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L776_C5")]
             public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L767_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L779_C5")]
             public _Anonymous3_1_e__Struct Anonymous3_1;
 
             internal partial struct _Anonymous1_1_e__Struct

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
+using Temporalio.Client;
 using Temporalio.Exceptions;
 using Temporalio.Worker.Tuning;
 
@@ -256,6 +257,8 @@ namespace Temporalio.Bridge
             }
 
             var scheme = tls == null ? "http" : "https";
+            // Property is non-nullable but NRT is advisory, so defensively check for null here
+            PayloadLimitsOptions payloadLimits = options.PayloadLimits ?? new();
             return new Interop.TemporalCoreConnectionOptions()
             {
                 target_url = scope.ByteArray($"{scheme}://{options.TargetHost}"),
@@ -292,6 +295,10 @@ namespace Temporalio.Bridge
                     _ => throw new ArgumentException(
                         $"Unsupported gRPC compression: {options.GrpcCompression.GetType()}"),
                 },
+                payloads_warn_size =
+                    (ulong)Math.Max(0, payloadLimits.PayloadsWarnSize),
+                memo_warn_size =
+                    (ulong)Math.Max(0, payloadLimits.MemoWarnSize),
             };
         }
 
@@ -646,6 +653,7 @@ namespace Temporalio.Bridge
                     AllNonDeterminismFailureTypeWorkflows(options.Workflows)),
                 plugins = scope.ByteArrayArray(pluginNames),
                 storage_drivers = scope.ByteArrayArray(storageDrivers),
+                disable_payload_error_limit = (byte)(options.DisablePayloadErrorLimit ? 1 : 0),
             };
         }
 

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -259,6 +259,22 @@ namespace Temporalio.Bridge
             var scheme = tls == null ? "http" : "https";
             // Property is non-nullable but NRT is advisory, so defensively check for null here
             PayloadLimitsOptions payloadLimits = options.PayloadLimits ?? new();
+            if (payloadLimits.PayloadsWarnSize < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    payloadLimits.PayloadsWarnSize,
+                    "PayloadLimits.PayloadsWarnSize must not be negative.");
+            }
+
+            if (payloadLimits.MemoWarnSize < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    payloadLimits.MemoWarnSize,
+                    "PayloadLimits.MemoWarnSize must not be negative.");
+            }
+
             return new Interop.TemporalCoreConnectionOptions()
             {
                 target_url = scope.ByteArray($"{scheme}://{options.TargetHost}"),
@@ -295,10 +311,8 @@ namespace Temporalio.Bridge
                     _ => throw new ArgumentException(
                         $"Unsupported gRPC compression: {options.GrpcCompression.GetType()}"),
                 },
-                payloads_warn_size =
-                    (ulong)Math.Max(0, payloadLimits.PayloadsWarnSize),
-                memo_warn_size =
-                    (ulong)Math.Max(0, payloadLimits.MemoWarnSize),
+                payloads_warn_size = (ulong)payloadLimits.PayloadsWarnSize,
+                memo_warn_size = (ulong)payloadLimits.MemoWarnSize,
             };
         }
 

--- a/src/Temporalio/Client/PayloadLimitsOptions.cs
+++ b/src/Temporalio/Client/PayloadLimitsOptions.cs
@@ -10,19 +10,27 @@ namespace Temporalio.Client
     /// </remarks>
     public class PayloadLimitsOptions : ICloneable
     {
+        // Mirrors the Temporal server's dynamic-config default for limit.blobSize.warn, so the SDK
+        // warns at the same payload-field size the server would.
+        private const int DefaultPayloadsWarnSize = 512 * 1024;
+
+        // Mirrors the Temporal server's dynamic-config default for limit.memoSize.warn, so the SDK
+        // warns at the same memo size the server would.
+        private const int DefaultMemoWarnSize = 2 * 1024;
+
         /// <summary>
         /// Gets or sets the warning threshold, in bytes, for the size of an outbound payload-bearing
         /// field. Over-threshold fields are logged but still sent to the server. Defaults to 512KiB;
         /// set to <c>0</c> to disable.
         /// </summary>
-        public int PayloadsWarnSize { get; set; } = 512 * 1024;
+        public int PayloadsWarnSize { get; set; } = DefaultPayloadsWarnSize;
 
         /// <summary>
         /// Gets or sets the warning threshold, in bytes, for outbound memo size. Over-threshold
         /// memos are logged but still sent to the server. Defaults to 2KiB; set to <c>0</c> to
         /// disable.
         /// </summary>
-        public int MemoWarnSize { get; set; } = 2 * 1024;
+        public int MemoWarnSize { get; set; } = DefaultMemoWarnSize;
 
         /// <summary>
         /// Create a shallow copy of these options.

--- a/src/Temporalio/Client/PayloadLimitsOptions.cs
+++ b/src/Temporalio/Client/PayloadLimitsOptions.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Temporalio.Client
+{
+    /// <summary>
+    /// Payload size-limit options for a connection.
+    /// </summary>
+    public class PayloadLimitsOptions : ICloneable
+    {
+        /// <summary>
+        /// Gets or sets the warning threshold, in bytes, for the size of an outbound payload-bearing
+        /// field. Over-threshold fields are logged but still sent to the server. Defaults to 512KiB;
+        /// set to <c>0</c> to disable.
+        /// </summary>
+        public int PayloadsWarnSize { get; set; } = 512 * 1024;
+
+        /// <summary>
+        /// Gets or sets the warning threshold, in bytes, for outbound memo size. Over-threshold
+        /// memos are logged but still sent to the server. Defaults to 2KiB; set to <c>0</c> to
+        /// disable.
+        /// </summary>
+        public int MemoWarnSize { get; set; } = 2 * 1024;
+
+        /// <summary>
+        /// Create a shallow copy of these options.
+        /// </summary>
+        /// <returns>A shallow copy of these options.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio/Client/PayloadLimitsOptions.cs
+++ b/src/Temporalio/Client/PayloadLimitsOptions.cs
@@ -5,6 +5,9 @@ namespace Temporalio.Client
     /// <summary>
     /// Payload size-limit options for a connection.
     /// </summary>
+    /// <remarks>
+    /// WARNING: This API is experimental and may change in the future.
+    /// </remarks>
     public class PayloadLimitsOptions : ICloneable
     {
         /// <summary>

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -87,6 +87,12 @@ namespace Temporalio.Client
         public GrpcCompression GrpcCompression { get; set; } = new GrpcCompression.Gzip();
 
         /// <summary>
+        /// Gets or sets the payload size-limit options for this connection. Defaults to a new
+        /// <see cref="PayloadLimitsOptions"/>. See that type for the default thresholds.
+        /// </summary>
+        public PayloadLimitsOptions PayloadLimits { get; set; } = new();
+
+        /// <summary>
         /// Gets or sets the gRPC metadata for all calls (i.e. the headers).
         /// </summary>
         /// <remarks>
@@ -158,6 +164,10 @@ namespace Temporalio.Client
             if (DnsLoadBalancing != null)
             {
                 copy.DnsLoadBalancing = (DnsLoadBalancingOptions)DnsLoadBalancing.Clone();
+            }
+            if (PayloadLimits != null)
+            {
+                copy.PayloadLimits = (PayloadLimitsOptions)PayloadLimits.Clone();
             }
             return copy;
         }

--- a/src/Temporalio/Client/TemporalConnectionOptions.cs
+++ b/src/Temporalio/Client/TemporalConnectionOptions.cs
@@ -90,6 +90,9 @@ namespace Temporalio.Client
         /// Gets or sets the payload size-limit options for this connection. Defaults to a new
         /// <see cref="PayloadLimitsOptions"/>. See that type for the default thresholds.
         /// </summary>
+        /// <remarks>
+        /// WARNING: This API is experimental and may change in the future.
+        /// </remarks>
         public PayloadLimitsOptions PayloadLimits { get; set; } = new();
 
         /// <summary>

--- a/src/Temporalio/Runtime/TelemetryFilterOptions.cs
+++ b/src/Temporalio/Runtime/TelemetryFilterOptions.cs
@@ -24,7 +24,7 @@ namespace Temporalio.Runtime
             var coreLevel = core.ToString().ToUpper();
             var otherLevel = other.ToString().ToUpper();
             FilterString =
-                $"{otherLevel},temporalio_sdk_core={coreLevel},temporalio_client={coreLevel},temporalio_sdk={coreLevel}";
+                $"{otherLevel},temporalio_common={coreLevel},temporalio_sdk_core={coreLevel},temporalio_client={coreLevel},temporalio_sdk={coreLevel}";
         }
 
         /// <summary>

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -355,6 +355,16 @@ namespace Temporalio.Worker
         public bool DisableEagerActivityExecution { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the worker should skip proactively failing
+        /// workflow/activity tasks whose payloads exceed the namespace error limits.
+        /// </summary>
+        /// <remarks>
+        /// When <c>false</c> (the default), the worker fails such tasks before sending them. When
+        /// <c>true</c>, oversized payloads are sent to the server, which enforces the limit.
+        /// </remarks>
+        public bool DisablePayloadErrorLimit { get; set; }
+
+        /// <summary>
         /// Gets or sets the plugins.
         /// </summary>
         /// <remarks>

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -361,7 +361,6 @@ namespace Temporalio.Worker
         /// <remarks>
         /// When <c>false</c> (the default), the worker fails such tasks before sending them. When
         /// <c>true</c>, oversized payloads are sent to the server, which enforces the limit.
-        /// <para>WARNING: This API is experimental and may change in the future.</para>
         /// </remarks>
         public bool DisablePayloadErrorLimit { get; set; }
 

--- a/src/Temporalio/Worker/TemporalWorkerOptions.cs
+++ b/src/Temporalio/Worker/TemporalWorkerOptions.cs
@@ -361,6 +361,7 @@ namespace Temporalio.Worker
         /// <remarks>
         /// When <c>false</c> (the default), the worker fails such tasks before sending them. When
         /// <c>true</c>, oversized payloads are sent to the server, which enforces the limit.
+        /// <para>WARNING: This API is experimental and may change in the future.</para>
         /// </remarks>
         public bool DisablePayloadErrorLimit { get; set; }
 

--- a/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
+++ b/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
@@ -80,6 +80,13 @@ public class PayloadSizeLimitsTests : TestBase
                         "[TMPRL1103] Attempted to upload payloads with size that exceeded the error limit."));
                 return Task.CompletedTask;
             });
+
+            // Failure mechanism: worker reported a WorkflowTaskFailed with PAYLOADS_TOO_LARGE.
+            var history = await handle.FetchHistoryAsync();
+            Assert.Contains(history.Events, e =>
+                e.EventType == Temporalio.Api.Enums.V1.EventType.WorkflowTaskFailed &&
+                e.WorkflowTaskFailedEventAttributes.Cause ==
+                    Temporalio.Api.Enums.V1.WorkflowTaskFailedCause.PayloadsTooLarge);
         });
     }
 
@@ -154,6 +161,55 @@ public class PayloadSizeLimitsTests : TestBase
                 e.Level == LogLevel.Warning &&
                 e.Formatted.Contains(
                     "[TMPRL1103] Attempted to upload payloads with size that exceeded the warning limit."));
+        });
+    }
+
+    [Fact]
+    public async Task MemoWarnSize_ProducesWarningLog()
+    {
+        await using var env = await WorkflowEnvironment.StartLocalAsync(
+            new() { DevServerOptions = new() { ExtraArgs = PayloadLimitsExtraArgs } });
+
+        using var loggerFactory = new TestUtils.LogCaptureFactory(LoggerFactory);
+        // Only the memo threshold is lowered; the payloads threshold stays at its default so the
+        // small workflow input/output do not warn.
+        var client = await TemporalClient.ConnectAsync(new()
+        {
+            TargetHost = env.Client.Connection.Options.TargetHost,
+            Namespace = env.Client.Options.Namespace,
+            PayloadLimits = new() { MemoWarnSize = 1024 },
+            Runtime = new TemporalRuntime(new()
+            {
+                Telemetry = new()
+                {
+                    Logging = new()
+                    {
+                        Forwarding = new() { Logger = loggerFactory.CreateLogger("core") },
+                    },
+                },
+            }),
+        });
+
+        var workerOpts = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddWorkflow<LargePayloadWorkflow>().
+            AddActivity(LargePayloadActivities.NoOp);
+        using var worker = new TemporalWorker(client, workerOpts);
+        await worker.ExecuteAsync(async () =>
+        {
+            // The memo rides on the StartWorkflowExecution request; its 2KiB value is above the 1KiB
+            // memo warn threshold, so the workflow starts and a memo warning is logged.
+            await client.ExecuteWorkflowAsync(
+                (LargePayloadWorkflow wf) => wf.RunAsync(new(0, 0)),
+                new($"wf-{Guid.NewGuid()}", workerOpts.TaskQueue!)
+                {
+                    ExecutionTimeout = TimeSpan.FromSeconds(10),
+                    Memo = new Dictionary<string, object> { ["big"] = new string('m', 2 * 1024) },
+                });
+
+            Assert.Contains(loggerFactory.Logs, e =>
+                e.Level == LogLevel.Warning &&
+                e.Formatted.Contains(
+                    "[TMPRL1103] Attempted to upload memo with size that exceeded the warning limit."));
         });
     }
 

--- a/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
+++ b/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
@@ -114,7 +114,11 @@ public class PayloadSizeLimitsTests : TestBase
                 {
                     ExecutionTimeout = TimeSpan.FromSeconds(5),
                 });
-            await Assert.ThrowsAsync<WorkflowFailedException>(() => handle.GetResultAsync());
+            var exc = await Assert.ThrowsAsync<WorkflowFailedException>(() => handle.GetResultAsync());
+            var terminated = Assert.IsType<TerminatedFailureException>(exc.InnerException);
+            Assert.Equal(
+                "BadScheduleActivityAttributes: ScheduleActivityTaskCommandAttributes.Input exceeds size limit.",
+                terminated.Message);
         });
     }
 

--- a/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
+++ b/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
@@ -1,0 +1,185 @@
+namespace Temporalio.Tests.Worker;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Temporalio.Activities;
+using Temporalio.Client;
+using Temporalio.Exceptions;
+using Temporalio.Runtime;
+using Temporalio.Testing;
+using Temporalio.Worker;
+using Temporalio.Workflows;
+using Xunit;
+using Xunit.Abstractions;
+
+// Payload/memo size-limit enforcement lives in sdk-core. These tests only assert that the .NET
+// plumbing reaches core: an oversized worker completion is failed proactively (with a forwarded
+// [TMPRL1103] error log), the DisablePayloadErrorLimit opt-out lets the oversized payload reach
+// (and be rejected by) the server, and the connection's PayloadsWarnSize threshold produces a
+// forwarded [TMPRL1103] warning.
+public class PayloadSizeLimitsTests : TestBase
+{
+    private const int PayloadErrorLimit = 10 * 1024;
+
+    private static readonly string[] PayloadLimitsExtraArgs =
+    {
+        "--dynamic-config-value", $"limit.blobSize.error={PayloadErrorLimit}",
+        // Warn limit must be specified to have the server enforce the error limit.
+        "--dynamic-config-value", "limit.blobSize.warn=2048",
+    };
+
+    public PayloadSizeLimitsTests(ITestOutputHelper output)
+        : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task OversizedPayload_FailsTask_WithErrorLog()
+    {
+        await using var env = await WorkflowEnvironment.StartLocalAsync(
+            new() { DevServerOptions = new() { ExtraArgs = PayloadLimitsExtraArgs } });
+
+        using var loggerFactory = new TestUtils.LogCaptureFactory(LoggerFactory);
+        var client = await TemporalClient.ConnectAsync(new()
+        {
+            TargetHost = env.Client.Connection.Options.TargetHost,
+            Namespace = env.Client.Options.Namespace,
+            Runtime = new TemporalRuntime(new()
+            {
+                Telemetry = new()
+                {
+                    Logging = new()
+                    {
+                        Forwarding = new() { Logger = loggerFactory.CreateLogger("core") },
+                    },
+                },
+            }),
+        });
+
+        var workerOpts = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddWorkflow<LargePayloadWorkflow>().
+            AddActivity(LargePayloadActivities.NoOp);
+        using var worker = new TemporalWorker(client, workerOpts);
+        await worker.ExecuteAsync(async () =>
+        {
+            var handle = await env.Client.StartWorkflowAsync(
+                (LargePayloadWorkflow wf) => wf.RunAsync(new(0, PayloadErrorLimit + 1024)),
+                new($"wf-{Guid.NewGuid()}", workerOpts.TaskQueue!)
+                {
+                    ExecutionTimeout = TimeSpan.FromSeconds(5),
+                });
+
+            await Assert.ThrowsAsync<WorkflowFailedException>(() => handle.GetResultAsync());
+
+            await AssertMore.EventuallyAsync(() =>
+            {
+                Assert.Contains(loggerFactory.Logs, e =>
+                    e.Level == LogLevel.Error &&
+                    e.Formatted.Contains(
+                        "[TMPRL1103] Attempted to upload payloads with size that exceeded the error limit."));
+                return Task.CompletedTask;
+            });
+        });
+    }
+
+    [Fact]
+    public async Task DisablePayloadErrorLimit_SendsToServer()
+    {
+        await using var env = await WorkflowEnvironment.StartLocalAsync(
+            new() { DevServerOptions = new() { ExtraArgs = PayloadLimitsExtraArgs } });
+
+        var workerOpts = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}")
+        {
+            DisablePayloadErrorLimit = true,
+        }.
+            AddWorkflow<LargePayloadWorkflow>().
+            AddActivity(LargePayloadActivities.NoOp);
+        using var worker = new TemporalWorker(env.Client, workerOpts);
+        await worker.ExecuteAsync(async () =>
+        {
+            // With the opt-out, core does not pre-fail; the oversized activity input reaches the
+            // server.
+            var handle = await env.Client.StartWorkflowAsync(
+                (LargePayloadWorkflow wf) => wf.RunAsync(new(PayloadErrorLimit + 1024, 0)),
+                new($"wf-{Guid.NewGuid()}", workerOpts.TaskQueue!)
+                {
+                    ExecutionTimeout = TimeSpan.FromSeconds(5),
+                });
+            await Assert.ThrowsAsync<WorkflowFailedException>(() => handle.GetResultAsync());
+        });
+    }
+
+    [Fact]
+    public async Task PayloadsWarnSize_ProducesWarningLog()
+    {
+        await using var env = await WorkflowEnvironment.StartLocalAsync(
+            new() { DevServerOptions = new() { ExtraArgs = PayloadLimitsExtraArgs } });
+
+        using var loggerFactory = new TestUtils.LogCaptureFactory(LoggerFactory);
+        // The warn threshold is configured on the (worker's) connection and forwarded to core.
+        var client = await TemporalClient.ConnectAsync(new()
+        {
+            TargetHost = env.Client.Connection.Options.TargetHost,
+            Namespace = env.Client.Options.Namespace,
+            PayloadLimits = new() { PayloadsWarnSize = 1024 },
+            Runtime = new TemporalRuntime(new()
+            {
+                Telemetry = new()
+                {
+                    Logging = new()
+                    {
+                        Forwarding = new() { Logger = loggerFactory.CreateLogger("core") },
+                    },
+                },
+            }),
+        });
+
+        var workerOpts = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddWorkflow<LargePayloadWorkflow>().
+            AddActivity(LargePayloadActivities.NoOp);
+        using var worker = new TemporalWorker(client, workerOpts);
+        await worker.ExecuteAsync(async () =>
+        {
+            // 2KiB result is above the 1KiB warn threshold but below the 10KiB error limit, so the
+            // workflow completes and a warning is logged.
+            await client.ExecuteWorkflowAsync(
+                (LargePayloadWorkflow wf) => wf.RunAsync(new(0, 2 * 1024)),
+                new($"wf-{Guid.NewGuid()}", workerOpts.TaskQueue!)
+                {
+                    ExecutionTimeout = TimeSpan.FromSeconds(10),
+                });
+
+            Assert.Contains(loggerFactory.Logs, e =>
+                e.Level == LogLevel.Warning &&
+                e.Formatted.Contains(
+                    "[TMPRL1103] Attempted to upload payloads with size that exceeded the warning limit."));
+        });
+    }
+
+    public record LargePayloadInput(int ActivityInputDataSize, int WorkflowOutputDataSize);
+
+    public static class LargePayloadActivities
+    {
+        [Activity]
+        public static void NoOp(string data)
+        {
+        }
+    }
+
+    [Workflow]
+    public class LargePayloadWorkflow
+    {
+        [WorkflowRun]
+        public async Task<string> RunAsync(LargePayloadInput input)
+        {
+            if (input.ActivityInputDataSize > 0)
+            {
+                await Workflow.ExecuteActivityAsync(
+                    () => LargePayloadActivities.NoOp(new string('i', input.ActivityInputDataSize)),
+                    new() { ScheduleToCloseTimeout = TimeSpan.FromSeconds(5) });
+            }
+            return new string('o', input.WorkflowOutputDataSize);
+        }
+    }
+}

--- a/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
+++ b/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
@@ -25,7 +25,8 @@ public class PayloadSizeLimitsTests : TestBase
     private static readonly string[] PayloadLimitsExtraArgs =
     {
         "--dynamic-config-value", $"limit.blobSize.error={PayloadErrorLimit}",
-        // Warn limit must be specified to have the server enforce the error limit.
+        // The server only enforces the error limit for payloads that also exceed the warn limit, so
+        // the warn limit must be below the error limit.
         "--dynamic-config-value", "limit.blobSize.warn=2048",
     };
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Added `PayloadLimitsOptions` (`PayloadsWarnSize`, `MemoWarnSize`) and wired it onto
  `TemporalConnectionOptions.PayloadLimits`; over-threshold values are logged (`[TMPRL1103]`) but
  still sent, `0` disables.
- Added `TemporalWorkerOptions.DisablePayloadErrorLimit` to opt out of worker error-limit
  enforcement and defer to the server.
- Update `sdk-core` submodule to bring in payloads/memo size enforcement.

## :boom: Breaking Change

Payload size-limit enforcement is now on by default; existing code changes behavior without opting in: an oversized payload is now failed proactively by the worker (as a retryable task failure) before it's sent, rather than being sent and hard-failed by the server as before.

If you use a proxy between the worker and server that alters the size of payloads (e.g.
compression, encryption, external storage), it is advised that you disable size enforcement by
setting `DisablePayloadErrorLimit` to `true` on the worker.

## Why?

Prevent server from hard-failing workflows, activities, and operations due to payloads/memo size limit violations. Allows customers to potentially update their workflows, activities, and operations to reduce the oversized payloads/memos.

## Checklist
<!--- add/delete as needed --->

1. Closes #638 
1. How was this tested: Core library tests and minimal .NET tests

## Todo

1. [x] Wait for https://github.com/temporalio/sdk-rust/pull/1363 to be merged
1. [x] Updated sdk-core submodule after https://github.com/temporalio/sdk-rust/pull/1363 is merged.