### PR TITLE
Defer schedule catchup window default to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Fixed
+
+- Schedule policies now omit an unspecified catch-up window so the Temporal Server applies its
+  default (currently one year).
+
 ### [1.17.0] - 2026-07-13
 
 ### Added

--- a/src/Temporalio/Client/Schedules/SchedulePolicy.cs
+++ b/src/Temporalio/Client/Schedules/SchedulePolicy.cs
@@ -16,10 +16,11 @@ namespace Temporalio.Client.Schedules
         public ScheduleOverlapPolicy Overlap { get; init; } = ScheduleOverlapPolicy.Skip;
 
         /// <summary>
-        /// Gets the amount of time in the past to execute misseed actions after a Temporal server
-        /// is unavailable.
+        /// Gets the amount of time in the past to execute missed actions after a Temporal server
+        /// is unavailable. Zero is omitted from requests so the Temporal Server applies its
+        /// default (currently one year).
         /// </summary>
-        public TimeSpan CatchupWindow { get; init; } = TimeSpan.FromDays(365);
+        public TimeSpan CatchupWindow { get; init; }
 
         /// <summary>
         /// Gets a value indicating whether to pause the schedule if an action fails or times out.
@@ -34,7 +35,7 @@ namespace Temporalio.Client.Schedules
         internal static SchedulePolicy FromProto(Api.Schedule.V1.SchedulePolicies proto) => new()
         {
             Overlap = proto.OverlapPolicy,
-            CatchupWindow = proto.CatchupWindow.ToTimeSpan(),
+            CatchupWindow = proto.CatchupWindow?.ToTimeSpan() ?? TimeSpan.Zero,
             PauseOnFailure = proto.PauseOnFailure,
         };
 
@@ -45,7 +46,7 @@ namespace Temporalio.Client.Schedules
         internal Api.Schedule.V1.SchedulePolicies ToProto() => new()
         {
             OverlapPolicy = Overlap,
-            CatchupWindow = Duration.FromTimeSpan(CatchupWindow),
+            CatchupWindow = CatchupWindow == TimeSpan.Zero ? null : Duration.FromTimeSpan(CatchupWindow),
             PauseOnFailure = PauseOnFailure,
         };
     }

--- a/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
@@ -17,6 +17,14 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    public void SchedulePolicy_ToProto_DefaultCatchupWindowIsOmitted()
+    {
+        var policy = new SchedulePolicy();
+        Assert.Equal(TimeSpan.Zero, policy.CatchupWindow);
+        Assert.Null(policy.ToProto().CatchupWindow);
+    }
+
+    [Fact]
     public async Task CreateScheduleAsync_Basics_Succeeds()
     {
         await TestUtils.AssertNoSchedulesAsync(Client);
@@ -140,6 +148,8 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
         await handle.UpdateAsync(_ => new(newSched));
         desc = await handle.DescribeAsync();
         Assert.NotEqual(expectedUpdateTime, desc.Info.LastUpdatedAt);
+        Assert.Equal(TimeSpan.Zero, newSched.Policy.CatchupWindow);
+        Assert.Equal(TimeSpan.FromDays(365), desc.Schedule.Policy.CatchupWindow);
         // Try to create a duplicate
         await Assert.ThrowsAsync<ScheduleAlreadyRunningException>(
             () => Client.CreateScheduleAsync(handle.Id, newSched));


### PR DESCRIPTION
## What changed
- Use `TimeSpan.Zero` as the unset representation instead of materializing one year.
- Omit a zero catch-up window from protobuf requests.
- Add request-level and server-backed default coverage.
- Correct a documentation typo and update the changelog.

## Why
The Temporal Server should own and apply the default catch-up window.


## Breaking changes
An unconfigured policy reports `TimeSpan.Zero` before server round-tripping. Described schedules report the server-resolved duration.