### PR TITLE
fix: workaround dotnet tool install rid package issue

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,18 +2,18 @@
   "version": 1,
   "isRoot": true,
   "tools": {
+    "docfx": {
+      "version": "2.78.5",
+      "commands": [
+        "docfx"
+      ]
+    },
     "clangsharppinvokegenerator": {
       "version": "20.1.2.1",
       "commands": [
         "ClangSharpPInvokeGenerator"
       ],
       "rollForward": true
-    },
-    "docfx": {
-      "version": "2.78.5",
-      "commands": [
-        "docfx"
-      ]
     }
   }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -43,4 +43,9 @@ run = "dotnet run --project src/Temporalio.SystemNexus.Generator"
 
 [tasks."tools:restore"]
 description = "Restore the .NET tools pinned in .config/dotnet-tools.json"
+# docfx must stay ahead of clangsharppinvokegenerator in the manifest. ClangSharp ships
+# RID-specific tool packages from 20.1.2.2 on, and `dotnet tool restore` then validates the
+# next manifest entry against ClangSharp's DotnetToolSettings.xml, failing the whole restore
+# with "the command docfx ... is not contained in the package with Package Id docfx".
+# See https://github.com/dotnet/sdk/issues/53783 (the manifest itself cannot hold comments).
 run = "dotnet tool restore"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Reorder the list of dotnet tools to avoid a installation bug in the .NET SDK.

## Why?

The .NET SDK has a bug where if a RID-specific tool package is installed before RID-neutral packages, information from the RID-specific tool package is propagated into the installs of the RID-neutral packages causing installation failures. See https://github.com/temporalio/sdk-dotnet/pull/816 as an example failure.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: CI

1. Any docs updates needed? No
