### PR TITLE
Add changelog CI gate workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog-check:
+    name: Changelog checkpoint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a CHANGELOG.md update or override label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -q '"skip-changelog"'; then
+            echo "Found 'skip-changelog' label; no CHANGELOG.md entry required."
+            exit 0
+          fi
+          if gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' \
+            | grep -Eq '(^|/)CHANGELOG\.md$'; then
+            echo "A CHANGELOG.md was updated."
+            exit 0
+          fi
+          echo "::error::This PR does not update a CHANGELOG.md. If it includes a user-facing change, add an entry under [Unreleased] in CHANGELOG.md. If no changelog entry is needed, a maintainer can apply the 'skip-changelog' label."
+          exit 1


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that requires PRs to either update `CHANGELOG.md` or carry a `skip-changelog` label
- Matches the pattern already used in `sdk-go` and `sdk-typescript`
- Encourages consistent changelog discipline without blocking non-user-facing changes

## Test plan

- [ ] Verify the workflow runs on this PR
- [ ] Verify PRs without changelog updates or `skip-changelog` label are flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)