### PR TITLE
ci: extract shared build setup into a composite action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,73 @@
+name: Setup
+description: >
+  Common build setup: Rust toolchain, Rust cache for the sdk-core workspace, .NET
+  from global.json, the mise version pinned by min_version in mise.toml, the tools
+  mise.toml declares, and PROTOC. Callers that install their own tooling (a build
+  container, say) can set install to 'false' and read the version output.
+
+inputs:
+  install:
+    description: >
+      Set to 'false' to skip all tool installation and only resolve the pinned mise
+      version. The version output is set either way.
+    required: false
+    default: "true"
+  dotnet:
+    description: "Set to 'false' to skip the .NET install."
+    required: false
+    default: "true"
+  rust-cache-key:
+    description: "Extra key segment for Swatinem/rust-cache."
+    required: false
+    default: ""
+
+outputs:
+  version:
+    description: "The mise version pinned by min_version in mise.toml."
+    value: ${{ steps.mise-version.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      if: ${{ inputs.install != 'false' }}
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      with:
+        toolchain: stable
+
+    - name: Setup Rust cache
+      if: ${{ inputs.install != 'false' }}
+      # Fixed version due to https://github.com/Swatinem/rust-cache/issues/183#issuecomment-1893979126
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        workspaces: src/Temporalio/Bridge/sdk-core
+        key: ${{ inputs.rust-cache-key }}
+        cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
+
+    - name: Setup .NET
+      if: ${{ inputs.install != 'false' && inputs.dotnet != 'false' }}
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        global-json-file: global.json
+
+    - name: Read mise version
+      id: mise-version
+      shell: bash
+      run: |
+        version=$(sed -n 's/^min_version = "\([^"]*\)".*/\1/p' mise.toml)
+        if [ -z "$version" ]; then
+          echo "::error::Could not read min_version from mise.toml"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Run mise install
+      if: ${{ inputs.install != 'false' }}
+      uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
+      with:
+        version: ${{ steps.mise-version.outputs.version }}
+
+    - name: Set PROTOC
+      if: ${{ inputs.install != 'false' }}
+      shell: bash
+      run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" only covers .github/workflows. The composite actions under
+    # .github/actions pin `uses:` refs of their own, so they need their own
+    # entries or those pins are never updated.
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     cooldown:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,39 +36,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: src/Temporalio/Bridge/sdk-core
-          cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          global-json-file: global.json
-
-      - name: Read mise version
-        id: mise-version
-        shell: bash
-        run: |
-          version=$(sed -n 's/^min_version = "\([^"]*\)".*/\1/p' mise.toml)
-          if [ -z "$version" ]; then
-            echo "::error::Could not read min_version from mise.toml"
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Run mise install
-        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
-        with:
-          version: ${{ steps.mise-version.outputs.version }}
-
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Regen confirm unchanged
         if: ${{ matrix.checkTarget }}

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -71,42 +71,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Read mise version
-        id: mise-version
-        shell: bash
-        run: |
-          version=$(sed -n 's/^min_version = "\([^"]*\)".*/\1/p' mise.toml)
-          if [ -z "$version" ]; then
-            echo "::error::Could not read min_version from mise.toml"
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Install Rust
-        if: ${{ !matrix.container }}
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup
+        id: setup
+        uses: ./.github/actions/setup
         with:
-          toolchain: stable
-
-      - name: Setup Rust cache
-        if: ${{ !matrix.container }}
-        # Fixed version due to https://github.com/Swatinem/rust-cache/issues/183#issuecomment-1893979126
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: src/Temporalio/Bridge/sdk-core
-          key: ${{ matrix.os }}
-          cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
-
-      - name: Run mise install
-        if: ${{ !matrix.container }}
-        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
-        with:
-          version: ${{ steps.mise-version.outputs.version }}
-
-      - name: Set PROTOC
-        if: ${{ !matrix.container }}
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          # Container legs install their own tooling below, and only need the
+          # pinned mise version resolved here.
+          install: ${{ !matrix.container }}
+          dotnet: "false"
+          rust-cache-key: ${{ matrix.os }}
 
       - name: Build (non-Docker)
         if: ${{ !matrix.container }}
@@ -121,7 +94,7 @@ jobs:
             sh -c ' \
                 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y \
              && . $HOME/.cargo/env \
-             && curl https://mise.run | MISE_VERSION=v${{ steps.mise-version.outputs.version }} MISE_INSTALL_MUSL=1 sh \
+             && curl https://mise.run | MISE_VERSION=v${{ steps.setup.outputs.version }} MISE_INSTALL_MUSL=1 sh \
              && export PATH="$HOME/.local/bin:$PATH" \
              && mise trust /workspace/mise.toml \
              && mise install \
@@ -138,7 +111,7 @@ jobs:
                 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y \
              && . $HOME/.cargo/env \
              && apk add --no-cache build-base \
-             && curl https://mise.run | MISE_VERSION=v${{ steps.mise-version.outputs.version }} MISE_INSTALL_MUSL=1 sh \
+             && curl https://mise.run | MISE_VERSION=v${{ steps.setup.outputs.version }} MISE_INSTALL_MUSL=1 sh \
              && export PATH="$HOME/.local/bin:$PATH" \
              && mise trust /workspace/mise.toml \
              && mise install \

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -16,39 +16,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: src/Temporalio/Bridge/sdk-core
-          cache-bin: false # https://github.com/Swatinem/rust-cache/issues/341
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          global-json-file: global.json
-
-      - name: Read mise version
-        id: mise-version
-        shell: bash
-        run: |
-          version=$(sed -n 's/^min_version = "\([^"]*\)".*/\1/p' mise.toml)
-          if [ -z "$version" ]; then
-            echo "::error::Could not read min_version from mise.toml"
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Run mise install
-        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
-        with:
-          version: ${{ steps.mise-version.outputs.version }}
-
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Build
         run: dotnet build --configuration Release


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Refactor GitHub job setup into a single GitHub action
- Allow dependabot to update in-repo GitHub actions

## Why?

Less duplication of common GitHub job setup.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: CI
1. Any docs updates needed? No
