### PR TITLE
fix: checkout global.json for nuget-publish

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -52,6 +52,12 @@ jobs:
       contents: read
       id-token: write # Required for Trusted Publishing OIDC token issuance
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: global.json
+          sparse-checkout-cone-mode: false
+
       - name: Download NuGet artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add checkout step to get the global.json file so setup-dotnet action knows which SDK to install.