### PR TITLE
fix(test): deflake ExecuteWorkflowAsync_HistoryInfo_IsAccurate

### DIFF
--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -476,10 +476,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             // Now send a lot of events
             await handle.SignalAsync(wf =>
                 wf.BunchOfEventsAsync(WorkflowEnvironment.ContinueAsNewSuggestedHistoryCount));
-            // Send one more event to trigger the WFT update. We have to do this because just a
-            // query will have a stale representation of history counts, but signal forces a new
-            // WFT.
-            await handle.SignalAsync(wf => wf.BunchOfEventsAsync(1));
+            // Wait for those timers to be recorded before signaling again. Otherwise both signals
+            // can batch into one WFT that starts before the TimerStarted events, permanently
+            // stranding CurrentHistoryLength below them.
             await AssertMore.EventuallyAsync(async () =>
             {
                 var eventCount = (await handle.FetchHistoryAsync()).Events.Count;
@@ -488,13 +487,20 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                     $"We sent at least {WorkflowEnvironment.ContinueAsNewSuggestedHistoryCount} events but " +
                     $"history length said it was only {eventCount}");
             });
-            var newInfo = await handle.QueryAsync(wf => wf.HistoryInfo);
-            Assert.True(
-                newInfo.HistoryLength > WorkflowEnvironment.ContinueAsNewSuggestedHistoryCount,
-                $"We sent at least {WorkflowEnvironment.ContinueAsNewSuggestedHistoryCount} events but " +
-                $"history length said it was only {newInfo.HistoryLength}");
-            Assert.True(newInfo.HistorySize > origInfo.HistorySize);
-            Assert.True(newInfo.ContinueAsNewSuggested);
+            // Force a fresh WFT so the query sees an up-to-date count; a query alone is stale. That
+            // WFT now starts after the timers, so its CurrentHistoryLength includes them.
+            await handle.SignalAsync(wf => wf.BunchOfEventsAsync(1));
+            // Query eventually to absorb the window before the worker processes that WFT.
+            await AssertMore.EventuallyAsync(async () =>
+            {
+                var newInfo = await handle.QueryAsync(wf => wf.HistoryInfo);
+                Assert.True(
+                    newInfo.HistoryLength > WorkflowEnvironment.ContinueAsNewSuggestedHistoryCount,
+                    $"We sent at least {WorkflowEnvironment.ContinueAsNewSuggestedHistoryCount} events but " +
+                    $"history length said it was only {newInfo.HistoryLength}");
+                Assert.True(newInfo.HistorySize > origInfo.HistorySize);
+                Assert.True(newInfo.ContinueAsNewSuggested);
+            });
         });
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Adjust ExecuteWorkflowAsync_HistoryInfo_IsAccurate test to avoid batching signals together into the same workflow task, which prevents history length from advancing.

## Why?

Deflake the test

## Checklist
<!--- add/delete as needed --->

1. Closes #738
