### PR TITLE
Test Cloud with ephemeral namespaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,15 +87,52 @@ jobs:
       - name: Confirm bench works
         run: dotnet run --project tests/Temporalio.SimpleBench/Temporalio.SimpleBench.csproj -- --workflow-count 5 --max-cached-workflows 100 --max-concurrent 100
 
+      - name: Generate Cloud test certificates
+        # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.
+        if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
+        shell: bash
+        run: |
+          cert_dir="$RUNNER_TEMP/cloud-test-certs"
+          mkdir "$cert_dir"
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -keyout "$cert_dir/ca.key" -out "$cert_dir/ca.pem" \
+            -subj '/CN=Temporal .NET SDK Cloud CI CA'
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout "$cert_dir/client.key" -out "$cert_dir/client.csr" \
+            -subj '/CN=Temporal .NET SDK Cloud CI'
+          openssl x509 -req -days 1 -in "$cert_dir/client.csr" \
+            -CA "$cert_dir/ca.pem" -CAkey "$cert_dir/ca.key" -CAcreateserial \
+            -out "$cert_dir/client.pem" -extfile <(printf 'extendedKeyUsage=clientAuth')
+          {
+            echo "TEMPORAL_CLOUD_CLIENT_CA_PATH=$cert_dir/ca.pem"
+            echo "TEMPORAL_TLS_CLIENT_CERT_PATH=$cert_dir/client.pem"
+            echo "TEMPORAL_TLS_CLIENT_KEY_PATH=$cert_dir/client.key"
+          } >> "$GITHUB_ENV"
+
+      - name: Create Cloud namespace
+        id: create-cloud-namespace
+        # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.
+        if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
+        env:
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+          TEMPORAL_CLIENT_CLOUD_API_VERSION: v0.19.1
+        run: dotnet run --project tests/Temporalio.Tests -- cloud-namespace create
+
       - name: Test cloud (mTLS)
         # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.
         if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
         env:
-          TEMPORAL_TEST_CLIENT_TARGET_HOST: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
-          TEMPORAL_TEST_CLIENT_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
-          TEMPORAL_TEST_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
-          TEMPORAL_TEST_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
+          TEMPORAL_TEST_ENV_CONFIG_SERVER: true
+          TEMPORAL_ADDRESS: ${{ steps.create-cloud-namespace.outputs.namespace }}.tmprl.cloud:7233
+          TEMPORAL_NAMESPACE: ${{ steps.create-cloud-namespace.outputs.namespace }}
         run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.ExecuteWorkflowAsync_Simple_Succeeds"
+
+      - name: Delete Cloud namespace
+        if: ${{ always() && matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') && steps.create-cloud-namespace.outputs.namespace != '' }}
+        env:
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+          TEMPORAL_CLIENT_CLOUD_API_VERSION: v0.19.1
+        run: dotnet run --project tests/Temporalio.Tests -- cloud-namespace delete "${{ steps.create-cloud-namespace.outputs.namespace }}"
 
       - name: Test cloud (API key)
         # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   build-lint-test:
     env:
       RestoreLockedMode: true
+      TEMPORAL_CLIENT_CLOUD_API_VERSION: v0.19.1
     strategy:
       fail-fast: false
       matrix:
@@ -87,9 +88,15 @@ jobs:
       - name: Confirm bench works
         run: dotnet run --project tests/Temporalio.SimpleBench/Temporalio.SimpleBench.csproj -- --workflow-count 5 --max-cached-workflows 100 --max-concurrent 100
 
-      - name: Generate Cloud test certificates
-        # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.
+      - name: Check Cloud test eligibility
+        id: cloud-test-eligibility
+        # Secrets are unavailable to Dependabot and pull requests from forks.
         if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
+        shell: bash
+        run: echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Cloud test certificates
+        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
         shell: bash
         run: |
           cert_dir="$RUNNER_TEMP/cloud-test-certs"
@@ -111,16 +118,13 @@ jobs:
 
       - name: Create Cloud namespace
         id: create-cloud-namespace
-        # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.
-        if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
+        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
         env:
           TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
-          TEMPORAL_CLIENT_CLOUD_API_VERSION: v0.19.1
         run: dotnet run --project tests/Temporalio.Tests -- cloud-namespace create
 
       - name: Test cloud (mTLS)
-        # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.
-        if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
+        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
         env:
           TEMPORAL_TEST_ENV_CONFIG_SERVER: true
           TEMPORAL_ADDRESS: ${{ steps.create-cloud-namespace.outputs.namespace }}.tmprl.cloud:7233
@@ -128,16 +132,21 @@ jobs:
         run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.ExecuteWorkflowAsync_Simple_Succeeds"
 
       - name: Delete Cloud namespace
-        if: ${{ always() && matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') && steps.create-cloud-namespace.outputs.namespace != '' }}
+        id: delete-cloud-namespace
+        if: ${{ always() && steps.cloud-test-eligibility.outputs.enabled == 'true' && steps.create-cloud-namespace.outputs.namespace != '' }}
+        continue-on-error: true
         env:
           TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
-          TEMPORAL_CLIENT_CLOUD_API_VERSION: v0.19.1
         run: dotnet run --project tests/Temporalio.Tests -- cloud-namespace delete "${{ steps.create-cloud-namespace.outputs.namespace }}"
 
+      - name: Report Cloud namespace cleanup failure
+        if: ${{ always() && steps.delete-cloud-namespace.outcome == 'failure' }}
+        shell: bash
+        run: echo "::warning title=Cloud namespace cleanup failed::Failed to delete Cloud namespace ${{ steps.create-cloud-namespace.outputs.namespace }}"
+
       - name: Test cloud (API key)
-        # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.
         # Uses API key auth to test auto-TLS feature (TLS auto-enabled when API key provided).
-        if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
+        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
         env:
           TEMPORAL_TEST_CLIENT_TARGET_HOST: ca-central-1.aws.api.temporal.io:7233
           TEMPORAL_TEST_CLIENT_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
@@ -145,12 +154,10 @@ jobs:
         run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.ExecuteWorkflowAsync_Simple_Succeeds"
 
       - name: Test cloud operations client
-        # Only supported in non-fork, non-Dependabot runs since secrets are not available in those contexts.
-        if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
+        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
         env:
           TEMPORAL_CLIENT_CLOUD_NAMESPACE: sdk-ci.a2dd6
           TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
-          TEMPORAL_CLIENT_CLOUD_API_VERSION: 2024-05-13-00
         run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.TemporalCloudOperationsClientTests.*"
 
       - name: Upload native symbols

--- a/tests/Temporalio.Tests/CloudNamespaceCommand.cs
+++ b/tests/Temporalio.Tests/CloudNamespaceCommand.cs
@@ -129,8 +129,8 @@ internal static class CloudNamespaceCommand
                 throw new TimeoutException($"Timed out waiting for Cloud operation {operationId}");
             }
 
-            // Honor the server hint so the control plane can throttle polling when needed.
-            var delay = operation.CheckDuration?.ToTimeSpan() ?? TimeSpan.Zero;
+            // Honor server guidance when present and avoid aggressive polling when it is absent.
+            var delay = operation.CheckDuration?.ToTimeSpan() ?? TimeSpan.FromSeconds(5);
             if (delay < TimeSpan.FromSeconds(1))
             {
                 delay = TimeSpan.FromSeconds(1);

--- a/tests/Temporalio.Tests/CloudNamespaceCommand.cs
+++ b/tests/Temporalio.Tests/CloudNamespaceCommand.cs
@@ -14,13 +14,13 @@ internal static class CloudNamespaceCommand
 
     public static async Task<int> RunAsync(string[] args)
     {
-        if (args is ["create"])
+        if (args.Length == 1 && args[0] == "create")
         {
             await CreateAsync();
         }
-        else if (args is ["delete", var namespaceName])
+        else if (args.Length == 2 && args[0] == "delete")
         {
-            await DeleteAsync(namespaceName);
+            await DeleteAsync(args[1]);
         }
         else
         {
@@ -96,7 +96,7 @@ internal static class CloudNamespaceCommand
             throw new InvalidOperationException($"Missing required environment variable {name}");
 
     private static async Task WaitForOperationAsync(
-        ITemporalCloudOperationsClient client,
+        TemporalCloudOperationsClient client,
         AsyncOperation? initialOperation)
     {
         var operationId = initialOperation?.Id;

--- a/tests/Temporalio.Tests/CloudNamespaceCommand.cs
+++ b/tests/Temporalio.Tests/CloudNamespaceCommand.cs
@@ -130,7 +130,7 @@ internal static class CloudNamespaceCommand
             }
 
             // Honor server guidance when present and avoid aggressive polling when it is absent.
-            var delay = operation.CheckDuration?.ToTimeSpan() ?? TimeSpan.FromSeconds(5);
+            var delay = operation.CheckDuration?.ToTimeSpan() ?? TimeSpan.FromSeconds(10);
             if (delay < TimeSpan.FromSeconds(1))
             {
                 delay = TimeSpan.FromSeconds(1);

--- a/tests/Temporalio.Tests/CloudNamespaceCommand.cs
+++ b/tests/Temporalio.Tests/CloudNamespaceCommand.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics;
+using Google.Protobuf;
+using Temporalio.Api.Cloud.CloudService.V1;
+using Temporalio.Api.Cloud.Namespace.V1;
+using Temporalio.Api.Cloud.Operation.V1;
+using Temporalio.Client;
+
+namespace Temporalio.Tests;
+
+internal static class CloudNamespaceCommand
+{
+    private const string CloudRegion = "aws-ca-central-1";
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromMinutes(10);
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        if (args is ["create"])
+        {
+            await CreateAsync();
+        }
+        else if (args is ["delete", var namespaceName])
+        {
+            await DeleteAsync(namespaceName);
+        }
+        else
+        {
+            throw new ArgumentException(
+                "Usage: Temporalio.Tests cloud-namespace create | delete <namespace>",
+                nameof(args));
+        }
+        return 0;
+    }
+
+    private static async Task CreateAsync()
+    {
+        var client = await ConnectAsync();
+        var namespaceName = $"sdk-dotnet-ci-{RequiredEnv("GITHUB_RUN_ID")}-{RequiredEnv("GITHUB_RUN_ATTEMPT")}";
+        var result = await client.CloudService.CreateNamespaceAsync(new()
+        {
+            AsyncOperationId = Guid.NewGuid().ToString(),
+            Spec = new NamespaceSpec
+            {
+                Name = namespaceName,
+                RetentionDays = 1,
+                MtlsAuth = new()
+                {
+                    AcceptedClientCa = ByteString.CopyFrom(
+                        await File.ReadAllBytesAsync(RequiredEnv("TEMPORAL_CLOUD_CLIENT_CA_PATH"))),
+                    Enabled = true,
+                },
+                Replicas = { new ReplicaSpec { Region = CloudRegion } },
+            },
+        });
+        if (string.IsNullOrEmpty(result.Namespace))
+        {
+            throw new InvalidOperationException("Create namespace response did not include a namespace");
+        }
+
+        // Persist the namespace before polling so cleanup can run if provisioning later fails.
+        await File.AppendAllTextAsync(
+            RequiredEnv("GITHUB_OUTPUT"),
+            $"namespace={result.Namespace}{Environment.NewLine}");
+        await WaitForOperationAsync(client, result.AsyncOperation);
+    }
+
+    private static async Task DeleteAsync(string namespaceName)
+    {
+        var client = await ConnectAsync();
+        var existing = await client.CloudService.GetNamespaceAsync(new() { Namespace = namespaceName });
+        var resourceVersion = existing.Namespace?.ResourceVersion;
+        if (string.IsNullOrEmpty(resourceVersion))
+        {
+            throw new InvalidOperationException(
+                $"Cloud namespace {namespaceName} did not include a resource version");
+        }
+
+        var result = await client.CloudService.DeleteNamespaceAsync(new()
+        {
+            Namespace = namespaceName,
+            ResourceVersion = resourceVersion,
+            AsyncOperationId = Guid.NewGuid().ToString(),
+        });
+        await WaitForOperationAsync(client, result.AsyncOperation);
+    }
+
+    private static Task<TemporalCloudOperationsClient> ConnectAsync() =>
+        TemporalCloudOperationsClient.ConnectAsync(
+            new(RequiredEnv("TEMPORAL_CLIENT_CLOUD_API_KEY"))
+            {
+                Version = RequiredEnv("TEMPORAL_CLIENT_CLOUD_API_VERSION"),
+            });
+
+    private static string RequiredEnv(string name) =>
+        Environment.GetEnvironmentVariable(name) is { Length: > 0 } value ?
+            value :
+            throw new InvalidOperationException($"Missing required environment variable {name}");
+
+    private static async Task WaitForOperationAsync(
+        ITemporalCloudOperationsClient client,
+        AsyncOperation? initialOperation)
+    {
+        var operationId = initialOperation?.Id;
+        if (string.IsNullOrEmpty(operationId))
+        {
+            throw new InvalidOperationException("Cloud operation response did not include an ID");
+        }
+
+        var elapsed = Stopwatch.StartNew();
+        while (true)
+        {
+            var response = await client.CloudService.GetAsyncOperationAsync(
+                new() { AsyncOperationId = operationId });
+            var operation = response.AsyncOperation ??
+                throw new InvalidOperationException($"Cloud operation {operationId} could not be read");
+            if (operation.State == AsyncOperation.Types.State.Fulfilled)
+            {
+                return;
+            }
+            if (operation.State is AsyncOperation.Types.State.Failed or
+                AsyncOperation.Types.State.Cancelled or
+                AsyncOperation.Types.State.Rejected)
+            {
+                throw new InvalidOperationException(
+                    $"Cloud operation {operationId} {operation.State}: {operation.FailureReason}");
+            }
+
+            var remaining = OperationTimeout - elapsed.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                throw new TimeoutException($"Timed out waiting for Cloud operation {operationId}");
+            }
+
+            // Honor the server hint so the control plane can throttle polling when needed.
+            var delay = operation.CheckDuration?.ToTimeSpan() ?? TimeSpan.Zero;
+            if (delay < TimeSpan.FromSeconds(1))
+            {
+                delay = TimeSpan.FromSeconds(1);
+            }
+            await Task.Delay(delay < remaining ? delay : remaining);
+        }
+    }
+}

--- a/tests/Temporalio.Tests/CloudNamespaceCommand.cs
+++ b/tests/Temporalio.Tests/CloudNamespaceCommand.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Google.Protobuf;
-using Temporalio.Api.Cloud.CloudService.V1;
 using Temporalio.Api.Cloud.Namespace.V1;
 using Temporalio.Api.Cloud.Operation.V1;
 using Temporalio.Client;

--- a/tests/Temporalio.Tests/Program.cs
+++ b/tests/Temporalio.Tests/Program.cs
@@ -6,8 +6,13 @@ public static class Program
 
     internal static bool Verbose { get; private set; }
 
-    public static int Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
+        if (args.Length > 0 && args[0] == "cloud-namespace")
+        {
+            return await CloudNamespaceCommand.RunAsync(args[1..]);
+        }
+
         InProc = true;
         Verbose = args.Contains("-verbose");
         // Always put self assembly as first arg if "--help" isn't first arg


### PR DESCRIPTION
## What was changed

**TLDR**: port of https://github.com/temporalio/sdk-python/pull/1731

Cloud CI now generates a short-lived certificate authority and client certificate, provisions an
ephemeral Temporal Cloud namespace that trusts that authority, and runs the existing mTLS workflow
smoke test through the envconfig-backed test harness. Namespace deletion runs even if provisioning
or the smoke test fails.

The namespace lifecycle command is hosted in the existing test executable and waits for Cloud
Operations API requests to reach a terminal state. The focused API-key and Cloud Operations client
tests remain unchanged.

## Why?

Enables isolation for parallel cloud CI runs

## Checklist

1. Closes N/A

2. How was this tested:

   - `dotnet format --verify-no-changes --no-restore`
   - `actionlint .github/workflows/ci.yml`
   - Certificate-chain verification
   - Ephemeral namespace creation, envconfig mTLS smoke execution, and deletion in GitHub Actions

3. Any docs updates needed?

   No. This is an internal test/CI change, so no changelog entry is needed.
