### PR TITLE
Add Nexus Otel tracing instructions

### DIFF
--- a/src/Temporalio.Extensions.OpenTelemetry/README.md
+++ b/src/Temporalio.Extensions.OpenTelemetry/README.md
@@ -34,7 +34,8 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder().
     AddSource(
         TracingInterceptor.ClientSource.Name,
         TracingInterceptor.WorkflowsSource.Name,
-        TracingInterceptor.ActivitiesSource.Name).
+        TracingInterceptor.ActivitiesSource.Name,
+        TracingInterceptor.NexusSource.Name).
     AddConsoleExporter().
     Build();
 

--- a/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
+++ b/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
@@ -795,6 +795,21 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
             ActivityAssertion.NameAndParent(
                 "CompleteWorkflow:TracingWorkflow",
                 "RunWorkflow:TracingWorkflow"));
+
+        // AssertActivities only checks there are no unexpected spans; it does not require any
+        // particular span to exist and, since two StartWorkflow spans are expected (one rooted,
+        // one under the Nexus handler), a disconnected handler-started workflow would still match.
+        // So explicitly assert the trace stays connected across the Nexus handler: the handler span
+        // must exist, and the workflow started inside the handler must be parented to it (same
+        // trace), not begin a new root trace.
+        var nexusHandler = Assert.Single(
+            activities,
+            a => a.OperationName == "RunStartNexusOperationHandler:NexusTracingService/DoSomething");
+        var nexusStartedWorkflow = Assert.Single(
+            activities,
+            a => a.OperationName == "StartWorkflow:TracingWorkflow" &&
+                a.ParentSpanId == nexusHandler.SpanId);
+        Assert.Equal(nexusHandler.TraceId, nexusStartedWorkflow.TraceId);
     }
 
     [Fact]
@@ -912,6 +927,7 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
                 TracingInterceptor.ClientSource.Name,
                 TracingInterceptor.WorkflowsSource.Name,
                 TracingInterceptor.ActivitiesSource.Name,
+                TracingInterceptor.NexusSource.Name,
                 TracingWorkflow.CustomSource.Name).
             AddInMemoryExporter(activities).
             Build();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Small adjustment to the otel tracing readme to call out Nexus support.

## Why?

Some users are having issues getting Nexus + Otel working

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no production tracing interceptor logic is modified in this diff.
> 
> **Overview**
> Documents that OpenTelemetry tracer setup must register **`TracingInterceptor.NexusSource`** alongside the existing client, workflow, and activity sources so Nexus handler spans are collected.
> 
> Test harness changes mirror that: **`WithTracingWorkerAsync`** now adds **`NexusSource`** to the in-memory exporter, and the Nexus tracing test adds explicit checks that the workflow started inside the Nexus handler is parented to **`RunStartNexusOperationHandler`** and shares the same trace ID (guarding against a disconnected root trace that the looser **`AssertActivities`** list could still pass).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d56ef8e395b862fffc6eed70fd9fa3e913275f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->