### PR TITLE
fix: mark system Nexus envelope payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,11 +115,6 @@ to docs, or any other relevant information.
 - Try-cancel child workflows no longer cause nondeterminism when they complete or fail after their
   cancellation was requested.
 
-### Fixed
-
-- Marked system Nexus envelope payloads so nested payloads continue to be encoded and decoded after
-  the envelope is stored in a generic payload field.
-
 ### [1.17.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,11 @@ to docs, or any other relevant information.
 - Try-cancel child workflows no longer cause nondeterminism when they complete or fail after their
   cancellation was requested.
 
+### Fixed
+
+- Marked system Nexus envelope payloads so nested payloads continue to be encoded and decoded after
+  the envelope is stored in a generic payload field.
+
 ### [1.17.0] - 2026-07-13
 
 ### Added

--- a/src/Temporalio.SystemNexus.Generator/Program.cs
+++ b/src/Temporalio.SystemNexus.Generator/Program.cs
@@ -182,7 +182,7 @@ static void GeneratePayloadVisitor(
     builder.AppendLine("            PayloadsVisitor visitPayloads,");
     builder.AppendLine("            EnvelopeVisitor? visitEnvelope = null)");
     builder.AppendLine("        {");
-    builder.AppendLine("            if (!IsSystemNexusPayload(payload))");
+    builder.AppendLine("            if (!IsSystemPayload(payload))");
     builder.AppendLine("            {");
     builder.AppendLine("                return false;");
     builder.AppendLine("            }");

--- a/src/Temporalio.SystemNexus.Generator/Program.cs
+++ b/src/Temporalio.SystemNexus.Generator/Program.cs
@@ -164,8 +164,6 @@ static void GeneratePayloadVisitor(
     builder.AppendLine("    [GeneratedCode(\"Temporalio.SystemNexus.Generator\", null)]");
     builder.AppendLine("    internal static partial class SystemNexusPayloadVisitor");
     builder.AppendLine("    {");
-    builder.AppendLine("        private const string TemporalSystemEndpoint = \"__temporal_system\";");
-    builder.AppendLine();
     builder.AppendLine("        private static readonly IReadOnlyDictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, EnvelopeVisitor?, Task>> EnvelopeVisitors =");
     builder.AppendLine("            new Dictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, EnvelopeVisitor?, Task>>");
     builder.AppendLine("            {");
@@ -178,14 +176,13 @@ static void GeneratePayloadVisitor(
 
     builder.AppendLine("            };");
     builder.AppendLine();
-    builder.AppendLine("        private static async Task<bool> TryVisitAsync(");
-    builder.AppendLine("            string? endpoint,");
+    builder.AppendLine("        internal static async Task<bool> TryVisitAsync(");
     builder.AppendLine("            Payload payload,");
     builder.AppendLine("            PayloadVisitor visitPayload,");
     builder.AppendLine("            PayloadsVisitor visitPayloads,");
-    builder.AppendLine("            EnvelopeVisitor? visitEnvelope)");
+    builder.AppendLine("            EnvelopeVisitor? visitEnvelope = null)");
     builder.AppendLine("        {");
-    builder.AppendLine("            if (!IsSystemNexusEndpoint(endpoint))");
+    builder.AppendLine("            if (!IsSystemNexusPayload(payload))");
     builder.AppendLine("            {");
     builder.AppendLine("                return false;");
     builder.AppendLine("            }");
@@ -200,9 +197,6 @@ static void GeneratePayloadVisitor(
     builder.AppendLine("            return true;");
     builder.AppendLine("        }");
     builder.AppendLine();
-    builder.AppendLine("        internal static bool IsSystemNexusEndpoint(string? endpoint) => endpoint == TemporalSystemEndpoint;");
-    builder.AppendLine();
-
     foreach (var operation in operationMessages)
     {
         EmitVisitMethod(builder, operation.Input, messages, containsPayloadMemo, emittedMethods);

--- a/src/Temporalio.SystemNexus.Generator/Program.cs
+++ b/src/Temporalio.SystemNexus.Generator/Program.cs
@@ -164,8 +164,8 @@ static void GeneratePayloadVisitor(
     builder.AppendLine("    [GeneratedCode(\"Temporalio.SystemNexus.Generator\", null)]");
     builder.AppendLine("    internal static partial class SystemNexusPayloadVisitor");
     builder.AppendLine("    {");
-    builder.AppendLine("        private static readonly IReadOnlyDictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, EnvelopeVisitor?, Task>> EnvelopeVisitors =");
-    builder.AppendLine("            new Dictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, EnvelopeVisitor?, Task>>");
+    builder.AppendLine("        private static readonly IReadOnlyDictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, Task>> EnvelopeVisitors =");
+    builder.AppendLine("            new Dictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, Task>>");
     builder.AppendLine("            {");
 
     foreach (var operation in operationMessages)
@@ -179,8 +179,7 @@ static void GeneratePayloadVisitor(
     builder.AppendLine("        internal static async Task<bool> TryVisitAsync(");
     builder.AppendLine("            Payload payload,");
     builder.AppendLine("            PayloadVisitor visitPayload,");
-    builder.AppendLine("            PayloadsVisitor visitPayloads,");
-    builder.AppendLine("            EnvelopeVisitor? visitEnvelope = null)");
+    builder.AppendLine("            PayloadsVisitor visitPayloads)");
     builder.AppendLine("        {");
     builder.AppendLine("            if (!IsSystemPayload(payload))");
     builder.AppendLine("            {");
@@ -194,7 +193,7 @@ static void GeneratePayloadVisitor(
     builder.AppendLine("                    $\"Unrecognized marked System Nexus envelope message type: {messageType?.ToStringUtf8() ?? \"<missing>\"}\");");
     builder.AppendLine("            }");
     builder.AppendLine();
-    builder.AppendLine("            await visit(payload, visitPayload, visitPayloads, visitEnvelope).ConfigureAwait(false);");
+    builder.AppendLine("            await visit(payload, visitPayload, visitPayloads).ConfigureAwait(false);");
     builder.AppendLine("            return true;");
     builder.AppendLine("        }");
     builder.AppendLine();
@@ -296,13 +295,12 @@ static void EmitEnvelopeVisitor(
         return;
     }
 
-    builder.AppendLine($"                [\"{message.FullName}\"] = (payload, visitPayload, visitPayloads, visitEnvelope) =>");
+    builder.AppendLine($"                [\"{message.FullName}\"] = (payload, visitPayload, visitPayloads) =>");
     builder.AppendLine($"                    VisitEnvelopeAsync<{message.CsharpType}>(");
     builder.AppendLine("                        payload,");
     builder.AppendLine($"                        {VisitMethodName(message)},");
     builder.AppendLine("                        visitPayload,");
-    builder.AppendLine("                        visitPayloads,");
-    builder.AppendLine("                        visitEnvelope),");
+    builder.AppendLine("                        visitPayloads),");
 }
 
 static void EmitVisitMethod(

--- a/src/Temporalio.SystemNexus.Generator/Program.cs
+++ b/src/Temporalio.SystemNexus.Generator/Program.cs
@@ -190,7 +190,8 @@ static void GeneratePayloadVisitor(
     builder.AppendLine("            if (!payload.Metadata.TryGetValue(\"messageType\", out var messageType) ||");
     builder.AppendLine("                !EnvelopeVisitors.TryGetValue(messageType.ToStringUtf8(), out var visit))");
     builder.AppendLine("            {");
-    builder.AppendLine("                return false;");
+    builder.AppendLine("                throw new InvalidOperationException(");
+    builder.AppendLine("                    $\"Unrecognized marked System Nexus envelope message type: {messageType?.ToStringUtf8() ?? \"<missing>\"}\");");
     builder.AppendLine("            }");
     builder.AppendLine();
     builder.AppendLine("            await visit(payload, visitPayload, visitPayloads, visitEnvelope).ConfigureAwait(false);");

--- a/src/Temporalio/Nexus/SystemNexusPayloadConverter.cs
+++ b/src/Temporalio/Nexus/SystemNexusPayloadConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using Temporalio.Api.Common.V1;
 using Temporalio.Converters;
+using Temporalio.Worker;
 
 namespace Temporalio.Nexus
 {
@@ -38,9 +39,9 @@ namespace Temporalio.Nexus
         /// <inheritdoc />
         public Payload ToPayload(object? value)
         {
-            // TODO: Scope userPayloadConverter and userFailureConverter in the generated System
-            // Nexus support converter context once that support file is ingested into the SDK.
-            return OuterPayloadConverter.ToPayload(value);
+            var payload = OuterPayloadConverter.ToPayload(value);
+            SystemNexusPayloadVisitor.MarkSystemPayload(payload);
+            return payload;
         }
 
         /// <inheritdoc />

--- a/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
@@ -46,7 +46,8 @@ namespace Temporalio.Worker
             if (!payload.Metadata.TryGetValue("messageType", out var messageType) ||
                 !EnvelopeVisitors.TryGetValue(messageType.ToStringUtf8(), out var visit))
             {
-                return false;
+                throw new InvalidOperationException(
+                    $"Unrecognized marked System Nexus envelope message type: {messageType?.ToStringUtf8() ?? "<missing>"}");
             }
 
             await visit(payload, visitPayload, visitPayloads, visitEnvelope).ConfigureAwait(false);

--- a/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
@@ -13,30 +13,27 @@ namespace Temporalio.Worker
     [GeneratedCode("Temporalio.SystemNexus.Generator", null)]
     internal static partial class SystemNexusPayloadVisitor
     {
-        private static readonly IReadOnlyDictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, EnvelopeVisitor?, Task>> EnvelopeVisitors =
-            new Dictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, EnvelopeVisitor?, Task>>
+        private static readonly IReadOnlyDictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, Task>> EnvelopeVisitors =
+            new Dictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, Task>>
             {
-                ["temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest"] = (payload, visitPayload, visitPayloads, visitEnvelope) =>
+                ["temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest"] = (payload, visitPayload, visitPayloads) =>
                     VisitEnvelopeAsync<global::Temporalio.Api.WorkflowService.V1.SignalWithStartWorkflowExecutionRequest>(
                         payload,
                         Visit_temporal_api_workflowservice_v1_SignalWithStartWorkflowExecutionRequest,
                         visitPayload,
-                        visitPayloads,
-                        visitEnvelope),
-                ["temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse"] = (payload, visitPayload, visitPayloads, visitEnvelope) =>
+                        visitPayloads),
+                ["temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse"] = (payload, visitPayload, visitPayloads) =>
                     VisitEnvelopeAsync<global::Temporalio.Api.WorkflowService.V1.SignalWithStartWorkflowExecutionResponse>(
                         payload,
                         Visit_temporal_api_workflowservice_v1_SignalWithStartWorkflowExecutionResponse,
                         visitPayload,
-                        visitPayloads,
-                        visitEnvelope),
+                        visitPayloads),
             };
 
         internal static async Task<bool> TryVisitAsync(
             Payload payload,
             PayloadVisitor visitPayload,
-            PayloadsVisitor visitPayloads,
-            EnvelopeVisitor? visitEnvelope = null)
+            PayloadsVisitor visitPayloads)
         {
             if (!IsSystemPayload(payload))
             {
@@ -50,7 +47,7 @@ namespace Temporalio.Worker
                     $"Unrecognized marked System Nexus envelope message type: {messageType?.ToStringUtf8() ?? "<missing>"}");
             }
 
-            await visit(payload, visitPayload, visitPayloads, visitEnvelope).ConfigureAwait(false);
+            await visit(payload, visitPayload, visitPayloads).ConfigureAwait(false);
             return true;
         }
 

--- a/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
@@ -38,7 +38,7 @@ namespace Temporalio.Worker
             PayloadsVisitor visitPayloads,
             EnvelopeVisitor? visitEnvelope = null)
         {
-            if (!IsSystemNexusPayload(payload))
+            if (!IsSystemPayload(payload))
             {
                 return false;
             }

--- a/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
@@ -13,8 +13,6 @@ namespace Temporalio.Worker
     [GeneratedCode("Temporalio.SystemNexus.Generator", null)]
     internal static partial class SystemNexusPayloadVisitor
     {
-        private const string TemporalSystemEndpoint = "__temporal_system";
-
         private static readonly IReadOnlyDictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, EnvelopeVisitor?, Task>> EnvelopeVisitors =
             new Dictionary<string, Func<Payload, PayloadVisitor, PayloadsVisitor, EnvelopeVisitor?, Task>>
             {
@@ -34,14 +32,13 @@ namespace Temporalio.Worker
                         visitEnvelope),
             };
 
-        private static async Task<bool> TryVisitAsync(
-            string? endpoint,
+        internal static async Task<bool> TryVisitAsync(
             Payload payload,
             PayloadVisitor visitPayload,
             PayloadsVisitor visitPayloads,
-            EnvelopeVisitor? visitEnvelope)
+            EnvelopeVisitor? visitEnvelope = null)
         {
-            if (!IsSystemNexusEndpoint(endpoint))
+            if (!IsSystemNexusPayload(payload))
             {
                 return false;
             }
@@ -55,8 +52,6 @@ namespace Temporalio.Worker
             await visit(payload, visitPayload, visitPayloads, visitEnvelope).ConfigureAwait(false);
             return true;
         }
-
-        internal static bool IsSystemNexusEndpoint(string? endpoint) => endpoint == TemporalSystemEndpoint;
 
         private static async Task Visit_temporal_api_common_v1_Memo(
             global::Temporalio.Api.Common.V1.Memo value,

--- a/src/Temporalio/Worker/IWorkflowCodecHelperInstance.cs
+++ b/src/Temporalio/Worker/IWorkflowCodecHelperInstance.cs
@@ -40,18 +40,5 @@ namespace Temporalio.Worker
         /// <param name="seq">Sequence.</param>
         /// <returns>Context.</returns>
         ISerializationContext.Workflow? GetPendingExternalSignalSerializationContext(uint seq);
-
-        /// <summary>
-        /// Gets the pending Nexus operation info for the given sequence.
-        /// </summary>
-        /// <param name="seq">Sequence.</param>
-        /// <returns>Info.</returns>
-        NexusOperationInfo? GetPendingNexusOperationInfo(uint seq);
-
-        /// <summary>
-        /// Pending Nexus operation info.
-        /// </summary>
-        /// <param name="Endpoint">Endpoint name.</param>
-        internal record NexusOperationInfo(string? Endpoint);
     }
 }

--- a/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
@@ -16,6 +16,7 @@ namespace Temporalio.Worker
         private const string SystemPayloadMetadataKey = "__temporal_system_payload";
 
         private static readonly ByteString SystemPayloadMetadataValue = ByteString.CopyFromUtf8("true");
+
         internal delegate Task PayloadVisitor(Payload payload);
 
         internal delegate Task PayloadsVisitor(RepeatedField<Payload> payloads);
@@ -50,10 +51,8 @@ namespace Temporalio.Worker
             }
         }
 
-        private static bool IsSystemNexusPayload(Payload payload) =>
+        private static bool IsSystemPayload(Payload payload) =>
             payload.Metadata.TryGetValue(SystemPayloadMetadataKey, out var value) &&
-            value == SystemPayloadMetadataValue;
-
-        private static bool IsSystemNexusEndpoint(string? endpoint) => endpoint == TemporalSystemEndpoint;
+            value.Equals(SystemPayloadMetadataValue);
     }
 }

--- a/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
@@ -21,9 +21,7 @@ namespace Temporalio.Worker
 
         internal delegate Task PayloadsVisitor(RepeatedField<Payload> payloads);
 
-        internal delegate Task EnvelopeVisitor(Payload payload);
-
-        internal static bool IsSystemNexusEndpoint(string? endpoint) => endpoint == TemporalSystemEndpoint;
+        internal static bool IsSystemEndpoint(string? endpoint) => endpoint == TemporalSystemEndpoint;
 
         internal static void MarkSystemPayload(Payload payload) =>
             payload.Metadata[SystemPayloadMetadataKey] = SystemPayloadMetadataValue;
@@ -32,8 +30,7 @@ namespace Temporalio.Worker
             Payload payload,
             Func<T, PayloadVisitor, PayloadsVisitor, Task> visitMessage,
             PayloadVisitor visitPayload,
-            PayloadsVisitor visitPayloads,
-            EnvelopeVisitor? visitEnvelope)
+            PayloadsVisitor visitPayloads)
             where T : IMessage<T>, new()
         {
             BinaryProtoConverter.AssertProtoPayload(payload, typeof(T));
@@ -45,10 +42,6 @@ namespace Temporalio.Worker
             payload.Metadata["messageType"] = ByteString.CopyFromUtf8(message.Descriptor.FullName);
             MarkSystemPayload(payload);
             payload.Data = message.ToByteString();
-            if (visitEnvelope != null)
-            {
-                await visitEnvelope(payload).ConfigureAwait(false);
-            }
         }
 
         private static bool IsSystemPayload(Payload payload) =>

--- a/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
@@ -11,27 +11,21 @@ namespace Temporalio.Worker
 {
     internal static partial class SystemNexusPayloadVisitor
     {
+        private const string TemporalSystemEndpoint = "__temporal_system";
+
+        private const string SystemPayloadMetadataKey = "__temporal_system_payload";
+
+        private static readonly ByteString SystemPayloadMetadataValue = ByteString.CopyFromUtf8("true");
         internal delegate Task PayloadVisitor(Payload payload);
 
         internal delegate Task PayloadsVisitor(RepeatedField<Payload> payloads);
 
         internal delegate Task EnvelopeVisitor(Payload payload);
 
-        internal static Task<bool> TryVisitInputAsync(
-            string? endpoint,
-            Payload payload,
-            PayloadVisitor visitPayload,
-            PayloadsVisitor visitPayloads,
-            EnvelopeVisitor? visitEnvelope = null) =>
-            TryVisitAsync(endpoint, payload, visitPayload, visitPayloads, visitEnvelope);
+        internal static bool IsSystemNexusEndpoint(string? endpoint) => endpoint == TemporalSystemEndpoint;
 
-        internal static Task<bool> TryVisitOutputAsync(
-            string? endpoint,
-            Payload payload,
-            PayloadVisitor visitPayload,
-            PayloadsVisitor visitPayloads,
-            EnvelopeVisitor? visitEnvelope = null) =>
-            TryVisitAsync(endpoint, payload, visitPayload, visitPayloads, visitEnvelope);
+        internal static void MarkSystemPayload(Payload payload) =>
+            payload.Metadata[SystemPayloadMetadataKey] = SystemPayloadMetadataValue;
 
         private static async Task VisitEnvelopeAsync<T>(
             Payload payload,
@@ -48,11 +42,18 @@ namespace Temporalio.Worker
             payload.Metadata.Clear();
             payload.Metadata["encoding"] = ByteString.CopyFromUtf8("binary/protobuf");
             payload.Metadata["messageType"] = ByteString.CopyFromUtf8(message.Descriptor.FullName);
+            MarkSystemPayload(payload);
             payload.Data = message.ToByteString();
             if (visitEnvelope != null)
             {
                 await visitEnvelope(payload).ConfigureAwait(false);
             }
         }
+
+        private static bool IsSystemNexusPayload(Payload payload) =>
+            payload.Metadata.TryGetValue(SystemPayloadMetadataKey, out var value) &&
+            value == SystemPayloadMetadataValue;
+
+        private static bool IsSystemNexusEndpoint(string? endpoint) => endpoint == TemporalSystemEndpoint;
     }
 }

--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Google.Protobuf;
@@ -125,20 +126,9 @@ namespace Temporalio.Worker
                         }
                         if (job.ResolveNexusOperation.Result.Completed != null)
                         {
-                            var operationInfo = context.Instance?.GetPendingNexusOperationInfo(
-                                job.ResolveNexusOperation.Seq);
-                            if (operationInfo == null ||
-                                !await SystemNexusPayloadVisitor.TryVisitOutputAsync(
-                                    operationInfo.Endpoint,
-                                    job.ResolveNexusOperation.Result.Completed,
-                                    payload => DecodeAsync(nexusCodec, payload),
-                                    payloads => DecodeAsync(nexusCodec, payloads)).
-                                    ConfigureAwait(false))
-                            {
-                                await DecodeAsync(
-                                    nexusCodec, job.ResolveNexusOperation.Result.Completed).
-                                    ConfigureAwait(false);
-                            }
+                            await DecodeAsync(
+                                nexusCodec, job.ResolveNexusOperation.Result.Completed).
+                                ConfigureAwait(false);
                         }
                         else if (job.ResolveNexusOperation.Result.Failed != null)
                         {
@@ -347,16 +337,7 @@ namespace Temporalio.Worker
                     codec = context.CodecNoContext;
                     if (cmd.ScheduleNexusOperation.Input != null && codec != null)
                     {
-                        if (!await SystemNexusPayloadVisitor.TryVisitInputAsync(
-                                cmd.ScheduleNexusOperation.Endpoint,
-                                cmd.ScheduleNexusOperation.Input,
-                                payload => EncodeAsync(codec, payload),
-                                payloads => EncodeAsync(codec, payloads)).
-                            ConfigureAwait(false))
-                        {
-                            await EncodeAsync(
-                                codec, cmd.ScheduleNexusOperation.Input).ConfigureAwait(false);
-                        }
+                        await EncodeAsync(codec, cmd.ScheduleNexusOperation.Input).ConfigureAwait(false);
                     }
                     break;
                 case WorkflowCommand.VariantOneofCase.StartChildWorkflowExecution:
@@ -429,15 +410,43 @@ namespace Temporalio.Worker
             {
                 return;
             }
-            // We have to convert to list here just in case they are based on the underlying list
-            // and we clear it out (which can happen with Linq selectors)
-            var newPayloads = (await codec.EncodeAsync(payloads).ConfigureAwait(false)).ToList();
+            var allPayloads = payloads.ToList();
+            var codecPayloadIndexes = new List<int>();
+            for (var i = 0; i < allPayloads.Count; i++)
+            {
+                if (!await SystemNexusPayloadVisitor.TryVisitAsync(
+                        allPayloads[i],
+                        payload => EncodeAsync(codec, payload),
+                        nestedPayloads => EncodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
+                {
+                    codecPayloadIndexes.Add(i);
+                }
+            }
+            if (codecPayloadIndexes.Count == 0)
+            {
+                return;
+            }
+            // We have to convert to a list here just in case codec results are based on the
+            // underlying list and we clear it out below.
+            var codecPayloads = codecPayloadIndexes.Select(index => allPayloads[index]).ToList();
+            var newPayloads = (await codec.EncodeAsync(codecPayloads).ConfigureAwait(false)).ToList();
+            for (var i = 0; i < codecPayloadIndexes.Count; i++)
+            {
+                allPayloads[codecPayloadIndexes[i]] = newPayloads[i];
+            }
             payloads.Clear();
-            payloads.AddRange(newPayloads);
+            payloads.AddRange(allPayloads);
         }
 
         private static async Task EncodeAsync(IPayloadCodec codec, Payload payload)
         {
+            if (await SystemNexusPayloadVisitor.TryVisitAsync(
+                    payload,
+                    nestedPayload => EncodeAsync(codec, nestedPayload),
+                    nestedPayloads => EncodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
+            {
+                return;
+            }
             // We are gonna require a single result here. It is important that we do Single() call
             // before clearing out payload to merge with since underlying enumerable may be lazy.
             // If the returned payload is literally the same object as the one sent to the codec,
@@ -538,15 +547,43 @@ namespace Temporalio.Worker
             {
                 return;
             }
-            // We have to convert to list here just in case they are based on the underlying list
-            // and we clear it out (which can happen with Linq selectors)
-            var newPayloads = (await codec.DecodeAsync(payloads).ConfigureAwait(false)).ToList();
+            var allPayloads = payloads.ToList();
+            var codecPayloadIndexes = new List<int>();
+            for (var i = 0; i < allPayloads.Count; i++)
+            {
+                if (!await SystemNexusPayloadVisitor.TryVisitAsync(
+                        allPayloads[i],
+                        payload => DecodeAsync(codec, payload),
+                        nestedPayloads => DecodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
+                {
+                    codecPayloadIndexes.Add(i);
+                }
+            }
+            if (codecPayloadIndexes.Count == 0)
+            {
+                return;
+            }
+            // We have to convert to a list here just in case codec results are based on the
+            // underlying list and we clear it out below.
+            var codecPayloads = codecPayloadIndexes.Select(index => allPayloads[index]).ToList();
+            var newPayloads = (await codec.DecodeAsync(codecPayloads).ConfigureAwait(false)).ToList();
+            for (var i = 0; i < codecPayloadIndexes.Count; i++)
+            {
+                allPayloads[codecPayloadIndexes[i]] = newPayloads[i];
+            }
             payloads.Clear();
-            payloads.AddRange(newPayloads);
+            payloads.AddRange(allPayloads);
         }
 
         private static async Task DecodeAsync(IPayloadCodec codec, Payload payload)
         {
+            if (await SystemNexusPayloadVisitor.TryVisitAsync(
+                    payload,
+                    nestedPayload => DecodeAsync(codec, nestedPayload),
+                    nestedPayloads => DecodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
+            {
+                return;
+            }
             // We are gonna require a single result here.
             // Similarly with encode, we leave the payload alone if it's exactly the same object as the original.
             var decoded = await codec.DecodeAsync(new Payload[] { payload }).ConfigureAwait(false);

--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -410,32 +410,32 @@ namespace Temporalio.Worker
             {
                 return;
             }
-            var allPayloads = payloads.ToList();
-            var codecPayloadIndexes = new List<int>();
-            for (var i = 0; i < allPayloads.Count; i++)
+            var newPayloads = new List<Payload>();
+            var codecPayloads = new List<Payload>();
+            foreach (var payload in payloads)
             {
                 if (!await SystemNexusPayloadVisitor.TryVisitAsync(
-                        allPayloads[i],
+                        payload,
                         payload => EncodeAsync(codec, payload),
                         nestedPayloads => EncodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
                 {
-                    codecPayloadIndexes.Add(i);
+                    codecPayloads.Add(payload);
+                    continue;
                 }
+
+                if (codecPayloads.Count > 0)
+                {
+                    newPayloads.AddRange(await codec.EncodeAsync(codecPayloads).ConfigureAwait(false));
+                    codecPayloads.Clear();
+                }
+                newPayloads.Add(payload);
             }
-            if (codecPayloadIndexes.Count == 0)
+            if (codecPayloads.Count > 0)
             {
-                return;
-            }
-            // We have to convert to a list here just in case codec results are based on the
-            // underlying list and we clear it out below.
-            var codecPayloads = codecPayloadIndexes.Select(index => allPayloads[index]).ToList();
-            var newPayloads = (await codec.EncodeAsync(codecPayloads).ConfigureAwait(false)).ToList();
-            for (var i = 0; i < codecPayloadIndexes.Count; i++)
-            {
-                allPayloads[codecPayloadIndexes[i]] = newPayloads[i];
+                newPayloads.AddRange(await codec.EncodeAsync(codecPayloads).ConfigureAwait(false));
             }
             payloads.Clear();
-            payloads.AddRange(allPayloads);
+            payloads.AddRange(newPayloads);
         }
 
         private static async Task EncodeAsync(IPayloadCodec codec, Payload payload)
@@ -547,32 +547,32 @@ namespace Temporalio.Worker
             {
                 return;
             }
-            var allPayloads = payloads.ToList();
-            var codecPayloadIndexes = new List<int>();
-            for (var i = 0; i < allPayloads.Count; i++)
+            var newPayloads = new List<Payload>();
+            var codecPayloads = new List<Payload>();
+            foreach (var payload in payloads)
             {
                 if (!await SystemNexusPayloadVisitor.TryVisitAsync(
-                        allPayloads[i],
+                        payload,
                         payload => DecodeAsync(codec, payload),
                         nestedPayloads => DecodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
                 {
-                    codecPayloadIndexes.Add(i);
+                    codecPayloads.Add(payload);
+                    continue;
                 }
+
+                if (codecPayloads.Count > 0)
+                {
+                    newPayloads.AddRange(await codec.DecodeAsync(codecPayloads).ConfigureAwait(false));
+                    codecPayloads.Clear();
+                }
+                newPayloads.Add(payload);
             }
-            if (codecPayloadIndexes.Count == 0)
+            if (codecPayloads.Count > 0)
             {
-                return;
-            }
-            // We have to convert to a list here just in case codec results are based on the
-            // underlying list and we clear it out below.
-            var codecPayloads = codecPayloadIndexes.Select(index => allPayloads[index]).ToList();
-            var newPayloads = (await codec.DecodeAsync(codecPayloads).ConfigureAwait(false)).ToList();
-            for (var i = 0; i < codecPayloadIndexes.Count; i++)
-            {
-                allPayloads[codecPayloadIndexes[i]] = newPayloads[i];
+                newPayloads.AddRange(await codec.DecodeAsync(codecPayloads).ConfigureAwait(false));
             }
             payloads.Clear();
-            payloads.AddRange(allPayloads);
+            payloads.AddRange(newPayloads);
         }
 
         private static async Task DecodeAsync(IPayloadCodec codec, Payload payload)

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -2683,7 +2683,7 @@ namespace Temporalio.Worker
 
                 // TODO: Scope the generated System Nexus support converter context around this
                 // operation converter once the generated support file is ingested into the SDK.
-                var systemNexusPayloadConverter = SystemNexusPayloadVisitor.IsSystemNexusEndpoint(
+                var systemNexusPayloadConverter = SystemNexusPayloadVisitor.IsSystemEndpoint(
                     input.ClientOptions.Endpoint) ?
                     new SystemNexusPayloadConverter(
                         instance.payloadConverterNoContext,

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -899,13 +899,6 @@ namespace Temporalio.Worker
         }
 
         /// <inheritdoc/>
-        public IWorkflowCodecHelperInstance.NexusOperationInfo? GetPendingNexusOperationInfo(uint seq)
-        {
-            nexusOperationsPending.TryGetValue(seq, out var pending);
-            return pending == null ? null : new(pending.Endpoint);
-        }
-
-        /// <inheritdoc/>
         protected override IEnumerable<Task>? GetScheduledTasks() => scheduledTasks;
 
         /// <inheritdoc/>
@@ -2737,7 +2730,6 @@ namespace Temporalio.Worker
 
                 var handleSource = new TaskCompletionSource<NexusWorkflowOperationHandle<TResult>>();
                 var pending = new PendingNexusOperationInfo(
-                    Endpoint: input.ClientOptions.Endpoint,
                     StartCompletionSource: new(),
                     ResultCompletionSource: new());
                 instance.nexusOperationsPending[seq] = pending;
@@ -3212,7 +3204,6 @@ namespace Temporalio.Worker
             TaskCompletionSource<ResolveRequestCancelExternalWorkflow> CompletionSource);
 
         private record PendingNexusOperationInfo(
-            string? Endpoint,
             TaskCompletionSource<ResolveNexusOperationStart> StartCompletionSource,
             TaskCompletionSource<NexusOperationResult> ResultCompletionSource);
 

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1426,7 +1426,10 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var exc2 = Assert.IsType<NexusOperationFailureException>(exc.InnerException);
         var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.NotImplemented, exc3.ErrorType);
-        Assert.Equal("Intentional failure", exc3.Message);
+        // Newer servers wrap a failed cancel handler in a cancellation-request HandlerException.
+        // The original handler error, including its message, is retained as the inner exception.
+        var handlerError = exc3.InnerException as HandlerException ?? exc3;
+        Assert.Equal("Intentional failure", handlerError.Message);
     }
 
     [Fact]

--- a/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
@@ -3,7 +3,9 @@ namespace Temporalio.Tests.Worker;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Temporalio.Api.Common.V1;
+using Temporalio.Api.WorkflowService.V1;
 using Temporalio.Bridge.Api.WorkflowActivation;
+using Temporalio.Bridge.Api.WorkflowCommands;
 using Temporalio.Bridge.Api.WorkflowCompletion;
 using Temporalio.Converters;
 using Temporalio.Worker;
@@ -102,6 +104,98 @@ public class WorkflowCodecHelperTests : TestBase
                 await WorkflowCodecHelper.EncodeAsync(CreateSimpleCodecContext(codec), comp);
             }
         });
+    }
+
+    [Fact]
+    public async Task EncodeAsync_SystemNexusEnvelopeInGenericPayloadField_EncodesNestedPayload()
+    {
+        var request = new SignalWithStartWorkflowExecutionRequest
+        {
+            Input = new() { Payloads_ = { new Payload { Data = ByteString.CopyFromUtf8("input") } } },
+        };
+        Assert.True(SystemNexusPayloadVisitor.TryToInputPayload(
+            "__temporal_system", request, out var envelope));
+        var completion = new WorkflowActivationCompletion
+        {
+            Successful = new()
+            {
+                Commands =
+                {
+                    new WorkflowCommand { UpdateResponse = new() { Completed = envelope } },
+                },
+            },
+        };
+
+        await WorkflowCodecHelper.EncodeAsync(CreateSimpleCodecContext(new MarkerPayloadCodec()), completion);
+
+        Assert.Equal(
+            ByteString.CopyFromUtf8("true"),
+            completion.Successful.Commands[0].UpdateResponse.Completed.Metadata[
+                "__temporal_system_payload"]);
+        Assert.DoesNotContain(
+            "encoded",
+            completion.Successful.Commands[0].UpdateResponse.Completed.Metadata.Keys);
+        var encodedRequest = SignalWithStartWorkflowExecutionRequest.Parser.ParseFrom(
+            completion.Successful.Commands[0].UpdateResponse.Completed.Data);
+        Assert.Contains("encoded", encodedRequest.Input.Payloads_[0].Metadata.Keys);
+    }
+
+    [Fact]
+    public async Task EncodeAsync_UnmarkedSystemNexusEnvelopeInGenericPayloadField_EncodesEnvelope()
+    {
+        var request = new SignalWithStartWorkflowExecutionRequest
+        {
+            Input = new() { Payloads_ = { new Payload { Data = ByteString.CopyFromUtf8("input") } } },
+        };
+        Assert.True(SystemNexusPayloadVisitor.TryToInputPayload(
+            "__temporal_system", request, out var envelope));
+        envelope.Metadata.Remove("__temporal_system_payload");
+        var completion = new WorkflowActivationCompletion
+        {
+            Successful = new()
+            {
+                Commands =
+                {
+                    new WorkflowCommand { UpdateResponse = new() { Completed = envelope } },
+                },
+            },
+        };
+
+        await WorkflowCodecHelper.EncodeAsync(CreateSimpleCodecContext(new MarkerPayloadCodec()), completion);
+
+        Assert.Contains(
+            "encoded",
+            completion.Successful.Commands[0].UpdateResponse.Completed.Metadata.Keys);
+        var encodedRequest = SignalWithStartWorkflowExecutionRequest.Parser.ParseFrom(
+            completion.Successful.Commands[0].UpdateResponse.Completed.Data);
+        Assert.DoesNotContain("encoded", encodedRequest.Input.Payloads_[0].Metadata.Keys);
+    }
+
+    [Fact]
+    public async Task DecodeAsync_SystemNexusEnvelopeInGenericPayloadField_DecodesNestedPayload()
+    {
+        var nestedPayload = new Payload { Data = ByteString.CopyFromUtf8("input") };
+        nestedPayload.Metadata["encoded"] = ByteString.Empty;
+        var request = new SignalWithStartWorkflowExecutionRequest
+        {
+            Input = new() { Payloads_ = { nestedPayload } },
+        };
+        Assert.True(SystemNexusPayloadVisitor.TryToInputPayload(
+            "__temporal_system", request, out var envelope));
+        var activation = new WorkflowActivation
+        {
+            Jobs =
+            {
+                new WorkflowActivationJob { DoUpdate = new() { Input = { envelope } } },
+            },
+        };
+
+        await WorkflowCodecHelper.DecodeAsync(CreateSimpleCodecContext(new MarkerPayloadCodec()), activation);
+
+        Assert.DoesNotContain("decoded", activation.Jobs[0].DoUpdate.Input[0].Metadata.Keys);
+        var decodedRequest = SignalWithStartWorkflowExecutionRequest.Parser.ParseFrom(
+            activation.Jobs[0].DoUpdate.Input[0].Data);
+        Assert.Contains("decoded", decodedRequest.Input.Payloads_[0].Metadata.Keys);
     }
 
     private static WorkflowCodecHelper.WorkflowCodecContext CreateSimpleCodecContext(IPayloadCodec codec) => new(

--- a/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
@@ -170,6 +170,33 @@ public class WorkflowCodecHelperTests : TestBase
     }
 
     [Fact]
+    public async Task EncodeAsync_UnrecognizedMarkedSystemNexusEnvelope_FailsExplicitly()
+    {
+        var completion = new WorkflowActivationCompletion
+        {
+            Successful = new()
+            {
+                Commands =
+                {
+                    new WorkflowCommand
+                    {
+                        UpdateResponse = new()
+                        {
+                            Completed = CreateSystemEnvelope(new Google.Protobuf.WellKnownTypes.Empty()),
+                        },
+                    },
+                },
+            },
+        };
+
+        var err = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            WorkflowCodecHelper.EncodeAsync(CreateSimpleCodecContext(new MarkerPayloadCodec()), completion));
+
+        Assert.Contains("Unrecognized marked System Nexus envelope message type", err.Message);
+        Assert.Contains("google.protobuf.Empty", err.Message);
+    }
+
+    [Fact]
     public async Task DecodeAsync_SystemNexusEnvelopeInGenericPayloadField_DecodesNestedPayload()
     {
         var nestedPayload = new Payload { Data = ByteString.CopyFromUtf8("input") };

--- a/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowCodecHelperTests.cs
@@ -113,8 +113,7 @@ public class WorkflowCodecHelperTests : TestBase
         {
             Input = new() { Payloads_ = { new Payload { Data = ByteString.CopyFromUtf8("input") } } },
         };
-        Assert.True(SystemNexusPayloadVisitor.TryToInputPayload(
-            "__temporal_system", request, out var envelope));
+        var envelope = CreateSystemEnvelope(request);
         var completion = new WorkflowActivationCompletion
         {
             Successful = new()
@@ -147,8 +146,7 @@ public class WorkflowCodecHelperTests : TestBase
         {
             Input = new() { Payloads_ = { new Payload { Data = ByteString.CopyFromUtf8("input") } } },
         };
-        Assert.True(SystemNexusPayloadVisitor.TryToInputPayload(
-            "__temporal_system", request, out var envelope));
+        var envelope = CreateSystemEnvelope(request);
         envelope.Metadata.Remove("__temporal_system_payload");
         var completion = new WorkflowActivationCompletion
         {
@@ -180,8 +178,7 @@ public class WorkflowCodecHelperTests : TestBase
         {
             Input = new() { Payloads_ = { nestedPayload } },
         };
-        Assert.True(SystemNexusPayloadVisitor.TryToInputPayload(
-            "__temporal_system", request, out var envelope));
+        var envelope = CreateSystemEnvelope(request);
         var activation = new WorkflowActivation
         {
             Jobs =
@@ -196,6 +193,113 @@ public class WorkflowCodecHelperTests : TestBase
         var decodedRequest = SignalWithStartWorkflowExecutionRequest.Parser.ParseFrom(
             activation.Jobs[0].DoUpdate.Input[0].Data);
         Assert.Contains("decoded", decodedRequest.Input.Payloads_[0].Metadata.Keys);
+    }
+
+    [Fact]
+    public async Task EncodeAsync_AllSystemPayloads_EncodesNestedPayloads()
+    {
+        var firstEnvelope = CreateSystemEnvelope("first");
+        var secondEnvelope = CreateSystemEnvelope("second");
+        var completion = new WorkflowActivationCompletion
+        {
+            Successful = new()
+            {
+                Commands =
+                {
+                    new WorkflowCommand
+                    {
+                        ScheduleActivity = new()
+                        {
+                            Arguments = { firstEnvelope, secondEnvelope },
+                        },
+                    },
+                },
+            },
+        };
+
+        await WorkflowCodecHelper.EncodeAsync(CreateSimpleCodecContext(new PackingPayloadCodec()), completion);
+
+        var arguments = completion.Successful.Commands[0].ScheduleActivity.Arguments;
+        Assert.Equal(2, arguments.Count);
+        Assert.All(arguments, payload =>
+        {
+            Assert.Equal(ByteString.CopyFromUtf8("true"), payload.Metadata["__temporal_system_payload"]);
+            var request = SignalWithStartWorkflowExecutionRequest.Parser.ParseFrom(payload.Data);
+            Assert.Contains("packed", request.Input.Payloads_[0].Metadata.Keys);
+        });
+    }
+
+    [Fact]
+    public async Task EncodeAndDecodeAsync_MixedPayloads_PreservesSystemPayloadBoundaries()
+    {
+        var envelope = CreateSystemEnvelope("system");
+        var completion = new WorkflowActivationCompletion
+        {
+            Successful = new()
+            {
+                Commands =
+                {
+                    new WorkflowCommand
+                    {
+                        ScheduleActivity = new()
+                        {
+                            Arguments =
+                            {
+                                new Payload { Data = ByteString.CopyFromUtf8("first") },
+                                new Payload { Data = ByteString.CopyFromUtf8("second") },
+                                envelope,
+                                new Payload { Data = ByteString.CopyFromUtf8("third") },
+                                new Payload { Data = ByteString.CopyFromUtf8("fourth") },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var codec = new PackingPayloadCodec();
+        await WorkflowCodecHelper.EncodeAsync(CreateSimpleCodecContext(codec), completion);
+
+        var encodedArguments = completion.Successful.Commands[0].ScheduleActivity.Arguments;
+        Assert.Equal(3, encodedArguments.Count);
+        Assert.Equal("first|second", encodedArguments[0].Data.ToStringUtf8());
+        Assert.Equal(ByteString.CopyFromUtf8("true"), encodedArguments[1].Metadata["__temporal_system_payload"]);
+        Assert.Equal("third|fourth", encodedArguments[2].Data.ToStringUtf8());
+
+        var activation = new WorkflowActivation
+        {
+            Jobs =
+            {
+                new WorkflowActivationJob
+                {
+                    DoUpdate = new() { Input = { encodedArguments } },
+                },
+            },
+        };
+        await WorkflowCodecHelper.DecodeAsync(CreateSimpleCodecContext(codec), activation);
+
+        var decodedPayloads = activation.Jobs[0].DoUpdate.Input;
+        Assert.Equal(5, decodedPayloads.Count);
+        Assert.Equal("first", decodedPayloads[0].Data.ToStringUtf8());
+        Assert.Equal("second", decodedPayloads[1].Data.ToStringUtf8());
+        Assert.Equal(ByteString.CopyFromUtf8("true"), decodedPayloads[2].Metadata["__temporal_system_payload"]);
+        Assert.Equal("third", decodedPayloads[3].Data.ToStringUtf8());
+        Assert.Equal("fourth", decodedPayloads[4].Data.ToStringUtf8());
+        var decodedRequest = SignalWithStartWorkflowExecutionRequest.Parser.ParseFrom(decodedPayloads[2].Data);
+        Assert.Equal("system", decodedRequest.Input.Payloads_[0].Data.ToStringUtf8());
+    }
+
+    private static Payload CreateSystemEnvelope(string value) => CreateSystemEnvelope(
+        new SignalWithStartWorkflowExecutionRequest
+        {
+            Input = new() { Payloads_ = { new Payload { Data = ByteString.CopyFromUtf8(value) } } },
+        });
+
+    private static Payload CreateSystemEnvelope(IMessage message)
+    {
+        Assert.True(new BinaryProtoConverter().TryToPayload(message, out var payload));
+        SystemNexusPayloadVisitor.MarkSystemPayload(payload!);
+        return payload!;
     }
 
     private static WorkflowCodecHelper.WorkflowCodecContext CreateSimpleCodecContext(IPayloadCodec codec) => new(
@@ -316,5 +420,23 @@ public class WorkflowCodecHelperTests : TestBase
                 newP.Metadata["decoded"] = ByteString.Empty;
                 return newP;
             }).ToList());
+    }
+
+    private class PackingPayloadCodec : IPayloadCodec
+    {
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult<IReadOnlyCollection<Payload>>(new[]
+            {
+                new Payload
+                {
+                    Data = ByteString.CopyFromUtf8(string.Join("|", payloads.Select(p => p.Data.ToStringUtf8()))),
+                    Metadata = { ["packed"] = ByteString.CopyFromUtf8(payloads.Count.ToString()) },
+                },
+            });
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult<IReadOnlyCollection<Payload>>(payloads.SelectMany(payload =>
+                payload.Data.ToStringUtf8().Split('|').Select(value =>
+                    new Payload { Data = ByteString.CopyFromUtf8(value) })).ToList());
     }
 }

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -71,7 +71,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
             {
                 DevServerOptions = new()
                 {
-                    DownloadVersion = "v1.7.2-standalone-nexus-operations",
+                    DownloadVersion = "v1.7.4-standalone-nexus-operations",
                     ExtraArgs = new List<string>
                     {
                         // Disable search attribute cache

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -71,7 +71,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
             {
                 DevServerOptions = new()
                 {
-                    DownloadVersion = "v1.7.4-standalone-nexus-operations",
+                    DownloadVersion = "v1.7.2-standalone-nexus-operations",
                     ExtraArgs = new List<string>
                     {
                         // Disable search attribute cache

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -71,7 +71,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
             {
                 DevServerOptions = new()
                 {
-                    DownloadVersion = "v1.7.2-standalone-nexus-operations",
+                    DownloadVersion = "v1.8.3-server-1.32.0-162.0",
                     ExtraArgs = new List<string>
                     {
                         // Disable search attribute cache

--- a/tests/Temporalio.Tests/WorkflowEnvironment.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironment.cs
@@ -96,6 +96,7 @@ public sealed class WorkflowEnvironment : IAsyncLifetime, IAsyncDisposable
                         // Enable standalone activities
                         "--dynamic-config-value", "frontend.activityAPIsEnabled=true",
                         "--dynamic-config-value", "activity.enableStandalone=true",
+                        "--dynamic-config-value", "activity.enableCallbacks=true",
                         "--dynamic-config-value", "history.enableChasm=true",
                         "--dynamic-config-value", "history.enableTransitionHistory=true",
                         "--dynamic-config-value", "activity.startDelayEnabled=true",


### PR DESCRIPTION
## What changed

- Mark System Nexus envelopes when they are created.
- Detect marked envelopes anywhere workflow codecs visit a payload, so nested user payloads are encoded and decoded after an envelope is stored in a generic payload field.
- Keep unmarked payloads on the regular codec path and preserve batch codec behavior for ordinary payload collections.

## Blocked on server behavior

This stacked draft depends on #846. It must not be completed until the server marks System Nexus
operation result payloads as System envelopes too. The server currently returns an unmarked
binary-protobuf completion payload, which a workflow codec correctly treats as an ordinary payload
and may transform, making the outer response no longer parseable.
