### PR TITLE
chore: pin tool versions and add mise tasks

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "clangsharppinvokegenerator": {
+      "version": "20.1.2.1",
+      "commands": [
+        "ClangSharpPInvokeGenerator"
+      ],
+      "rollForward": true
+    },
+    "docfx": {
+      "version": "2.78.5",
+      "commands": [
+        "docfx"
+      ]
+    }
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,10 +37,23 @@ updates:
           - "OpenTelemetry*"
     # Dependencies of the shipped product projects (src/*) are kept on their
     # current versions to preserve low version floors for downstream consumers.
-    # Security updates still flow through, since update-types ignores don't
-    # apply to them. Build- and test-only dependencies are left updatable.
+    # The codegen tooling in .config/dotnet-tools.json is likewise pinned, since a
+    # new generator version rewrites checked-in generated code and needs a regen
+    # commit alongside it. Security updates still flow through, since update-types
+    # ignores don't apply to them. Other build- and test-only dependencies are
+    # left updatable. Entries are kept in alphabetical order.
     ignore:
       - dependency-name: "Amazon.Lambda.Core"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "ClangSharpPInvokeGenerator"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "docfx"
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,18 +70,11 @@ jobs:
         shell: bash
         run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
 
-      - name: Install nex-gen
-        if: ${{ matrix.checkTarget }}
-        run: cargo install --locked --version 0.1.5 --force nex-gen
-
       - name: Regen confirm unchanged
         if: ${{ matrix.checkTarget }}
+        shell: bash
         run: |
-          $ErrorActionPreference = 'Stop'
-          dotnet tool install --global --version '[20.1.2.1]' ClangSharpPInvokeGenerator
-          ClangSharpPInvokeGenerator @src/Temporalio/Bridge/GenerateInterop.rsp
-          dotnet run --project src/Temporalio.Api.Generator
-          dotnet run --project src/Temporalio.SystemNexus.Generator
+          mise run gen
           git add .
           git config --global core.safecrlf false
           git diff --cached > generator.diff
@@ -180,9 +173,7 @@ jobs:
 
       - name: Build docs
         if: ${{ matrix.docsTarget }}
-        run: |
-          dotnet tool update -g docfx
-          docfx src/Temporalio.ApiDoc/docfx.json --warningsAsErrors
+        run: mise run docs
 
       - name: Deploy docs
         # Only deploy on main merge, not in PRs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ document as your quick reference when submitting pull requests.
   Server or the time-skipping test server that is lazily downloaded and run as a sub-process on first
   use (see `Temporalio.Testing.WorkflowEnvironment`). No separate server setup is required for most
   tests.
+- Declaration lists in config files are kept alphabetized, case-insensitively and ignoring any
+  quoting. This covers `Directory.Packages.props`, each `ItemGroup` in `Directory.Build.props`,
+  `.config/dotnet-tools.json`, the `[tasks.*]` blocks in `mise.toml`, and the Dependabot `ignore`
+  list. Insert new entries in order rather than appending them.
 - The build treats warnings as errors (`TreatWarningsAsErrors`) and enables the full analyzer set
   (`AnalysisMode=AllEnabledByDefault`) plus StyleCop. A build that produces analyzer warnings will
   fail. Fix the underlying issue rather than suppressing it, unless a suppression is already the
@@ -56,8 +60,7 @@ dotnet run --project tests/Temporalio.Tests          # all tests
 dotnet run --project tests/Temporalio.Tests -- --help  # see runner options
 ```
 
-API documentation is generated with [docfx](https://dotnet.github.io/docfx/) via
-`docfx src/Temporalio.ApiDoc/docfx.json`.
+API documentation is generated with [docfx](https://dotnet.github.io/docfx/) via `mise run docs`.
 
 The following environment variables override the test environment to run against an external server:
 
@@ -84,7 +87,7 @@ The following environment variables override the test environment to run against
   them:
 
   ```bash
-  dotnet pack -c Debug /p:GenerateCompatibilitySuppressionFile=true
+  mise run apicompat:baseline
   ```
 
   Then review the diff to `src/Temporalio/CompatibilitySuppressions.xml` and keep only the intended
@@ -128,6 +131,8 @@ Reviewers will look for:
   - `tests/Temporalio.SimpleBench/`, `tests/Temporalio.SmokeTest*/` – benchmarks and smoke tests
 - `Directory.Build.props` – shared MSBuild properties
 - `Directory.Packages.props` – central package versions (this repo uses central package management).
+- `.config/dotnet-tools.json` – pinned .NET codegen tools (ClangSharpPInvokeGenerator, docfx).
+- `mise.toml` – pinned `protoc` and `nex-gen`, plus the `gen`/`docs` tasks CI runs.
 - `.editorconfig` – analyzer/StyleCop rule configuration and Temporal-specific overrides.
 - `README.md`, `CONTRIBUTING.md` – contributor and development guide.
 - `bin/`, `obj/`, `target/` – compiled output. You never need to look in here.
@@ -139,11 +144,12 @@ Reviewers will look for:
 - Workflow code must be deterministic. The README's "Workflow Logic Constraints" section (including
   ".NET Task Determinism") explains the rules and the Workflow-specific `.editorconfig` overrides —
   read it before changing Workflow internals.
-- The interop layer is regenerated from the C header with ClangSharpPInvokeGenerator:
-  `ClangSharpPInvokeGenerator @src/Temporalio/Bridge/GenerateInterop.rsp`.
-- Protobuf types are regenerated with `dotnet run --project src/Temporalio.Api.Generator` (requires
-  `protoc` on the `PATH`; use `protoc` 23.x for now). Regenerate and commit the output rather than
-  hand-editing generated files under `src/Temporalio/Api/`.
+- Generated code is regenerated with [mise](https://mise.jdx.dev/) tasks, which install their pinned
+  tools on first run: `mise run gen` for everything, or `mise run gen:api`
+  (`Temporalio.Api.*` protobuf types), `mise run gen:nexus` (system Nexus service bindings), and
+  `mise run gen:interop` (bridge interop layer from the C header) individually. Regenerate and commit
+  the output rather than hand-editing generated files; CI runs `mise run gen` and fails on any diff.
+  `gen:interop` only works on Windows since its generator ships Windows-only native `libclang`.
 - `src/Temporalio/Bridge/sdk-core` is a git submodule pointing at
   [`sdk-rust`](https://github.com/temporalio/sdk-rust); change it via the submodule, not by editing
   files in place.

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ Extensions:
   - [Code formatting](#code-formatting)
     - [VisualStudio Code](#visualstudio-code)
   - [Testing](#testing)
-  - [Rebuilding Rust extension and interop layer](#rebuilding-rust-extension-and-interop-layer)
-  - [Regenerating protos](#regenerating-protos)
+  - [Regenerating code](#regenerating-code)
   - [Regenerating API docs](#regenerating-api-docs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -1325,6 +1324,8 @@ Prerequisites:
 * [.NET SDK](https://learn.microsoft.com/en-us/dotnet/core/install/) — version pinned in [`global.json`](global.json)
 * [Rust](https://www.rust-lang.org/) (i.e. `cargo` on the `PATH`)
 * [Protobuf Compiler](https://protobuf.dev/) (i.e. `protoc` on the `PATH`)
+* [mise](https://mise.jdx.dev/getting-started.html) — running `mise install` in the repository root installs the
+  `protoc` version pinned in [`mise.toml`](mise.toml) and puts it on the `PATH`, matching what CI uses
 * This repository, cloned recursively
 
 With all prerequisites in place, run:
@@ -1380,35 +1381,45 @@ The following environment variables can be set to override the environment:
 * `TEMPORAL_TEST_CLIENT_CERT` - Optional, must be present if below is
 * `TEMPORAL_TEST_CLIENT_KEY` - Optional, must be present if above is
 
-### Rebuilding Rust extension and interop layer
+### Regenerating code
 
-To regen core interop from header, install
-[ClangSharpPInvokeGenerator](https://github.com/dotnet/ClangSharp#generating-bindings) like:
+Every generator is a [mise](https://mise.jdx.dev/) task. The .NET tools they need are pinned in
+[`.config/dotnet-tools.json`](.config/dotnet-tools.json) and the rest in [`mise.toml`](mise.toml). To regenerate
+everything the way CI does:
 
-    dotnet tool install --global ClangSharpPInvokeGenerator
+    mise run gen
 
-Then, run:
+Or regenerate a single piece:
 
-    ClangSharpPInvokeGenerator @src/Temporalio/Bridge/GenerateInterop.rsp
+* `mise run gen:api` - the `Temporalio.Api.*` protobuf types
+* `mise run gen:nexus` - the system Nexus workflow service bindings
+* `mise run gen:interop` - the bridge interop layer, from the `sdk-core` C header, using
+  [ClangSharpPInvokeGenerator](https://github.com/dotnet/ClangSharp#generating-bindings)
 
-The Rust DLL is built automatically when the project is built. `protoc` may need to be on the `PATH` to build the Rust
-DLL.
+Each task installs the tools it needs on first run, so nothing has to be installed globally. Run `mise tasks` to see
+them all. Commit the regenerated output rather than hand-editing generated files; CI runs `mise run gen` and fails if
+it produces a diff.
 
-This can be annoying to install on linux - so alternatively, publish your PR and you can download the
-patch from the windows build when it fails because of a mismatch. It uploads the patch as an artifact.
+`gen:interop` runs on Windows only, because the generator package ships native `libclang` binaries for Windows alone
+(it can be made to work on Linux, but it is annoying to set up). It is ordered last so the other generators still
+complete elsewhere.
 
-### Regenerating protos
+If you cannot run a generator locally, let CI produce the output for you. The "Regen confirm unchanged" step uploads a
+`generator-diff` artifact holding a single `generator.diff`, a unified diff of everything the regen changed. From the
+repository root:
 
-Must have `protoc` on the `PATH`. This project uses [mise](https://mise.jdx.dev/) to manage the `protoc` version,
-matching what CI uses. After [installing mise](https://mise.jdx.dev/getting-started.html), run `mise install` in the
-repository root to install the version pinned in [`mise.toml`](mise.toml) and put `protoc` on your `PATH`.
+    gh run download <run-id> -n generator-diff
+    git apply generator.diff
 
-Then:
+The artifact can also be downloaded as a zip from the Artifacts section of the workflow run page. Review the result and
+commit it as you would your own regen.
 
-    dotnet run --project src/Temporalio.Api.Generator
+The Rust DLL itself is built automatically when the project is built, and needs `protoc` on the `PATH` (see
+[Build](#build)).
 
 ### Regenerating API docs
 
-Install [docfx](https://dotnet.github.io/docfx/), then run:
+    mise run docs
 
-    docfx src/Temporalio.ApiDoc/docfx.json
+This builds the docs with [docfx](https://dotnet.github.io/docfx/) at the version pinned in
+[`.config/dotnet-tools.json`](.config/dotnet-tools.json).

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,45 @@ min_version = "2026.6.14"
 
 [tools]
 protoc = "23.4"
+
+# .NET tools are pinned in .config/dotnet-tools.json so Dependabot can see them.
+
+# Tasks are kept in alphabetical order, ignoring the quoting.
+
+[tasks."apicompat:baseline"]
+description = "Regenerate src/Temporalio/CompatibilitySuppressions.xml, then review the diff"
+run = "dotnet pack -c Debug /p:GenerateCompatibilitySuppressionFile=true"
+
+[tasks.docs]
+description = "Build the API documentation"
+depends = ["tools:restore"]
+run = "dotnet docfx src/Temporalio.ApiDoc/docfx.json --warningsAsErrors"
+
+[tasks.gen]
+description = "Regenerate all generated code"
+# The three outputs are independent. Interop goes last because it is the only one that
+# cannot run outside Windows, so the others still complete on a non-Windows machine.
+run = [
+  "mise run gen:api",
+  "mise run gen:nexus",
+  "mise run gen:interop",
+]
+
+[tasks."gen:api"]
+description = "Regenerate the Temporalio.Api.* protobuf types"
+run = "dotnet run --project src/Temporalio.Api.Generator"
+
+[tasks."gen:interop"]
+description = "Regenerate the bridge interop layer from the sdk-core C header (Windows only)"
+# ClangSharpPInvokeGenerator ships only Windows native libclang binaries.
+depends = ["tools:restore"]
+run = "dotnet clangsharppinvokegenerator @src/Temporalio/Bridge/GenerateInterop.rsp"
+
+[tasks."gen:nexus"]
+description = "Regenerate the system Nexus service bindings"
+tools = { "cargo:nex-gen" = "0.1.5" }
+run = "dotnet run --project src/Temporalio.SystemNexus.Generator"
+
+[tasks."tools:restore"]
+description = "Restore the .NET tools pinned in .config/dotnet-tools.json"
+run = "dotnet tool restore"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Moved tool versions from ci.yml to central locations.
- Create mise tool tasks for regenerating files, updating docs, and updating API baseline exclusions.
- Updated repo docs to better describe regeneration process and how to leverage CI to execute tools that have platform dependencies.

## Why?

Allow developers and CI to use the same tools and versions in a consistent manner.

## Checklist

1. How was this tested: local and CI

1. Any docs updates needed? No
