### PR TITLE
Remove experimental markers from user metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ to docs, or any other relevant information.
 
 ### Changed
 
+- User metadata fields (StaticSummary, StaticDetails, CurrentDetails, Activity Summary, Timer
+  Summary) are no longer marked as experimental.
 - Hardened read-only workflow context enforcement so queries, update validators, and patch activation
   callbacks cannot mutate handlers or workflow details, invoke patches, or schedule workflow work.
   Patch activation callbacks also cannot use workflow randomness or issue workflow commands.

--- a/src/Temporalio/Client/WorkflowExecutionDescription.cs
+++ b/src/Temporalio/Client/WorkflowExecutionDescription.cs
@@ -38,7 +38,6 @@ namespace Temporalio.Client
         /// Gets the single-line fixed summary for this workflow execution that may appear in
         /// UI/CLI. This can be in single-line Temporal markdown format.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         /// <returns>Static summary.</returns>
 #pragma warning disable VSTHRD003 // Awaiting our own lazily-created task
         public async Task<string?> GetStaticSummaryAsync() =>
@@ -49,7 +48,6 @@ namespace Temporalio.Client
         /// Gets the general fixed details for this workflow execution that may appear in UI/CLI.
         /// This can be in Temporal markdown format and can span multiple lines.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         /// <returns>Static details.</returns>
 #pragma warning disable VSTHRD003 // Awaiting our own lazily-created task
         public async Task<string?> GetStaticDetailsAsync() =>

--- a/src/Temporalio/Client/WorkflowOptions.cs
+++ b/src/Temporalio/Client/WorkflowOptions.cs
@@ -45,7 +45,6 @@ namespace Temporalio.Client
         /// Gets or sets a single-line fixed summary for this workflow execution that may appear in
         /// UI/CLI. This can be in single-line Temporal markdown format.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public string? StaticSummary { get; set; }
 
         /// <summary>
@@ -54,7 +53,6 @@ namespace Temporalio.Client
         /// fixed value on the workflow that cannot be updated. For details that can be updated, use
         /// <see cref="Workflows.Workflow.CurrentDetails" /> within the workflow.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public string? StaticDetails { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Workflows/ActivityOptions.cs
+++ b/src/Temporalio/Workflows/ActivityOptions.cs
@@ -76,7 +76,6 @@ namespace Temporalio.Workflows
         /// Gets or sets a single-line fixed summary for this activity that may appear in UI/CLI.
         /// This can be in single-line Temporal markdown format.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public string? Summary { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Workflows/ChildWorkflowOptions.cs
+++ b/src/Temporalio/Workflows/ChildWorkflowOptions.cs
@@ -26,7 +26,6 @@ namespace Temporalio.Workflows
         /// Gets or sets a single-line fixed summary for this workflow execution that may appear in
         /// UI/CLI. This can be in single-line Temporal markdown format.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public string? StaticSummary { get; set; }
 
         /// <summary>
@@ -35,7 +34,6 @@ namespace Temporalio.Workflows
         /// fixed value on the workflow that cannot be updated. For details that can be updated, use
         /// <see cref="Workflow.CurrentDetails" /> within the workflow.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public string? StaticDetails { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Workflows/DelayOptions.cs
+++ b/src/Temporalio/Workflows/DelayOptions.cs
@@ -62,7 +62,6 @@ namespace Temporalio.Workflows
         /// Gets or sets a simple string identifying this timer that may be visible in UI/CLI. While
         /// it can be normal text, it is best to treat as a timer ID.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public string? Summary { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Workflows/LocalActivityOptions.cs
+++ b/src/Temporalio/Workflows/LocalActivityOptions.cs
@@ -76,7 +76,6 @@ namespace Temporalio.Workflows
         /// Gets or sets a single-line fixed summary for this activity that may appear in UI/CLI.
         /// This can be in single-line Temporal markdown format.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public string? Summary { get; set; }
 
         /// <summary>

--- a/src/Temporalio/Workflows/Workflow.cs
+++ b/src/Temporalio/Workflows/Workflow.cs
@@ -76,7 +76,6 @@ namespace Temporalio.Workflows
         /// static details set at start, this value can be updated throughout the life of the
         /// workflow. This can be in Temporal markdown format and can span multiple lines.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
         public static string CurrentDetails
         {
             get => Context.CurrentDetails;


### PR DESCRIPTION
## Summary
- Remove `WARNING: This setting is experimental.` remarks from user metadata properties: StaticSummary, StaticDetails, CurrentDetails, Activity Summary, Timer Summary
- These features are stable and shipping across all SDKs - graduating to GA API surface
- 7 files changed, 10 deletions
- Standalone activities/Nexus experimental warnings are untouched

## Test plan
- [ ] Verify no compilation errors
- [ ] Confirm "Standalone activities are experimental" and "Standalone Nexus operations are experimental" warnings are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)