### PR TITLE
Classify and separate .NET tests for Cloud execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
   build-lint-test:
     env:
       RestoreLockedMode: true
-      TEMPORAL_CLIENT_CLOUD_API_VERSION: v0.19.1
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +22,6 @@ jobs:
             checkTarget: true
           - os: ubuntu-latest
             docsTarget: true
-            cloudTestTarget: true
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-arm
@@ -88,93 +86,6 @@ jobs:
       - name: Confirm bench works
         run: dotnet run --project tests/Temporalio.SimpleBench/Temporalio.SimpleBench.csproj -- --workflow-count 5 --max-cached-workflows 100 --max-concurrent 100
 
-      - name: Check Cloud test eligibility
-        id: cloud-test-eligibility
-        # Secrets are unavailable to Dependabot and pull requests from forks.
-        if: ${{ matrix.cloudTestTarget && github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
-        shell: bash
-        run: echo "enabled=true" >> "$GITHUB_OUTPUT"
-
-      - name: Generate Cloud test certificates
-        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
-        shell: bash
-        run: |
-          cert_dir="$RUNNER_TEMP/cloud-test-certs"
-          mkdir "$cert_dir"
-          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
-            -keyout "$cert_dir/ca.key" -out "$cert_dir/ca.pem" \
-            -subj '/CN=Temporal .NET SDK Cloud CI CA'
-          openssl req -newkey rsa:2048 -nodes \
-            -keyout "$cert_dir/client.key" -out "$cert_dir/client.csr" \
-            -subj '/CN=Temporal .NET SDK Cloud CI'
-          openssl x509 -req -days 1 -in "$cert_dir/client.csr" \
-            -CA "$cert_dir/ca.pem" -CAkey "$cert_dir/ca.key" -CAcreateserial \
-            -out "$cert_dir/client.pem" -extfile <(printf 'extendedKeyUsage=clientAuth')
-          {
-            echo "TEMPORAL_CLOUD_CLIENT_CA_PATH=$cert_dir/ca.pem"
-            echo "TEMPORAL_TLS_CLIENT_CERT_PATH=$cert_dir/client.pem"
-            echo "TEMPORAL_TLS_CLIENT_KEY_PATH=$cert_dir/client.key"
-          } >> "$GITHUB_ENV"
-
-      - name: Create Cloud namespace
-        id: create-cloud-namespace
-        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
-        env:
-          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
-        run: dotnet run --project tests/Temporalio.Tests -- cloud-namespace create
-
-      - name: Test cloud (mTLS)
-        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
-        env:
-          TEMPORAL_TEST_ENV_CONFIG_SERVER: true
-          TEMPORAL_ADDRESS: ${{ steps.create-cloud-namespace.outputs.namespace }}.tmprl.cloud:7233
-          TEMPORAL_NAMESPACE: ${{ steps.create-cloud-namespace.outputs.namespace }}
-        run: |
-          dotnet test tests/Temporalio.Tests/Temporalio.Tests.csproj --no-build \
-            --filter "CloudTest!=Excluded" \
-            --logger "console;verbosity=detailed" \
-            --logger "trx;LogFilePrefix=cloud-mtls-results" \
-            --results-directory tests/Temporalio.Tests/CloudTestResults \
-            --blame-crash -v n --blame-hang-timeout 10m
-
-      - name: Delete Cloud namespace
-        id: delete-cloud-namespace
-        if: ${{ always() && steps.cloud-test-eligibility.outputs.enabled == 'true' && steps.create-cloud-namespace.outputs.namespace != '' }}
-        continue-on-error: true
-        env:
-          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
-        run: dotnet run --project tests/Temporalio.Tests -- cloud-namespace delete "${{ steps.create-cloud-namespace.outputs.namespace }}"
-
-      - name: Report Cloud namespace cleanup failure
-        if: ${{ always() && steps.delete-cloud-namespace.outcome == 'failure' }}
-        shell: bash
-        run: echo "::warning title=Cloud namespace cleanup failed::Failed to delete Cloud namespace ${{ steps.create-cloud-namespace.outputs.namespace }}"
-
-      - name: Upload Cloud test results
-        if: ${{ !cancelled() && steps.cloud-test-eligibility.outputs.enabled == 'true' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: cloud-mtls-test-results-${{ matrix.os }}
-          path: tests/Temporalio.Tests/CloudTestResults/**/*.trx
-          if-no-files-found: warn
-          overwrite: true
-
-      - name: Test cloud (API key)
-        # Uses API key auth to test auto-TLS feature (TLS auto-enabled when API key provided).
-        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
-        env:
-          TEMPORAL_TEST_CLIENT_TARGET_HOST: ca-central-1.aws.api.temporal.io:7233
-          TEMPORAL_TEST_CLIENT_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
-          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
-        run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.ExecuteWorkflowAsync_Simple_Succeeds"
-
-      - name: Test cloud operations client
-        if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
-        env:
-          TEMPORAL_CLIENT_CLOUD_NAMESPACE: sdk-ci.a2dd6
-          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
-        run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.TemporalCloudOperationsClientTests.*"
-
       - name: Upload native symbols
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() }}
@@ -210,6 +121,101 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
         run: npx vercel deploy src/Temporalio.ApiDoc/_site --token ${{ secrets.VERCEL_TOKEN }} --prod --yes
+
+  cloud-test:
+    # Secrets are unavailable to Dependabot and pull requests from forks.
+    if: ${{ github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-dotnet') }}
+    env:
+      RestoreLockedMode: true
+      TEMPORAL_CLIENT_CLOUD_API_VERSION: v0.19.1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825a76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      # Required because the mTLS suite deliberately uses --no-build.
+      - name: Build
+        run: dotnet build
+
+      - name: Generate Cloud test certificates
+        shell: bash
+        run: |
+          cert_dir="$RUNNER_TEMP/cloud-test-certs"
+          mkdir "$cert_dir"
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -keyout "$cert_dir/ca.key" -out "$cert_dir/ca.pem" \
+            -subj '/CN=Temporal .NET SDK Cloud CI CA'
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout "$cert_dir/client.key" -out "$cert_dir/client.csr" \
+            -subj '/CN=Temporal .NET SDK Cloud CI'
+          openssl x509 -req -days 1 -in "$cert_dir/client.csr" \
+            -CA "$cert_dir/ca.pem" -CAkey "$cert_dir/ca.key" -CAcreateserial \
+            -out "$cert_dir/client.pem" -extfile <(printf 'extendedKeyUsage=clientAuth')
+          {
+            echo "TEMPORAL_CLOUD_CLIENT_CA_PATH=$cert_dir/ca.pem"
+            echo "TEMPORAL_TLS_CLIENT_CERT_PATH=$cert_dir/client.pem"
+            echo "TEMPORAL_TLS_CLIENT_KEY_PATH=$cert_dir/client.key"
+          } >> "$GITHUB_ENV"
+
+      - name: Create Cloud namespace
+        id: create-cloud-namespace
+        env:
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+        run: dotnet run --project tests/Temporalio.Tests -- cloud-namespace create
+
+      - name: Test cloud (mTLS)
+        env:
+          TEMPORAL_TEST_ENV_CONFIG_SERVER: true
+          TEMPORAL_ADDRESS: ${{ steps.create-cloud-namespace.outputs.namespace }}.tmprl.cloud:7233
+          TEMPORAL_NAMESPACE: ${{ steps.create-cloud-namespace.outputs.namespace }}
+        run: |
+          dotnet test tests/Temporalio.Tests/Temporalio.Tests.csproj --no-build \
+            --filter "CloudTest!=Excluded" \
+            --logger "console;verbosity=detailed" \
+            --logger "trx;LogFilePrefix=cloud-mtls-results" \
+            --results-directory tests/Temporalio.Tests/CloudTestResults \
+            --blame-crash -v n --blame-hang-timeout 10m
+
+      - name: Delete Cloud namespace
+        id: delete-cloud-namespace
+        if: ${{ always() && steps.create-cloud-namespace.outputs.namespace != '' }}
+        continue-on-error: true
+        env:
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+        run: dotnet run --project tests/Temporalio.Tests -- cloud-namespace delete "${{ steps.create-cloud-namespace.outputs.namespace }}"
+
+      - name: Report Cloud namespace cleanup failure
+        if: ${{ always() && steps.delete-cloud-namespace.outcome == 'failure' }}
+        shell: bash
+        run: echo "::warning title=Cloud namespace cleanup failed::Failed to delete Cloud namespace ${{ steps.create-cloud-namespace.outputs.namespace }}"
+
+      - name: Upload Cloud test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cloud-mtls-test-results-ubuntu-latest
+          path: tests/Temporalio.Tests/CloudTestResults/**/*.trx
+          if-no-files-found: warn
+          overwrite: true
+
+      - name: Test cloud (API key)
+        # Uses API key auth to test auto-TLS feature (TLS auto-enabled when API key provided).
+        env:
+          TEMPORAL_TEST_CLIENT_TARGET_HOST: ca-central-1.aws.api.temporal.io:7233
+          TEMPORAL_TEST_CLIENT_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+        run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.ExecuteWorkflowAsync_Simple_Succeeds"
+
+      - name: Test cloud operations client
+        env:
+          TEMPORAL_CLIENT_CLOUD_NAMESPACE: sdk-ci.a2dd6
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+        run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.TemporalCloudOperationsClientTests.*"
 
   # Runs the sdk features repo tests with this repo's current SDK code
   features-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825a76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,13 @@ jobs:
           TEMPORAL_TEST_ENV_CONFIG_SERVER: true
           TEMPORAL_ADDRESS: ${{ steps.create-cloud-namespace.outputs.namespace }}.tmprl.cloud:7233
           TEMPORAL_NAMESPACE: ${{ steps.create-cloud-namespace.outputs.namespace }}
-        run: dotnet run --project tests/Temporalio.Tests -- -verbose -method "*.ExecuteWorkflowAsync_Simple_Succeeds"
+        run: |
+          dotnet test tests/Temporalio.Tests/Temporalio.Tests.csproj --no-build \
+            --filter "CloudTest!=Excluded" \
+            --logger "console;verbosity=detailed" \
+            --logger "trx;LogFilePrefix=cloud-mtls-results" \
+            --results-directory tests/Temporalio.Tests/CloudTestResults \
+            --blame-crash -v n --blame-hang-timeout 10m
 
       - name: Delete Cloud namespace
         id: delete-cloud-namespace
@@ -143,6 +149,15 @@ jobs:
         if: ${{ always() && steps.delete-cloud-namespace.outcome == 'failure' }}
         shell: bash
         run: echo "::warning title=Cloud namespace cleanup failed::Failed to delete Cloud namespace ${{ steps.create-cloud-namespace.outputs.namespace }}"
+
+      - name: Upload Cloud test results
+        if: ${{ !cancelled() && steps.cloud-test-eligibility.outputs.enabled == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cloud-mtls-test-results-${{ matrix.os }}
+          path: tests/Temporalio.Tests/CloudTestResults/**/*.trx
+          if-no-files-found: warn
+          overwrite: true
 
       - name: Test cloud (API key)
         # Uses API key auth to test auto-TLS feature (TLS auto-enabled when API key provided).

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 bin/
 obj/
 /src/Temporalio/Bridge/target
+/tests/Temporalio.Tests/CloudTestResults
 /tests/Temporalio.Tests/TestResults
 /tests/golangworker/golangworker
 /.vs

--- a/README.md
+++ b/README.md
@@ -1374,6 +1374,19 @@ Extra args can be added after `--`, e.g. `-- -verbose` would show verbose logs a
 options. If the arguments are anything but `--help`, the current assembly is prepended to the args before sending to the
 xUnit runner.
 
+Tests are eligible to run against Temporal Cloud unless they have a `CloudTestExclusion` attribute. Run or list the
+Cloud-eligible tests with:
+
+    dotnet test tests/Temporalio.Tests --filter 'CloudTest!=Excluded'
+    dotnet test tests/Temporalio.Tests --list-tests --filter 'CloudTest!=Excluded'
+
+To inventory excluded tests, filter on `CloudTest=Excluded`, or filter on `CloudTestExclusionReason` to inspect a
+particular category:
+
+* `RequiresLocalServer` for tests of local server behavior
+* `CloudUnavailable` for functionality or permissions unavailable in Cloud CI
+* `NeedsCloudAdaptation` for otherwise compatible tests that still need adaptation
+
 The following environment variables can be set to override the environment:
 
 * `TEMPORAL_TEST_CLIENT_TARGET_HOST` - This must be set for any of the variables below to apply

--- a/README.md
+++ b/README.md
@@ -1380,12 +1380,8 @@ Cloud-eligible tests with:
     dotnet test tests/Temporalio.Tests --filter "CloudTest!=Excluded"
     dotnet test tests/Temporalio.Tests --list-tests --filter "CloudTest!=Excluded"
 
-To inventory excluded tests, filter on `CloudTest=Excluded`, or filter on `CloudTestExclusionReason` to inspect a
-particular category:
-
-* `RequiresLocalServer` for tests of local server behavior
-* `RequiresCloudProvisioning` for functionality or permissions unavailable in Cloud CI
-* `NeedsCloudAdaptation` for otherwise compatible tests that still need adaptation
+To inventory excluded tests, filter on `CloudTest=Excluded`, or filter on
+[`CloudTestExclusionReason`](tests/Temporalio.Tests/CloudTestExclusionReason.cs) to inspect a particular category.
 
 The following environment variables can be set to override the environment:
 

--- a/README.md
+++ b/README.md
@@ -1384,7 +1384,7 @@ To inventory excluded tests, filter on `CloudTest=Excluded`, or filter on `Cloud
 particular category:
 
 * `RequiresLocalServer` for tests of local server behavior
-* `CloudUnavailable` for functionality or permissions unavailable in Cloud CI
+* `RequiresCloudProvisioning` for functionality or permissions unavailable in Cloud CI
 * `NeedsCloudAdaptation` for otherwise compatible tests that still need adaptation
 
 The following environment variables can be set to override the environment:

--- a/README.md
+++ b/README.md
@@ -1377,8 +1377,8 @@ xUnit runner.
 Tests are eligible to run against Temporal Cloud unless they have a `CloudTestExclusion` attribute. Run or list the
 Cloud-eligible tests with:
 
-    dotnet test tests/Temporalio.Tests --filter 'CloudTest!=Excluded'
-    dotnet test tests/Temporalio.Tests --list-tests --filter 'CloudTest!=Excluded'
+    dotnet test tests/Temporalio.Tests --filter "CloudTest!=Excluded"
+    dotnet test tests/Temporalio.Tests --list-tests --filter "CloudTest!=Excluded"
 
 To inventory excluded tests, filter on `CloudTest=Excluded`, or filter on `CloudTestExclusionReason` to inspect a
 particular category:

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -305,6 +305,9 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Cloud visibility may return a next-page token that resolves to an empty final page.")]
     public async Task ListActivitiesAsync_SimpleList_IsAccurate()
     {
         await ExecuteActivityWorkerAsync(SimpleActivityAsync, async taskQueue =>

--- a/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
@@ -12,7 +12,9 @@ using Temporalio.Workflows;
 using Xunit;
 using Xunit.Abstractions;
 
-[CloudTestExclusion(CloudTestExclusionReason.RequiresCloudProvisioning)]
+[CloudTestExclusion(
+    CloudTestExclusionReason.RequiresCloudProvisioning,
+    "Requires a Cloud namespace with Standalone Nexus Operations enabled.")]
 public class TemporalClientNexusOperationTests : WorkflowEnvironmentTestBase
 {
     public TemporalClientNexusOperationTests(ITestOutputHelper output, WorkflowEnvironment env)

--- a/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
@@ -12,6 +12,7 @@ using Temporalio.Workflows;
 using Xunit;
 using Xunit.Abstractions;
 
+[CloudTestExclusion(CloudTestExclusionReason.CloudUnavailable)]
 public class TemporalClientNexusOperationTests : WorkflowEnvironmentTestBase
 {
     public TemporalClientNexusOperationTests(ITestOutputHelper output, WorkflowEnvironment env)

--- a/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientNexusOperationTests.cs
@@ -12,7 +12,7 @@ using Temporalio.Workflows;
 using Xunit;
 using Xunit.Abstractions;
 
-[CloudTestExclusion(CloudTestExclusionReason.CloudUnavailable)]
+[CloudTestExclusion(CloudTestExclusionReason.RequiresCloudProvisioning)]
 public class TemporalClientNexusOperationTests : WorkflowEnvironmentTestBase
 {
     public TemporalClientNexusOperationTests(ITestOutputHelper output, WorkflowEnvironment env)

--- a/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
@@ -17,7 +17,9 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Relies on schedule state and visibility becoming immediately consistent.")]
     public async Task CreateScheduleAsync_Basics_Succeeds()
     {
         await TestUtils.AssertNoSchedulesAsync(Client);
@@ -360,7 +362,9 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Relies on backfill action counts becoming immediately consistent.")]
     public async Task CreateScheduleAsync_Backfill_CreatesProperActions()
     {
         await TestUtils.AssertNoSchedulesAsync(Client);

--- a/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientScheduleTests.cs
@@ -17,6 +17,7 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task CreateScheduleAsync_Basics_Succeeds()
     {
         await TestUtils.AssertNoSchedulesAsync(Client);
@@ -359,6 +360,7 @@ public class TemporalClientScheduleTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task CreateScheduleAsync_Backfill_CreatesProperActions()
     {
         await TestUtils.AssertNoSchedulesAsync(Client);

--- a/tests/Temporalio.Tests/Client/TemporalClientTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientTests.cs
@@ -60,7 +60,9 @@ public class TemporalClientTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresLocalServer,
+        "Starts a development server to invoke every RPC method.")]
     public async Task ConnectAsync_Connection_AllGrpcCallsSupported()
     {
         // The approach we'll take here is to just start the dev server and reflectively make each

--- a/tests/Temporalio.Tests/Client/TemporalClientTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientTests.cs
@@ -60,6 +60,7 @@ public class TemporalClientTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
     public async Task ConnectAsync_Connection_AllGrpcCallsSupported()
     {
         // The approach we'll take here is to just start the dev server and reflectively make each

--- a/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
@@ -201,7 +201,9 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Requires custom search attributes that the Cloud harness does not provision.")]
     public async Task StartWorkflowAsync_SearchAttributesAndMemo_AreSetProperly()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -243,7 +245,9 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Relies on completed workflows becoming immediately visible.")]
     public async Task ListWorkflowsAsync_RunWithHistoryFetch_IsAccurate()
     {
         // Run 5 workflows. Use the same workflow ID over and over to make sure we don't clash with
@@ -331,7 +335,9 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Relies on completed workflows becoming immediately visible.")]
     public async Task ListWorkflowsAsync_ManualPaging_IsAccurate()
     {
         var workflowId = $"workflow-{Guid.NewGuid()}";

--- a/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientWorkflowTests.cs
@@ -201,6 +201,7 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task StartWorkflowAsync_SearchAttributesAndMemo_AreSetProperly()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -242,6 +243,7 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ListWorkflowsAsync_RunWithHistoryFetch_IsAccurate()
     {
         // Run 5 workflows. Use the same workflow ID over and over to make sure we don't clash with
@@ -329,6 +331,7 @@ public class TemporalClientWorkflowTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ListWorkflowsAsync_ManualPaging_IsAccurate()
     {
         var workflowId = $"workflow-{Guid.NewGuid()}";

--- a/tests/Temporalio.Tests/CloudTestExclusionAttribute.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionAttribute.cs
@@ -8,7 +8,13 @@ using Xunit.Sdk;
     "Temporalio.Tests")]
 public sealed class CloudTestExclusionAttribute : Attribute, ITraitAttribute
 {
-    public CloudTestExclusionAttribute(CloudTestExclusionReason reason) => Reason = reason;
+    public CloudTestExclusionAttribute(CloudTestExclusionReason reason, string note)
+    {
+        Reason = reason;
+        Note = note;
+    }
 
     public CloudTestExclusionReason Reason { get; }
+
+    public string Note { get; }
 }

--- a/tests/Temporalio.Tests/CloudTestExclusionAttribute.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionAttribute.cs
@@ -1,0 +1,14 @@
+namespace Temporalio.Tests;
+
+using Xunit.Sdk;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+[TraitDiscoverer(
+    "Temporalio.Tests.CloudTestExclusionDiscoverer",
+    "Temporalio.Tests")]
+public sealed class CloudTestExclusionAttribute : Attribute, ITraitAttribute
+{
+    public CloudTestExclusionAttribute(CloudTestExclusionReason reason) => Reason = reason;
+
+    public CloudTestExclusionReason Reason { get; }
+}

--- a/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
@@ -15,7 +15,7 @@ public sealed class CloudTestExclusionDiscoverer : ITraitDiscoverer
                 nameof(CloudTestExclusionReason.NeedsCloudAdaptation),
             CloudTestExclusionReason.RequiresLocalServer =>
                 nameof(CloudTestExclusionReason.RequiresLocalServer),
-            _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unknown reason"),
+            _ => throw new InvalidOperationException($"Unknown exclusion reason: {reason}"),
         };
         yield return new("CloudTest", "Excluded");
         yield return new("CloudTestExclusionReason", reasonName);

--- a/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
@@ -1,0 +1,23 @@
+namespace Temporalio.Tests;
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+public sealed class CloudTestExclusionDiscoverer : ITraitDiscoverer
+{
+    public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+    {
+        var reason = (CloudTestExclusionReason)traitAttribute.GetConstructorArguments().Single();
+        var reasonName = reason switch
+        {
+            CloudTestExclusionReason.CloudUnavailable => nameof(CloudTestExclusionReason.CloudUnavailable),
+            CloudTestExclusionReason.NeedsCloudAdaptation =>
+                nameof(CloudTestExclusionReason.NeedsCloudAdaptation),
+            CloudTestExclusionReason.RequiresLocalServer =>
+                nameof(CloudTestExclusionReason.RequiresLocalServer),
+            _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unknown reason"),
+        };
+        yield return new("CloudTest", "Excluded");
+        yield return new("CloudTestExclusionReason", reasonName);
+    }
+}

--- a/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
@@ -7,7 +7,7 @@ public sealed class CloudTestExclusionDiscoverer : ITraitDiscoverer
 {
     public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
     {
-        var reason = (CloudTestExclusionReason)traitAttribute.GetConstructorArguments().Single();
+        var reason = (CloudTestExclusionReason)traitAttribute.GetConstructorArguments().First();
         if (!Enum.IsDefined(typeof(CloudTestExclusionReason), reason))
         {
             throw new InvalidOperationException($"Unknown exclusion reason: {reason}");

--- a/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
@@ -10,7 +10,8 @@ public sealed class CloudTestExclusionDiscoverer : ITraitDiscoverer
         var reason = (CloudTestExclusionReason)traitAttribute.GetConstructorArguments().Single();
         var reasonName = reason switch
         {
-            CloudTestExclusionReason.CloudUnavailable => nameof(CloudTestExclusionReason.CloudUnavailable),
+            CloudTestExclusionReason.RequiresCloudProvisioning =>
+                nameof(CloudTestExclusionReason.RequiresCloudProvisioning),
             CloudTestExclusionReason.NeedsCloudAdaptation =>
                 nameof(CloudTestExclusionReason.NeedsCloudAdaptation),
             CloudTestExclusionReason.RequiresLocalServer =>

--- a/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionDiscoverer.cs
@@ -8,17 +8,11 @@ public sealed class CloudTestExclusionDiscoverer : ITraitDiscoverer
     public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
     {
         var reason = (CloudTestExclusionReason)traitAttribute.GetConstructorArguments().Single();
-        var reasonName = reason switch
+        if (!Enum.IsDefined(typeof(CloudTestExclusionReason), reason))
         {
-            CloudTestExclusionReason.RequiresCloudProvisioning =>
-                nameof(CloudTestExclusionReason.RequiresCloudProvisioning),
-            CloudTestExclusionReason.NeedsCloudAdaptation =>
-                nameof(CloudTestExclusionReason.NeedsCloudAdaptation),
-            CloudTestExclusionReason.RequiresLocalServer =>
-                nameof(CloudTestExclusionReason.RequiresLocalServer),
-            _ => throw new InvalidOperationException($"Unknown exclusion reason: {reason}"),
-        };
+            throw new InvalidOperationException($"Unknown exclusion reason: {reason}");
+        }
         yield return new("CloudTest", "Excluded");
-        yield return new("CloudTestExclusionReason", reasonName);
+        yield return new("CloudTestExclusionReason", reason.ToString());
     }
 }

--- a/tests/Temporalio.Tests/CloudTestExclusionReason.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionReason.cs
@@ -1,0 +1,8 @@
+namespace Temporalio.Tests;
+
+public enum CloudTestExclusionReason
+{
+    CloudUnavailable,
+    NeedsCloudAdaptation,
+    RequiresLocalServer,
+}

--- a/tests/Temporalio.Tests/CloudTestExclusionReason.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionReason.cs
@@ -1,8 +1,24 @@
 namespace Temporalio.Tests;
 
+/// <summary>
+/// Reasons tests are excluded from Temporal Cloud test execution.
+/// </summary>
 public enum CloudTestExclusionReason
 {
-    CloudUnavailable,
+    /// <summary>
+    /// The test requires a Temporal Cloud capability that the test harness cannot provision or a
+    /// feature that is not yet available in Temporal Cloud.
+    /// </summary>
+    RequiresCloudProvisioning,
+
+    /// <summary>
+    /// The test needs setup or assertions adapted for the Temporal Cloud environment.
+    /// </summary>
     NeedsCloudAdaptation,
+
+    /// <summary>
+    /// The test inherently requires one or more local Temporal Server instances. For example, it
+    /// may start a dev or time-skipping server or customize server configuration.
+    /// </summary>
     RequiresLocalServer,
 }

--- a/tests/Temporalio.Tests/CloudTestExclusionTests.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionTests.cs
@@ -8,8 +8,8 @@ public class CloudTestExclusionTests
 {
     [Theory]
     [InlineData(
-        nameof(CloudUnavailable),
-        nameof(CloudTestExclusionReason.CloudUnavailable))]
+        nameof(RequiresCloudProvisioning),
+        nameof(CloudTestExclusionReason.RequiresCloudProvisioning))]
     [InlineData(
         nameof(NeedsCloudAdaptation),
         nameof(CloudTestExclusionReason.NeedsCloudAdaptation))]
@@ -50,8 +50,8 @@ public class CloudTestExclusionTests
             attr => attr.AttributeType == typeof(CloudTestExclusionAttribute)));
     }
 
-    [CloudTestExclusion(CloudTestExclusionReason.CloudUnavailable)]
-    private void CloudUnavailable()
+    [CloudTestExclusion(CloudTestExclusionReason.RequiresCloudProvisioning)]
+    private void RequiresCloudProvisioning()
     {
     }
 

--- a/tests/Temporalio.Tests/CloudTestExclusionTests.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionTests.cs
@@ -50,22 +50,30 @@ public class CloudTestExclusionTests
             attr => attr.AttributeType == typeof(CloudTestExclusionAttribute)));
     }
 
-    [CloudTestExclusion(CloudTestExclusionReason.RequiresCloudProvisioning)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresCloudProvisioning,
+        "Provides attribute metadata for the discoverer test.")]
     private void RequiresCloudProvisioning()
     {
     }
 
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Provides attribute metadata for the discoverer test.")]
     private void NeedsCloudAdaptation()
     {
     }
 
-    [CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresLocalServer,
+        "Provides attribute metadata for the discoverer test.")]
     private void RequiresLocalServer()
     {
     }
 
-    [CloudTestExclusion((CloudTestExclusionReason)int.MaxValue)]
+    [CloudTestExclusion(
+        (CloudTestExclusionReason)int.MaxValue,
+        "Provides attribute metadata for the discoverer test.")]
     private void UnknownReason()
     {
     }

--- a/tests/Temporalio.Tests/CloudTestExclusionTests.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionTests.cs
@@ -1,0 +1,73 @@
+namespace Temporalio.Tests;
+
+using System.Reflection;
+using Xunit;
+using Xunit.Sdk;
+
+public class CloudTestExclusionTests
+{
+    [Theory]
+    [InlineData(
+        nameof(CloudUnavailable),
+        nameof(CloudTestExclusionReason.CloudUnavailable))]
+    [InlineData(
+        nameof(NeedsCloudAdaptation),
+        nameof(CloudTestExclusionReason.NeedsCloudAdaptation))]
+    [InlineData(
+        nameof(RequiresLocalServer),
+        nameof(CloudTestExclusionReason.RequiresLocalServer))]
+    public void GetTraits_Reason_GetsExclusionAndReasonTraits(
+        string methodName,
+        string expectedReasonName)
+    {
+        Assert.Equal(
+            new Dictionary<string, string>
+            {
+                ["CloudTest"] = "Excluded",
+                ["CloudTestExclusionReason"] = expectedReasonName,
+            },
+            new CloudTestExclusionDiscoverer().
+                GetTraits(GetAttributeInfo(methodName)).
+                ToDictionary(pair => pair.Key, pair => pair.Value));
+    }
+
+    [Fact]
+    public void GetTraits_UnknownReason_Throws()
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new CloudTestExclusionDiscoverer().
+                GetTraits(GetAttributeInfo(nameof(UnknownReason))).
+                ToList());
+        Assert.Equal("reason", exception.ParamName);
+    }
+
+    private static ReflectionAttributeInfo GetAttributeInfo(string methodName)
+    {
+        var method = typeof(CloudTestExclusionTests).GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic) ??
+            throw new InvalidOperationException($"Missing test method {methodName}");
+        return new(method.CustomAttributes.Single(
+            attr => attr.AttributeType == typeof(CloudTestExclusionAttribute)));
+    }
+
+    [CloudTestExclusion(CloudTestExclusionReason.CloudUnavailable)]
+    private void CloudUnavailable()
+    {
+    }
+
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    private void NeedsCloudAdaptation()
+    {
+    }
+
+    [CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
+    private void RequiresLocalServer()
+    {
+    }
+
+    [CloudTestExclusion((CloudTestExclusionReason)int.MaxValue)]
+    private void UnknownReason()
+    {
+    }
+}

--- a/tests/Temporalio.Tests/CloudTestExclusionTests.cs
+++ b/tests/Temporalio.Tests/CloudTestExclusionTests.cs
@@ -34,11 +34,10 @@ public class CloudTestExclusionTests
     [Fact]
     public void GetTraits_UnknownReason_Throws()
     {
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.Throws<InvalidOperationException>(() =>
             new CloudTestExclusionDiscoverer().
                 GetTraits(GetAttributeInfo(nameof(UnknownReason))).
                 ToList());
-        Assert.Equal("reason", exception.ParamName);
     }
 
     private static ReflectionAttributeInfo GetAttributeInfo(string methodName)

--- a/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
+++ b/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
@@ -11,6 +11,8 @@ namespace Temporalio.Tests.Common.EnvConfig
     /// Environment configuration tests following Python/TypeScript patterns for cross-SDK consistency.
     /// Comprehensive test suite covering all aspects of environment configuration.
     /// </summary>
+    // Tests whose controlled inputs are changed by the Cloud harness's process-wide TEMPORAL_*
+    // variables are excluded individually below.
     public class ClientConfigTests : TestBase
     {
         // Test fixtures matching Python/TypeScript patterns
@@ -58,6 +60,7 @@ client_key_data = ""client-key-data""
 
         // === PROFILE LOADING TESTS (7 tests) ===
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_From_File_Default()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -78,6 +81,7 @@ client_key_data = ""client-key-data""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_From_File_Custom()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -101,6 +105,7 @@ client_key_data = ""client-key-data""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_From_Data_Default()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -119,6 +124,7 @@ client_key_data = ""client-key-data""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_From_Data_Custom()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -417,6 +423,7 @@ x-custom-header = ""custom-value""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void DefaultProfileNotFoundReturnsEmptyProfile()
         {
             var toml = @"
@@ -440,6 +447,7 @@ address = ""other-address""
 
         // === TLS CONFIGURATION TESTS (7 tests) ===
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_Api_Key_Enables_Tls()
         {
             var toml = @"
@@ -466,6 +474,7 @@ api_key = ""my-api-key""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_Tls_Options()
         {
             var source = DataSource.FromUTF8String(TomlConfigTlsDetailed);
@@ -501,6 +510,7 @@ api_key = ""my-api-key""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_Tls_From_Paths()
         {
             var tempDir = Path.GetTempPath();
@@ -627,6 +637,7 @@ client_cert_data = ""some-data""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_Tls_Client_Key_Fallback()
         {
             var toml = @"
@@ -832,6 +843,7 @@ server_name = ""should-be-ignored""
 
         // === INTEGRATION/E2E TESTS (6 tests) ===
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void ClientConfigLoadClientConnectConfigWorksWithFilePathAndEnvOverrides()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -859,6 +871,7 @@ server_name = ""should-be-ignored""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Client_Connect_Config()
         {
             // Test the complete round-trip from config to connection options
@@ -903,6 +916,7 @@ authorization = ""Bearer test-token""
 
         // === E2E CLIENT CONNECTION TESTS (4 tests) ===
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_E2e_Basic_Development_Profile_Client_Connection()
         {
             // Test basic development profile configuration for client connection
@@ -938,6 +952,7 @@ namespace = ""development""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_E2e_Production_Tls_Api_Key_Client_Connection()
         {
             // Test production profile with TLS and API key for secure client connection
@@ -1026,6 +1041,7 @@ api_key = ""default-api-key""
         }
 
         [Fact]
+        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_E2e_Multi_Profile_Different_Client_Connections()
         {
             // Test that different profiles create different client connections appropriately

--- a/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
+++ b/tests/Temporalio.Tests/Common/EnvConfig/ClientConfigTests.cs
@@ -11,8 +11,6 @@ namespace Temporalio.Tests.Common.EnvConfig
     /// Environment configuration tests following Python/TypeScript patterns for cross-SDK consistency.
     /// Comprehensive test suite covering all aspects of environment configuration.
     /// </summary>
-    // Tests whose controlled inputs are changed by the Cloud harness's process-wide TEMPORAL_*
-    // variables are excluded individually below.
     public class ClientConfigTests : TestBase
     {
         // Test fixtures matching Python/TypeScript patterns
@@ -60,7 +58,6 @@ client_key_data = ""client-key-data""
 
         // === PROFILE LOADING TESTS (7 tests) ===
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_From_File_Default()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -68,6 +65,7 @@ client_key_data = ""client-key-data""
             {
                 Profile = "default",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
 
             Assert.Equal("default-address", profile.Address);
@@ -81,7 +79,6 @@ client_key_data = ""client-key-data""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_From_File_Custom()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -89,6 +86,7 @@ client_key_data = ""client-key-data""
             {
                 Profile = "custom",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
 
             Assert.Equal("custom-address", profile.Address);
@@ -105,7 +103,6 @@ client_key_data = ""client-key-data""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_From_Data_Default()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -113,6 +110,7 @@ client_key_data = ""client-key-data""
             {
                 Profile = "default",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
 
             Assert.Equal("default-address", profile.Address);
@@ -124,7 +122,6 @@ client_key_data = ""client-key-data""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_From_Data_Custom()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -132,6 +129,7 @@ client_key_data = ""client-key-data""
             {
                 Profile = "custom",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
 
             Assert.Equal("custom-address", profile.Address);
@@ -423,7 +421,6 @@ x-custom-header = ""custom-value""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void DefaultProfileNotFoundReturnsEmptyProfile()
         {
             var toml = @"
@@ -437,6 +434,7 @@ address = ""other-address""
             {
                 Profile = null,
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.Null(profile.Address);
             Assert.Null(profile.Namespace);
@@ -447,7 +445,6 @@ address = ""other-address""
 
         // === TLS CONFIGURATION TESTS (7 tests) ===
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_Api_Key_Enables_Tls()
         {
             var toml = @"
@@ -460,6 +457,7 @@ api_key = ""my-api-key""
             {
                 Profile = "default",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
 
             Assert.Equal("my-api-key", profile.ApiKey);
@@ -474,7 +472,6 @@ api_key = ""my-api-key""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_Tls_Options()
         {
             var source = DataSource.FromUTF8String(TomlConfigTlsDetailed);
@@ -484,6 +481,7 @@ api_key = ""my-api-key""
             {
                 Profile = "tls_disabled",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.NotNull(profileDisabled.Tls);
             Assert.True(profileDisabled.Tls.Disabled);
@@ -497,6 +495,7 @@ api_key = ""my-api-key""
             {
                 Profile = "tls_with_certs",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.NotNull(profileCerts.Tls);
             Assert.Equal("custom-server", profileCerts.Tls.ServerName);
@@ -510,7 +509,6 @@ api_key = ""my-api-key""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_Tls_From_Paths()
         {
             var tempDir = Path.GetTempPath();
@@ -538,6 +536,7 @@ client_key_path = ""{keyPath.Replace('\\', '/')}""
                 {
                     Profile = "default",
                     ConfigSource = source,
+                    OverrideEnvVars = new Dictionary<string, string>(),
                 });
 
                 Assert.NotNull(profile.Tls);
@@ -637,7 +636,6 @@ client_cert_data = ""some-data""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Profile_Tls_Client_Key_Fallback()
         {
             var toml = @"
@@ -652,6 +650,7 @@ client_key_data = ""client-key-data""
             {
                 Profile = "default",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
 
             Assert.NotNull(profile.Tls);
@@ -843,7 +842,6 @@ server_name = ""should-be-ignored""
 
         // === INTEGRATION/E2E TESTS (6 tests) ===
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void ClientConfigLoadClientConnectConfigWorksWithFilePathAndEnvOverrides()
         {
             var source = DataSource.FromUTF8String(TomlConfigBase);
@@ -852,6 +850,7 @@ server_name = ""should-be-ignored""
             var options1 = ClientEnvConfig.LoadClientConnectOptions(new ClientEnvConfig.ProfileLoadOptions
             {
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.Equal("default-address", options1.TargetHost);
             Assert.Equal("default-namespace", options1.Namespace);
@@ -871,7 +870,6 @@ server_name = ""should-be-ignored""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_Load_Client_Connect_Config()
         {
             // Test the complete round-trip from config to connection options
@@ -893,6 +891,7 @@ authorization = ""Bearer test-token""
             var defaultOptions = ClientEnvConfig.LoadClientConnectOptions(new ClientEnvConfig.ProfileLoadOptions
             {
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.Equal("localhost:7233", defaultOptions.TargetHost);
             Assert.Equal("integration-test", defaultOptions.Namespace);
@@ -904,6 +903,7 @@ authorization = ""Bearer test-token""
             {
                 Profile = "integration",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.Equal("integration.example.com:7233", integrationOptions.TargetHost);
             Assert.Equal("integration-namespace", integrationOptions.Namespace);
@@ -916,7 +916,6 @@ authorization = ""Bearer test-token""
 
         // === E2E CLIENT CONNECTION TESTS (4 tests) ===
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_E2e_Basic_Development_Profile_Client_Connection()
         {
             // Test basic development profile configuration for client connection
@@ -930,6 +929,7 @@ namespace = ""development""
             {
                 Profile = "development",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
 
             // Validate profile configuration
@@ -952,7 +952,6 @@ namespace = ""development""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_E2e_Production_Tls_Api_Key_Client_Connection()
         {
             // Test production profile with TLS and API key for secure client connection
@@ -969,6 +968,7 @@ server_name = ""production.temporal.cloud""
             {
                 Profile = "production",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
 
             // Validate profile configuration
@@ -1041,7 +1041,6 @@ api_key = ""default-api-key""
         }
 
         [Fact]
-        [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
         public void Test_E2e_Multi_Profile_Different_Client_Connections()
         {
             // Test that different profiles create different client connections appropriately
@@ -1070,6 +1069,7 @@ environment = ""production""
             var config = ClientEnvConfig.Load(new ClientEnvConfig.ConfigLoadOptions
             {
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.Equal(3, config.Profiles.Count);
 
@@ -1078,6 +1078,7 @@ environment = ""production""
             {
                 Profile = "development",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.Equal("localhost:7233", devOptions.TargetHost);
             Assert.Equal("dev", devOptions.Namespace);
@@ -1089,6 +1090,7 @@ environment = ""production""
             {
                 Profile = "staging",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.Equal("staging.temporal.io:7233", stagingOptions.TargetHost);
             Assert.Equal("staging", stagingOptions.Namespace);
@@ -1100,6 +1102,7 @@ environment = ""production""
             {
                 Profile = "production",
                 ConfigSource = source,
+                OverrideEnvVars = new Dictionary<string, string>(),
             });
             Assert.Equal("production.temporal.cloud:7233", prodOptions.TargetHost);
             Assert.Equal("production", prodOptions.Namespace);

--- a/tests/Temporalio.Tests/Extensions/DiagnosticSource/CustomMetricMeterTests.cs
+++ b/tests/Temporalio.Tests/Extensions/DiagnosticSource/CustomMetricMeterTests.cs
@@ -163,13 +163,7 @@ public class CustomMetricMeterTests : WorkflowEnvironmentTestBase
                 },
             },
         });
-        var client = await TemporalClient.ConnectAsync(
-            new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = runtime,
-            });
+        var client = await ConnectClientWithRuntimeAsync(runtime);
 
         // Run workflow
         using var worker = new TemporalWorker(
@@ -310,13 +304,7 @@ public class CustomMetricMeterTests : WorkflowEnvironmentTestBase
                 },
             },
         });
-        var client = await TemporalClient.ConnectAsync(
-            new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = runtime,
-            });
+        var client = await ConnectClientWithRuntimeAsync(runtime);
 
         // Run workflow
         using var worker = new TemporalWorker(
@@ -395,13 +383,7 @@ public class CustomMetricMeterTests : WorkflowEnvironmentTestBase
                 Metrics = new() { CustomMetricMeter = new CustomMetricMeter(meter, disableTracing) },
             },
         });
-        var client = await TemporalClient.ConnectAsync(
-            new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = runtime,
-            });
+        var client = await ConnectClientWithRuntimeAsync(runtime);
 
         // Run workflow
         using var worker = new TemporalWorker(

--- a/tests/Temporalio.Tests/Extensions/Hosting/ActivityScopeTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/ActivityScopeTests.cs
@@ -88,7 +88,9 @@ public class ActivityScopeTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "The host-created client omits Cloud TLS and authentication options.")]
     public async Task ActivityScope_CustomInstance_IsAccessible()
     {
         // Create the host

--- a/tests/Temporalio.Tests/Extensions/Hosting/ActivityScopeTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/ActivityScopeTests.cs
@@ -88,6 +88,7 @@ public class ActivityScopeTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ActivityScope_CustomInstance_IsAccessible()
     {
         // Create the host

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceRegistrationTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceRegistrationTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NexusRpc.Handlers;
+using Temporalio.Extensions.Hosting;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Temporalio.Tests.Extensions.Hosting;
+
+public class NexusWorkerServiceRegistrationTests : WorkflowEnvironmentTestBase
+{
+    public NexusWorkerServiceRegistrationTests(
+        ITestOutputHelper output,
+        WorkflowEnvironment env)
+        : base(output, env)
+    {
+    }
+
+    // A [NexusOperationHandler] method whose name maps to no operation on the service interface.
+    // Increment is a valid handler for the sole operation, so registration failure is isolated to
+    // the unmatched NotAnOperation method rather than surfacing as a missing-handler error.
+    [NexusServiceHandler(typeof(NexusWorkerServiceTests.ITestNexusService))]
+    public class UnmatchedOperationHandlerNexusService
+    {
+        [NexusOperationHandler]
+        public IOperationHandler<string, int> Increment() =>
+            throw new NotImplementedException();
+
+        [NexusOperationHandler]
+        public IOperationHandler<string, int> NotAnOperation() =>
+            throw new NotImplementedException();
+    }
+
+    // The hosting/DI registration path must reject a [NexusOperationHandler] method that maps to no
+    // operation, matching NexusRpc's ServiceHandlerInstance.FromInstance and the non-DI
+    // TemporalWorkerOptions.AddNexusService path (rather than silently skipping it). The worker
+    // service resolves (and validates) its Nexus operations from options while starting, so the
+    // failure surfaces from host startup.
+    [Fact]
+    public async Task NexusWorkerService_UnmatchedOperationHandler_FailsRegistration()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.
+            AddSingleton(Client).
+            AddHostedTemporalWorker($"tq-{Guid.NewGuid()}").
+            AddScopedNexusService<UnmatchedOperationHandlerNexusService>();
+        using var host = builder.Build();
+
+        var exc = await Assert.ThrowsAsync<ArgumentException>(() => host.StartAsync());
+        Assert.Equal("Failed obtaining operation handler from NotAnOperation", exc.Message);
+        Assert.Equal(
+            "No matching NexusOperation on the service interface",
+            Assert.IsType<ArgumentException>(exc.InnerException).Message);
+    }
+}

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -83,6 +83,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_SingletonNexusService_SingletonDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -99,6 +100,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_SingletonNexusService_ScopedDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -115,6 +117,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_SingletonNexusService_TransientDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -131,6 +134,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_ScopedNexusService_SingletonDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -147,6 +151,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_ScopedNexusService_ScopedDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -163,6 +168,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_ScopedNexusService_TransientDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -179,6 +185,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_TransientNexusService_SingletonDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -195,6 +202,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_TransientNexusService_ScopedDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -211,6 +219,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_TransientNexusService_TransientDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -248,6 +257,7 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     // fresh service instance) per operation call. Expected counts mirror the [NexusOperationHandler]
     // tests above.
     [Theory]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     [InlineData(ServiceLifetime.Singleton, ServiceLifetime.Singleton, 2)]
     [InlineData(ServiceLifetime.Singleton, ServiceLifetime.Scoped, 2)]
     [InlineData(ServiceLifetime.Singleton, ServiceLifetime.Transient, 2)]

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace Temporalio.Tests.Extensions.Hosting;
 
+[CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
 public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
 {
     public NexusWorkerServiceTests(ITestOutputHelper output, WorkflowEnvironment env)
@@ -83,7 +84,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_SingletonNexusService_SingletonDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -100,7 +100,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_SingletonNexusService_ScopedDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -117,7 +116,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_SingletonNexusService_TransientDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -134,7 +132,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_ScopedNexusService_SingletonDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -151,7 +148,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_ScopedNexusService_ScopedDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -168,7 +164,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_ScopedNexusService_TransientDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -185,7 +180,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_TransientNexusService_SingletonDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -202,7 +196,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_TransientNexusService_ScopedDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -219,7 +212,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task NexusWorkerService_TransientNexusService_TransientDependency()
     {
         int result = await ExecuteHostedNexusWithWorkflow(
@@ -257,7 +249,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
     // fresh service instance) per operation call. Expected counts mirror the [NexusOperationHandler]
     // tests above.
     [Theory]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     [InlineData(ServiceLifetime.Singleton, ServiceLifetime.Singleton, 2)]
     [InlineData(ServiceLifetime.Singleton, ServiceLifetime.Scoped, 2)]
     [InlineData(ServiceLifetime.Singleton, ServiceLifetime.Transient, 2)]
@@ -282,43 +273,6 @@ public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
             });
 
         Assert.Equal(expected, result);
-    }
-
-    // A [NexusOperationHandler] method whose name maps to no operation on the service interface.
-    // Increment is a valid handler for the sole operation, so registration failure is isolated to
-    // the unmatched NotAnOperation method rather than surfacing as a missing-handler error.
-    [NexusServiceHandler(typeof(ITestNexusService))]
-    public class UnmatchedOperationHandlerNexusService
-    {
-        [NexusOperationHandler]
-        public IOperationHandler<string, int> Increment() =>
-            throw new NotImplementedException();
-
-        [NexusOperationHandler]
-        public IOperationHandler<string, int> NotAnOperation() =>
-            throw new NotImplementedException();
-    }
-
-    // The hosting/DI registration path must reject a [NexusOperationHandler] method that maps to no
-    // operation, matching NexusRpc's ServiceHandlerInstance.FromInstance and the non-DI
-    // TemporalWorkerOptions.AddNexusService path (rather than silently skipping it). The worker
-    // service resolves (and validates) its Nexus operations from options while starting, so the
-    // failure surfaces from host startup.
-    [Fact]
-    public async Task NexusWorkerService_UnmatchedOperationHandler_FailsRegistration()
-    {
-        var builder = Host.CreateApplicationBuilder();
-        builder.Services.
-            AddSingleton(Client).
-            AddHostedTemporalWorker($"tq-{Guid.NewGuid()}").
-            AddScopedNexusService<UnmatchedOperationHandlerNexusService>();
-        using var host = builder.Build();
-
-        var exc = await Assert.ThrowsAsync<ArgumentException>(() => host.StartAsync());
-        Assert.Equal("Failed obtaining operation handler from NotAnOperation", exc.Message);
-        Assert.Equal(
-            "No matching NexusOperation on the service interface",
-            Assert.IsType<ArgumentException>(exc.InnerException).Message);
     }
 
     private static void AddNexusService<T>(

--- a/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/NexusWorkerServiceTests.cs
@@ -11,7 +11,9 @@ using Xunit.Abstractions;
 
 namespace Temporalio.Tests.Extensions.Hosting;
 
-[CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+[CloudTestExclusion(
+    CloudTestExclusionReason.NeedsCloudAdaptation,
+    "Requires Cloud Nexus endpoint setup and cleanup.")]
 public class NexusWorkerServiceTests : WorkflowEnvironmentTestBase
 {
     public NexusWorkerServiceTests(ITestOutputHelper output, WorkflowEnvironment env)

--- a/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
@@ -66,6 +66,7 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task TemporalWorkerService_ExecuteAsync_SimpleWorker()
     {
         using var loggerFactory = new TestUtils.LogCaptureFactory(NullLoggerFactory.Instance);
@@ -166,6 +167,7 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task TemporalWorkerService_ExecuteAsync_MultipleWorkers()
     {
         var taskQueue1 = $"tq-{Guid.NewGuid()}";
@@ -236,6 +238,7 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
     public async Task TemporalWorkerService_WorkerClientReplacement_UsesNewClient()
     {
         // We are going to start a second ephemeral server and then replace the client. So we will

--- a/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
+++ b/tests/Temporalio.Tests/Extensions/Hosting/TemporalWorkerServiceTests.cs
@@ -66,7 +66,9 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "The host-created client omits Cloud TLS and authentication options.")]
     public async Task TemporalWorkerService_ExecuteAsync_SimpleWorker()
     {
         using var loggerFactory = new TestUtils.LogCaptureFactory(NullLoggerFactory.Instance);
@@ -167,7 +169,9 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "The secondary host-created client omits Cloud TLS and authentication options.")]
     public async Task TemporalWorkerService_ExecuteAsync_MultipleWorkers()
     {
         var taskQueue1 = $"tq-{Guid.NewGuid()}";
@@ -238,7 +242,9 @@ public class TemporalWorkerServiceTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresLocalServer,
+        "Starts a second local server to verify worker client replacement.")]
     public async Task TemporalWorkerService_WorkerClientReplacement_UsesNewClient()
     {
         // We are going to start a second ephemeral server and then replace the client. So we will

--- a/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
+++ b/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
@@ -756,6 +756,7 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task TracingInterceptor_Nexus_HasTracing()
     {
         // Create Nexus endpoint

--- a/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
+++ b/tests/Temporalio.Tests/Extensions/OpenTelemetry/TracingInterceptorTests.cs
@@ -756,7 +756,9 @@ public class TracingInterceptorTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Requires Cloud Nexus endpoint setup and cleanup.")]
     public async Task TracingInterceptor_Nexus_HasTracing()
     {
         // Create Nexus endpoint

--- a/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
+++ b/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Temporalio.Bridge;
-using Temporalio.Client;
 using Temporalio.Common;
 using Temporalio.Runtime;
 using Temporalio.Worker;
@@ -24,24 +23,14 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
     {
         // Create two clients in separate runtimes with Prometheus endpoints and make calls on them
         var promAddr1 = $"127.0.0.1:{TestUtils.FreePort()}";
-        var client1 = await TemporalClient.ConnectAsync(
-            new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = new(
-                    new() { Telemetry = new() { Metrics = new() { Prometheus = new(promAddr1) } } }),
-            });
+        var runtime1 = new TemporalRuntime(
+            new() { Telemetry = new() { Metrics = new() { Prometheus = new(promAddr1) } } });
+        var client1 = await ConnectClientWithRuntimeAsync(runtime1);
         await client1.WorkflowService.GetSystemInfoAsync(new());
         var promAddr2 = $"127.0.0.1:{TestUtils.FreePort()}";
-        var client2 = await TemporalClient.ConnectAsync(
-            new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = new(
-                    new() { Telemetry = new() { Metrics = new() { Prometheus = new(promAddr2) } } }),
-            });
+        var runtime2 = new TemporalRuntime(
+            new() { Telemetry = new() { Metrics = new() { Prometheus = new(promAddr2) } } });
+        var client2 = await ConnectClientWithRuntimeAsync(runtime2);
         await client2.WorkflowService.GetSystemInfoAsync(new());
 
         // Check that Prometheus on each runtime is reporting metrics
@@ -218,12 +207,7 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
             });
 
             // Connect client with different runtime
-            var client = await TemporalClient.ConnectAsync(new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = runtime,
-            });
+            var client = await ConnectClientWithRuntimeAsync(runtime);
 
             // Start failing workflow and wait for log
             var workerOpts = new TemporalWorkerOptions($"ts-{Guid.NewGuid()}").
@@ -280,29 +264,24 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
     {
         // Prom metrics with custom histogram buckets
         var promAddr = $"127.0.0.1:{TestUtils.FreePort()}";
-        var client = await TemporalClient.ConnectAsync(
-            new()
+        var runtime = new TemporalRuntime(new()
+        {
+            Telemetry = new()
             {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = new(new()
+                Metrics = new()
                 {
-                    Telemetry = new()
+                    Prometheus = new(promAddr)
                     {
-                        Metrics = new()
+                        HistogramBucketOverrides = new Dictionary<string, IReadOnlyCollection<double>>
                         {
-                            Prometheus = new(promAddr)
-                            {
-                                HistogramBucketOverrides = new Dictionary<string, IReadOnlyCollection<double>>
-                                {
-                                    ["temporal_request_latency"] = new[] { 123.4, 567.89 },
-                                    ["custom_histogram"] = new[] { 5d, 6, 7 },
-                                },
-                            },
+                            ["temporal_request_latency"] = new[] { 123.4, 567.89 },
+                            ["custom_histogram"] = new[] { 5d, 6, 7 },
                         },
                     },
-                }),
-            });
+                },
+            },
+        });
+        var client = await ConnectClientWithRuntimeAsync(runtime);
 
         // Generate metrics
         await client.WorkflowService.GetSystemInfoAsync(new());

--- a/tests/Temporalio.Tests/Testing/WorkflowEnvironmentTests.cs
+++ b/tests/Temporalio.Tests/Testing/WorkflowEnvironmentTests.cs
@@ -13,6 +13,7 @@ using Temporalio.Workflows;
 using Xunit;
 using Xunit.Abstractions;
 
+[CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
 public class WorkflowEnvironmentTests : TestBase
 {
     // Time-skipping test server only runs on x86/x64

--- a/tests/Temporalio.Tests/Testing/WorkflowEnvironmentTests.cs
+++ b/tests/Temporalio.Tests/Testing/WorkflowEnvironmentTests.cs
@@ -13,7 +13,9 @@ using Temporalio.Workflows;
 using Xunit;
 using Xunit.Abstractions;
 
-[CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
+[CloudTestExclusion(
+    CloudTestExclusionReason.RequiresLocalServer,
+    "Covers local and time-skipping test-server APIs.")]
 public class WorkflowEnvironmentTests : TestBase
 {
     // Time-skipping test server only runs on x86/x64

--- a/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 /// End-to-end scaffold for UpdateWorkflow-backed Nexus operations, encoding the reviewer scenario
 /// punch-list from the feature's design.
 /// </summary>
+[CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
 public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
 {
     public NexusUpdateOperationTests(ITestOutputHelper output, WorkflowEnvironment env)

--- a/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusUpdateOperationTests.cs
@@ -15,7 +15,9 @@ using Xunit.Abstractions;
 /// End-to-end scaffold for UpdateWorkflow-backed Nexus operations, encoding the reviewer scenario
 /// punch-list from the feature's design.
 /// </summary>
-[CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+[CloudTestExclusion(
+    CloudTestExclusionReason.NeedsCloudAdaptation,
+    "Requires Cloud Nexus endpoint setup and cleanup.")]
 public class NexusUpdateOperationTests : WorkflowEnvironmentTestBase
 {
     public NexusUpdateOperationTests(ITestOutputHelper output, WorkflowEnvironment env)

--- a/tests/Temporalio.Tests/Worker/NexusWorkerRegistrationTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerRegistrationTests.cs
@@ -1,0 +1,184 @@
+namespace Temporalio.Tests.Worker;
+
+using NexusRpc;
+using NexusRpc.Handlers;
+using Temporalio.Nexus;
+using Temporalio.Worker;
+using Xunit;
+
+public class NexusWorkerRegistrationTests
+{
+    [NexusService]
+    public interface IBadService
+    {
+        [NexusOperation]
+        int DoSomething(string name);
+    }
+
+    [NexusServiceHandler(typeof(IBadService))]
+    public class BadService
+    {
+        [NexusOperationHandler]
+        public IOperationHandler<string, string> DoSomething() =>
+            throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void AddNexusService_BadService_FailsRegistration()
+    {
+        var exc = Assert.Throws<ArgumentException>(() =>
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+                AddNexusService(new BadService()));
+        Assert.Equal("Failed obtaining operation handler from DoSomething", exc.Message);
+        Assert.Equal(
+            "Expected return type of IOperationHandler<String, Int32>",
+            Assert.IsType<ArgumentException>(exc.InnerException).Message);
+    }
+
+    [NexusServiceHandler(typeof(NexusWorkerTests.IStringService))]
+    public class TemporalOperationAttrBadReturnService
+    {
+        [TemporalOperation]
+        public Task<string> DoSomething(
+            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
+            Task.FromResult(input);
+    }
+
+    [Fact]
+    public void AddNexusService_TemporalOperationBadReturnType_Throws()
+    {
+        var exc = Assert.Throws<ArgumentException>(() =>
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+                AddNexusService(new TemporalOperationAttrBadReturnService()));
+        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
+        Assert.Contains(
+            "must return Task<TemporalOperationResult<String>>",
+            Assert.IsType<ArgumentException>(exc.InnerException).Message);
+    }
+
+    [NexusServiceHandler(typeof(NexusWorkerTests.IStringService))]
+    public class TemporalOperationAttrBadParamsService
+    {
+        [TemporalOperation]
+        public Task<TemporalOperationResult<string>> DoSomething(string input) =>
+            Task.FromResult(TemporalOperationResult<string>.SyncResult(input));
+    }
+
+    [Fact]
+    public void AddNexusService_TemporalOperationBadParams_Throws()
+    {
+        var exc = Assert.Throws<ArgumentException>(() =>
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+                AddNexusService(new TemporalOperationAttrBadParamsService()));
+        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
+        Assert.Contains(
+            "must accept parameters (TemporalOperationStartContext, ITemporalNexusClient, String)",
+            Assert.IsType<ArgumentException>(exc.InnerException).Message);
+    }
+
+#pragma warning disable CA1052 // Intentionally non-static so registration reaches signature check
+    [NexusServiceHandler(typeof(NexusWorkerTests.IStringService))]
+    public class TemporalOperationAttrStaticService
+    {
+        [TemporalOperation]
+        public static Task<TemporalOperationResult<string>> DoSomething(
+            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
+            Task.FromResult(TemporalOperationResult<string>.SyncResult(input));
+    }
+#pragma warning restore CA1052
+
+    [Fact]
+    public void AddNexusService_TemporalOperationStaticMethod_Throws()
+    {
+        var exc = Assert.Throws<ArgumentException>(() =>
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+                AddNexusService(new TemporalOperationAttrStaticService()));
+        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
+        Assert.Contains(
+            "must not be static",
+            Assert.IsType<ArgumentException>(exc.InnerException).Message);
+    }
+
+    [NexusServiceHandler(typeof(NexusWorkerTests.IGenericInputService))]
+    public class TemporalOperationAttrGenericInputMismatchService
+    {
+        [TemporalOperation]
+        public Task<TemporalOperationResult<int>> Sum(
+            TemporalOperationStartContext ctx, ITemporalNexusClient client, List<string> values) =>
+            Task.FromResult(TemporalOperationResult<int>.SyncResult(0));
+    }
+
+    [Fact]
+    public void AddNexusService_TemporalOperationGenericInputMismatch_Throws()
+    {
+        var exc = Assert.Throws<ArgumentException>(() =>
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+                AddNexusService(new TemporalOperationAttrGenericInputMismatchService()));
+        Assert.Contains("Failed obtaining operation handler from Sum", exc.Message);
+        Assert.Contains(
+            "must accept parameters",
+            Assert.IsType<ArgumentException>(exc.InnerException).Message);
+    }
+
+    [NexusServiceHandler(typeof(NexusWorkerTests.IStringService))]
+    public class TemporalOperationAttrRawReturnService
+    {
+        [TemporalOperation]
+        public Task<int> DoSomething(
+            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
+            Task.FromResult(0);
+    }
+
+    [Fact]
+    public void AddNexusService_TemporalOperationRawReturn_Throws()
+    {
+        var exc = Assert.Throws<ArgumentException>(() =>
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+                AddNexusService(new TemporalOperationAttrRawReturnService()));
+        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
+        Assert.Contains(
+            "must return Task<TemporalOperationResult<String>>",
+            Assert.IsType<ArgumentException>(exc.InnerException).Message);
+    }
+
+    [NexusServiceHandler(typeof(NexusWorkerTests.IStringService))]
+    public class TemporalOperationAttrDualAnnotationService
+    {
+        [TemporalOperation]
+        [NexusOperationHandler]
+        public Task<TemporalOperationResult<string>> DoSomething(
+            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
+            Task.FromResult(TemporalOperationResult<string>.SyncResult(input));
+    }
+
+    [Fact]
+    public void AddNexusService_TemporalOperationDualAnnotation_Throws()
+    {
+        // The built-in [NexusOperationHandler] path claims the method first, and it
+        // rejects the signature (return type isn't IOperationHandler<,>).
+        Assert.Throws<ArgumentException>(() =>
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+                AddNexusService(new TemporalOperationAttrDualAnnotationService()));
+    }
+
+    [NexusServiceHandler(typeof(NexusWorkerTests.IStringService))]
+    public class TemporalOperationAttrPrivateService
+    {
+        [TemporalOperation]
+        private Task<TemporalOperationResult<string>> DoSomething(
+            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
+            Task.FromResult(TemporalOperationResult<string>.SyncResult(input));
+    }
+
+    [Fact]
+    public void AddNexusService_TemporalOperationPrivateMethod_Throws()
+    {
+        var exc = Assert.Throws<ArgumentException>(() =>
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+                AddNexusService(new TemporalOperationAttrPrivateService()));
+        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
+        Assert.Contains(
+            "must be public",
+            Assert.IsType<ArgumentException>(exc.InnerException).Message);
+    }
+}

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -17,6 +17,7 @@ using Temporalio.Workflows;
 using Xunit;
 using Xunit.Abstractions;
 
+[CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
 public class NexusWorkerTests : WorkflowEnvironmentTestBase
 {
     public NexusWorkerTests(ITestOutputHelper output, WorkflowEnvironment env)
@@ -95,7 +96,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_SimpleService_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -121,7 +121,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ContextHasEndpoint()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -145,7 +144,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_SimpleWorkflow_Succeeds()
     {
         WorkflowRunOperationContext? capturedContext = null;
@@ -205,7 +203,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_WaitForeverWorkflow_CanBeCanceled()
     {
         // Build the worker options w/ the nexus service
@@ -274,35 +271,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                 Client.GetWorkflowHandle(token.WorkflowId).GetResultAsync())).InnerException);
     }
 
-    [NexusService]
-    public interface IBadService
-    {
-        [NexusOperation]
-        int DoSomething(string name);
-    }
-
-    [NexusServiceHandler(typeof(IBadService))]
-    public class BadService
-    {
-        [NexusOperationHandler]
-        public IOperationHandler<string, string> DoSomething() =>
-            throw new NotImplementedException();
-    }
-
     [Fact]
-    public async Task ExecuteNexusOperationAsync_BadService_FailsRegistration()
-    {
-        var exc = Assert.Throws<ArgumentException>(() => new TemporalWorker(
-            Client,
-            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").AddNexusService(new BadService())));
-        Assert.Equal("Failed obtaining operation handler from DoSomething", exc.Message);
-        Assert.Equal(
-            "Expected return type of IOperationHandler<String, Int32>",
-            Assert.IsType<ArgumentException>(exc.InnerException).Message);
-    }
-
-    [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_SyncTimeout_FailsAsExpected()
     {
         var cancellationReasonSource = new TaskCompletionSource<string?>();
@@ -347,7 +316,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_RequestDeadline_SetOnContext()
     {
         var requestDeadlineSource = new TaskCompletionSource<DateTime?>();
@@ -371,7 +339,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationSummary_FoundInHistory()
     {
         string expectedSummary = "custom operation summary";
@@ -405,7 +372,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ScheduleToStartTimeout_FailsAsExpected()
     {
         var cancellationReasonSource = new TaskCompletionSource<string?>();
@@ -450,7 +416,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_StartToCloseTimeout_FailsAsExpected()
     {
         // Build a workflow-backed async operation that will never complete
@@ -498,7 +463,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_SimpleWorkflow_ConflictPolicy()
     {
         // Example of a Nexus service that creates a second operation with the same ID and
@@ -570,7 +534,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerSignal_ForwardsInboundLinks()
     {
         // A target workflow that the handler will signal from inside the operation. The signal it
@@ -623,7 +586,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerStart_ForwardsInboundLinks()
     {
         // A handler that plain-starts a target workflow from inside the operation. The start request
@@ -675,7 +637,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [SkippableFact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerSignal_PropagatesBacklink()
     {
         // The backward direction is gated by the server's history.enableCHASMSignalBacklinks dynamic
@@ -739,7 +700,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [SkippableFact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerSignalsMultiple_PropagatesAllBacklinks()
     {
         // Integration-level counterpart to the unit-level accumulation tests: a single operation
@@ -817,7 +777,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [SkippableFact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_AsyncHandlerSignal_PropagatesBacklinkOnStarted()
     {
         // Backlink propagation for an async operation: the handler signals a target workflow (the
@@ -891,7 +850,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_BadArgs_FailsOperation()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -913,7 +871,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_Untyped_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -929,7 +886,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_InputManip_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -950,7 +906,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ApplicationFailure_NonRetryable()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -976,7 +931,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationException_ProperlyFails()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -999,7 +953,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationExceptionWithCause_PreservesCauseChain()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1030,7 +983,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationExceptionCanceled_ProperlyFails()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1053,7 +1005,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationExceptionCanceledWithCause_PreservesCauseChain()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1082,7 +1033,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerException_ProperlyFails()
     {
         // Non-retryable
@@ -1107,7 +1057,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ManualDefinition_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1170,7 +1119,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_Interceptor_Reached()
     {
         var workflowId = $"wf-{Guid.NewGuid()}";
@@ -1205,7 +1153,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ServiceNotFound_ProperlyFails()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1228,7 +1175,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationNotFound_ProperlyFails()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1316,7 +1262,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_VoidTypes_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1424,7 +1369,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelWaitCompleted_ProperlyCancels()
     {
         var ret = await RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.WaitCompletedTargetTimerAndRethrow);
@@ -1445,7 +1389,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelWaitRequested_ProperlyCancels()
     {
         var ret = await RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.WaitRequestedTargetHang);
@@ -1465,7 +1408,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelWaitRequested_ProperlyFails()
     {
         // Confirm workflow fails trying to cancel
@@ -1478,7 +1420,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelAbandon_ProperlyCancels()
     {
         var ret = await RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.Abandon);
@@ -1498,7 +1439,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelTryCancel_ProperlyCancels()
     {
         var ret = await RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.TryCancelHandlerFail);
@@ -1596,7 +1536,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CodecFailure_IsRetried()
     {
         var codec = new FailOnceCodec();
@@ -1654,7 +1593,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_NoValueInputWithCodec_Succeeds()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();
@@ -1702,7 +1640,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ConverterFailure_IsNotRetried()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();
@@ -1769,7 +1706,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CodecHandlerException_IsPassedThrough()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();
@@ -1838,7 +1774,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ConverterHandlerException_IsPassedThrough()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();
@@ -1884,7 +1819,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartWorkflow_Succeeds()
     {
         // Build the worker options w/ the nexus service using the new generic handler
@@ -1907,7 +1841,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_Cancel_Succeeds()
     {
         // Build the worker options w/ the nexus service using the new generic handler
@@ -1941,7 +1874,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_SyncResult_Succeeds()
     {
         // Build the worker options w/ a handler that returns a sync result
@@ -1960,7 +1892,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_LinksAndContext_Populated()
     {
         // Capture the context and client passed to the generic handler so we can assert plumbing
@@ -2013,7 +1944,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_CancelOperation_CancelsUnderlying()
     {
         // The default CancelWorkflowRunAsync should cancel the underlying workflow when the
@@ -2051,7 +1981,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_CancelOverride_Invoked()
     {
         // Subclass with a CancelWorkflowRunAsync override; verify the override is used and
@@ -2091,7 +2020,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartWorkflowByName_Succeeds()
     {
         // Use the by-name overload of TemporalNexusClient.StartWorkflowAsync
@@ -2114,7 +2042,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_ConflictPolicy_UseExisting()
     {
         // Two operations with the same workflow ID + UseExisting policy attach to the same
@@ -2149,7 +2076,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_NoInputOverload_Succeeds()
     {
         // Exercise the no-input [TemporalOperation] path (2-arg method signature)
@@ -2196,7 +2122,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartActivity_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2232,7 +2157,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartActivityByName_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2259,7 +2183,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_CancelActivity_CancelsUnderlying()
     {
         ActivityStubs.WaitForCancelReached = new TaskCompletionSource();
@@ -2312,7 +2235,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_CancelActivityOverride_Invoked()
     {
         ActivityStubs.WaitForCancelReached = new TaskCompletionSource();
@@ -2433,7 +2355,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_WorkflowStart()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2458,7 +2379,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_SyncResult()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2482,7 +2402,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_NoInput()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2522,7 +2441,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_VoidTypes()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2564,7 +2482,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_MixedWithHandlerFactory()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2580,70 +2497,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                 "factory: hi",
                 await client.ExecuteNexusOperationAsync(svc => svc.ViaHandlerFactory("hi")));
         });
-    }
-
-    [NexusServiceHandler(typeof(IStringService))]
-    public class TemporalOperationAttrBadReturnService
-    {
-        [TemporalOperation]
-        public Task<string> DoSomething(
-            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
-            Task.FromResult(input);
-    }
-
-    [Fact]
-    public void AddNexusService_TemporalOperationBadReturnType_Throws()
-    {
-        var exc = Assert.Throws<ArgumentException>(() =>
-            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
-                AddNexusService(new TemporalOperationAttrBadReturnService()));
-        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
-        Assert.Contains(
-            "must return Task<TemporalOperationResult<String>>",
-            Assert.IsType<ArgumentException>(exc.InnerException).Message);
-    }
-
-    [NexusServiceHandler(typeof(IStringService))]
-    public class TemporalOperationAttrBadParamsService
-    {
-        [TemporalOperation]
-        public Task<TemporalOperationResult<string>> DoSomething(string input) =>
-            Task.FromResult(TemporalOperationResult<string>.SyncResult(input));
-    }
-
-    [Fact]
-    public void AddNexusService_TemporalOperationBadParams_Throws()
-    {
-        var exc = Assert.Throws<ArgumentException>(() =>
-            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
-                AddNexusService(new TemporalOperationAttrBadParamsService()));
-        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
-        Assert.Contains(
-            "must accept parameters (TemporalOperationStartContext, ITemporalNexusClient, String)",
-            Assert.IsType<ArgumentException>(exc.InnerException).Message);
-    }
-
-#pragma warning disable CA1052 // Intentionally non-static so registration reaches signature check
-    [NexusServiceHandler(typeof(IStringService))]
-    public class TemporalOperationAttrStaticService
-    {
-        [TemporalOperation]
-        public static Task<TemporalOperationResult<string>> DoSomething(
-            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
-            Task.FromResult(TemporalOperationResult<string>.SyncResult(input));
-    }
-#pragma warning restore CA1052
-
-    [Fact]
-    public void AddNexusService_TemporalOperationStaticMethod_Throws()
-    {
-        var exc = Assert.Throws<ArgumentException>(() =>
-            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
-                AddNexusService(new TemporalOperationAttrStaticService()));
-        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
-        Assert.Contains(
-            "must not be static",
-            Assert.IsType<ArgumentException>(exc.InnerException).Message);
     }
 
     [NexusService]
@@ -2663,7 +2516,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_CompositeGenericInput()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2675,68 +2527,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
                 ExecuteNexusOperationAsync(svc => svc.Sum(new List<int> { 1, 2, 3 }));
             Assert.Equal(6, result);
         });
-    }
-
-    [NexusServiceHandler(typeof(IGenericInputService))]
-    public class TemporalOperationAttrGenericInputMismatchService
-    {
-        [TemporalOperation]
-        public Task<TemporalOperationResult<int>> Sum(
-            TemporalOperationStartContext ctx, ITemporalNexusClient client, List<string> values) =>
-            Task.FromResult(TemporalOperationResult<int>.SyncResult(0));
-    }
-
-    [Fact]
-    public void AddNexusService_TemporalOperationGenericInputMismatch_Throws()
-    {
-        var exc = Assert.Throws<ArgumentException>(() =>
-            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
-                AddNexusService(new TemporalOperationAttrGenericInputMismatchService()));
-        Assert.Contains("Failed obtaining operation handler from Sum", exc.Message);
-        Assert.Contains(
-            "must accept parameters",
-            Assert.IsType<ArgumentException>(exc.InnerException).Message);
-    }
-
-    [NexusServiceHandler(typeof(IStringService))]
-    public class TemporalOperationAttrRawReturnService
-    {
-        [TemporalOperation]
-        public Task<int> DoSomething(
-            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
-            Task.FromResult(0);
-    }
-
-    [Fact]
-    public void AddNexusService_TemporalOperationRawReturn_Throws()
-    {
-        var exc = Assert.Throws<ArgumentException>(() =>
-            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
-                AddNexusService(new TemporalOperationAttrRawReturnService()));
-        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
-        Assert.Contains(
-            "must return Task<TemporalOperationResult<String>>",
-            Assert.IsType<ArgumentException>(exc.InnerException).Message);
-    }
-
-    [NexusServiceHandler(typeof(IStringService))]
-    public class TemporalOperationAttrDualAnnotationService
-    {
-        [TemporalOperation]
-        [NexusOperationHandler]
-        public Task<TemporalOperationResult<string>> DoSomething(
-            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
-            Task.FromResult(TemporalOperationResult<string>.SyncResult(input));
-    }
-
-    [Fact]
-    public void AddNexusService_TemporalOperationDualAnnotation_Throws()
-    {
-        // The built-in [NexusOperationHandler] path claims the method first, and it
-        // rejects the signature (return type isn't IOperationHandler<,>).
-        Assert.Throws<ArgumentException>(() =>
-            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
-                AddNexusService(new TemporalOperationAttrDualAnnotationService()));
     }
 
     [NexusServiceHandler(typeof(IStringService))]
@@ -2753,7 +2543,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_BindsToInstance()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2768,27 +2557,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [NexusServiceHandler(typeof(IStringService))]
-    public class TemporalOperationAttrPrivateService
-    {
-        [TemporalOperation]
-        private Task<TemporalOperationResult<string>> DoSomething(
-            TemporalOperationStartContext ctx, ITemporalNexusClient client, string input) =>
-            Task.FromResult(TemporalOperationResult<string>.SyncResult(input));
-    }
-
-    [Fact]
-    public void AddNexusService_TemporalOperationPrivateMethod_Throws()
-    {
-        var exc = Assert.Throws<ArgumentException>(() =>
-            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
-                AddNexusService(new TemporalOperationAttrPrivateService()));
-        Assert.Contains("Failed obtaining operation handler from DoSomething", exc.Message);
-        Assert.Contains(
-            "must be public",
-            Assert.IsType<ArgumentException>(exc.InnerException).Message);
-    }
-
-    [NexusServiceHandler(typeof(IStringService))]
     public class TemporalOperationAttrThrowingService
     {
         [TemporalOperation]
@@ -2798,7 +2566,6 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_ExceptionPropagatesUnwrapped()
     {
         // Compiled Expression call should propagate the user exception directly (no

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -95,6 +95,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_SimpleService_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -120,6 +121,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ContextHasEndpoint()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -143,6 +145,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_SimpleWorkflow_Succeeds()
     {
         WorkflowRunOperationContext? capturedContext = null;
@@ -202,6 +205,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_WaitForeverWorkflow_CanBeCanceled()
     {
         // Build the worker options w/ the nexus service
@@ -298,6 +302,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_SyncTimeout_FailsAsExpected()
     {
         var cancellationReasonSource = new TaskCompletionSource<string?>();
@@ -342,6 +347,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_RequestDeadline_SetOnContext()
     {
         var requestDeadlineSource = new TaskCompletionSource<DateTime?>();
@@ -365,6 +371,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationSummary_FoundInHistory()
     {
         string expectedSummary = "custom operation summary";
@@ -398,6 +405,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ScheduleToStartTimeout_FailsAsExpected()
     {
         var cancellationReasonSource = new TaskCompletionSource<string?>();
@@ -442,6 +450,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_StartToCloseTimeout_FailsAsExpected()
     {
         // Build a workflow-backed async operation that will never complete
@@ -489,6 +498,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_SimpleWorkflow_ConflictPolicy()
     {
         // Example of a Nexus service that creates a second operation with the same ID and
@@ -560,6 +570,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerSignal_ForwardsInboundLinks()
     {
         // A target workflow that the handler will signal from inside the operation. The signal it
@@ -612,6 +623,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerStart_ForwardsInboundLinks()
     {
         // A handler that plain-starts a target workflow from inside the operation. The start request
@@ -663,6 +675,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [SkippableFact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerSignal_PropagatesBacklink()
     {
         // The backward direction is gated by the server's history.enableCHASMSignalBacklinks dynamic
@@ -726,6 +739,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [SkippableFact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerSignalsMultiple_PropagatesAllBacklinks()
     {
         // Integration-level counterpart to the unit-level accumulation tests: a single operation
@@ -803,6 +817,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [SkippableFact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_AsyncHandlerSignal_PropagatesBacklinkOnStarted()
     {
         // Backlink propagation for an async operation: the handler signals a target workflow (the
@@ -876,6 +891,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_BadArgs_FailsOperation()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -897,6 +913,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_Untyped_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -912,6 +929,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_InputManip_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -932,6 +950,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ApplicationFailure_NonRetryable()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -957,6 +976,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationException_ProperlyFails()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -979,6 +999,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationExceptionWithCause_PreservesCauseChain()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1009,6 +1030,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationExceptionCanceled_ProperlyFails()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1031,6 +1053,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationExceptionCanceledWithCause_PreservesCauseChain()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1059,6 +1082,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_HandlerException_ProperlyFails()
     {
         // Non-retryable
@@ -1083,6 +1107,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ManualDefinition_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1145,6 +1170,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_Interceptor_Reached()
     {
         var workflowId = $"wf-{Guid.NewGuid()}";
@@ -1179,6 +1205,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ServiceNotFound_ProperlyFails()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1201,6 +1228,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_OperationNotFound_ProperlyFails()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1288,6 +1316,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_VoidTypes_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -1395,6 +1424,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelWaitCompleted_ProperlyCancels()
     {
         var ret = await RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.WaitCompletedTargetTimerAndRethrow);
@@ -1415,6 +1445,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelWaitRequested_ProperlyCancels()
     {
         var ret = await RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.WaitRequestedTargetHang);
@@ -1434,6 +1465,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelWaitRequested_ProperlyFails()
     {
         // Confirm workflow fails trying to cancel
@@ -1446,6 +1478,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelAbandon_ProperlyCancels()
     {
         var ret = await RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.Abandon);
@@ -1465,6 +1498,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CancelTryCancel_ProperlyCancels()
     {
         var ret = await RunCancelOperationScenarioAsync(ICancelTypeService.Scenario.TryCancelHandlerFail);
@@ -1562,6 +1596,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CodecFailure_IsRetried()
     {
         var codec = new FailOnceCodec();
@@ -1619,6 +1654,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_NoValueInputWithCodec_Succeeds()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();
@@ -1666,6 +1702,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ConverterFailure_IsNotRetried()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();
@@ -1732,6 +1769,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_CodecHandlerException_IsPassedThrough()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();
@@ -1800,6 +1838,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_ConverterHandlerException_IsPassedThrough()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();
@@ -1845,6 +1884,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartWorkflow_Succeeds()
     {
         // Build the worker options w/ the nexus service using the new generic handler
@@ -1867,6 +1907,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_Cancel_Succeeds()
     {
         // Build the worker options w/ the nexus service using the new generic handler
@@ -1900,6 +1941,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_SyncResult_Succeeds()
     {
         // Build the worker options w/ a handler that returns a sync result
@@ -1918,6 +1960,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_LinksAndContext_Populated()
     {
         // Capture the context and client passed to the generic handler so we can assert plumbing
@@ -1970,6 +2013,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_CancelOperation_CancelsUnderlying()
     {
         // The default CancelWorkflowRunAsync should cancel the underlying workflow when the
@@ -2007,6 +2051,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_CancelOverride_Invoked()
     {
         // Subclass with a CancelWorkflowRunAsync override; verify the override is used and
@@ -2046,6 +2091,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartWorkflowByName_Succeeds()
     {
         // Use the by-name overload of TemporalNexusClient.StartWorkflowAsync
@@ -2068,6 +2114,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_ConflictPolicy_UseExisting()
     {
         // Two operations with the same workflow ID + UseExisting policy attach to the same
@@ -2102,6 +2149,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_NoInputOverload_Succeeds()
     {
         // Exercise the no-input [TemporalOperation] path (2-arg method signature)
@@ -2148,6 +2196,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartActivity_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2183,6 +2232,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartActivityByName_Succeeds()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2209,6 +2259,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_CancelActivity_CancelsUnderlying()
     {
         ActivityStubs.WaitForCancelReached = new TaskCompletionSource();
@@ -2261,6 +2312,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_GenericHandler_CancelActivityOverride_Invoked()
     {
         ActivityStubs.WaitForCancelReached = new TaskCompletionSource();
@@ -2381,6 +2433,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_WorkflowStart()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2405,6 +2458,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_SyncResult()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2428,6 +2482,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_NoInput()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2467,6 +2522,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_VoidTypes()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2508,6 +2564,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_MixedWithHandlerFactory()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2606,6 +2663,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_CompositeGenericInput()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2695,6 +2753,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_BindsToInstance()
     {
         var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
@@ -2739,6 +2798,7 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteNexusOperationAsync_TemporalOperationAttribute_ExceptionPropagatesUnwrapped()
     {
         // Compiled Expression call should propagate the user exception directly (no

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -17,7 +17,9 @@ using Temporalio.Workflows;
 using Xunit;
 using Xunit.Abstractions;
 
-[CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+[CloudTestExclusion(
+    CloudTestExclusionReason.NeedsCloudAdaptation,
+    "Requires Cloud Nexus endpoint setup and cleanup.")]
 public class NexusWorkerTests : WorkflowEnvironmentTestBase
 {
     public NexusWorkerTests(ITestOutputHelper output, WorkflowEnvironment env)

--- a/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
+++ b/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 // [TMPRL1103] error log), the DisablePayloadErrorLimit opt-out lets the oversized payload reach
 // (and be rejected by) the server, and the connection's PayloadsWarnSize threshold produces a
 // forwarded [TMPRL1103] warning.
+[CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
 public class PayloadSizeLimitsTests : TestBase
 {
     private const int PayloadErrorLimit = 10 * 1024;

--- a/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
+++ b/tests/Temporalio.Tests/Worker/PayloadSizeLimitsTests.cs
@@ -18,7 +18,9 @@ using Xunit.Abstractions;
 // [TMPRL1103] error log), the DisablePayloadErrorLimit opt-out lets the oversized payload reach
 // (and be rejected by) the server, and the connection's PayloadsWarnSize threshold produces a
 // forwarded [TMPRL1103] warning.
-[CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
+[CloudTestExclusion(
+    CloudTestExclusionReason.RequiresLocalServer,
+    "Starts a server with custom payload-size dynamic configuration.")]
 public class PayloadSizeLimitsTests : TestBase
 {
     private const int PayloadErrorLimit = 10 * 1024;

--- a/tests/Temporalio.Tests/Worker/WorkerTuningTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkerTuningTests.cs
@@ -283,6 +283,7 @@ public class WorkerTuningTests : WorkflowEnvironmentTestBase
     }
 
     [Fact(Timeout = 10000)]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task CanRunWith_CustomSlotSupplier_WithNexus()
     {
         var mySlotSupplier = new MySlotSupplier();

--- a/tests/Temporalio.Tests/Worker/WorkerTuningTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkerTuningTests.cs
@@ -283,7 +283,9 @@ public class WorkerTuningTests : WorkflowEnvironmentTestBase
     }
 
     [Fact(Timeout = 10000)]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Requires Cloud Nexus endpoint setup and cleanup.")]
     public async Task CanRunWith_CustomSlotSupplier_WithNexus()
     {
         var mySlotSupplier = new MySlotSupplier();

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -846,6 +846,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Activity cancellation can complete after worker shutdown begins, exposing a bridge finalization race.")]
     public async Task ExecuteWorkflowAsync_Cancel_ProperlyCanceled()
     {
         Task AssertProperlyCanceled(
@@ -5885,6 +5888,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Leaves background workers with in-flight activities during shutdown, exposing a bridge finalization race.")]
     public async Task ExecuteWorkflowAsync_StdlibSemaphore_NonAsyncDeadlocks()
     {
         async Task AssertDeadlocks(Expression<Func<StdlibSemaphoreWorkflow, Task>> updateExpr)

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -459,7 +459,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresLocalServer,
+        "Requires local dynamic configuration for the continue-as-new history threshold.")]
     public async Task ExecuteWorkflowAsync_HistoryInfo_IsAccurate()
     {
         await ExecuteWorkerAsync<HistoryInfoWorkflow>(async worker =>
@@ -1577,7 +1579,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Requires custom search attributes that the Cloud harness does not provision.")]
     public async Task ExecuteWorkflowAsync_SearchAttributes_ProperlyUpserted()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -1635,7 +1639,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Requires custom search attributes that the Cloud harness does not provision.")]
     public async Task ExecuteWorkflowAsync_ChildWorkflowSearchAttributes_SetProperly()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -1810,7 +1816,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Requires custom search attributes that the Cloud harness does not provision.")]
     public async Task ExecuteWorkflowAsync_ContinueAsNewSearchAttributes_SetProperly()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -2936,7 +2944,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Requires custom search attributes that the Cloud harness does not provision.")]
     public async Task ExecuteWorkflowAsync_PatchSearchAttribute_ReturnsProperly()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -7855,7 +7865,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
-    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.NeedsCloudAdaptation,
+        "Requires Cloud Nexus endpoint setup and cleanup.")]
     public async Task ExecuteWorkflowAsync_ConverterContext_ProperlyAvailable()
     {
         // It is accepted that this does not test every pemutation of every way a payload converter,

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -5334,6 +5334,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresLocalServer,
+        "Requires two independent servers to verify worker client replacement.")]
     public async Task ExecuteWorkflowAsync_WorkerClientReplacement_UsesNewClient()
     {
         // We are going to create a second ephemeral server and start a workflow on each server.

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -1125,6 +1125,9 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresLocalServer,
+        "Requires history.enableSignalWithStartFromWorkflow dynamic configuration.")]
     public async Task ExecuteWorkflowAsync_SignalWithStartFromWorkflow_Succeeds()
     {
         var newOptions = (TemporalClientOptions)Client.Options.Clone();

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -459,6 +459,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
     public async Task ExecuteWorkflowAsync_HistoryInfo_IsAccurate()
     {
         await ExecuteWorkerAsync<HistoryInfoWorkflow>(async worker =>
@@ -1576,6 +1577,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteWorkflowAsync_SearchAttributes_ProperlyUpserted()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -1633,6 +1635,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteWorkflowAsync_ChildWorkflowSearchAttributes_SetProperly()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -1807,6 +1810,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteWorkflowAsync_ContinueAsNewSearchAttributes_SetProperly()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -2932,6 +2936,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteWorkflowAsync_PatchSearchAttribute_ReturnsProperly()
     {
         await EnsureSearchAttributesPresentAsync();
@@ -7868,6 +7873,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    [CloudTestExclusion(CloudTestExclusionReason.NeedsCloudAdaptation)]
     public async Task ExecuteWorkflowAsync_ConverterContext_ProperlyAvailable()
     {
         // It is accepted that this does not test every pemutation of every way a payload converter,

--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -4075,13 +4075,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 Metrics = new() { Prometheus = new(promAddr), MetricPrefix = "foo_" },
             },
         });
-        var client = await TemporalClient.ConnectAsync(
-            new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = runtime,
-            });
+        var client = await ConnectClientWithRuntimeAsync(runtime);
 
         await ExecuteWorkerAsync<CustomMetricsWorkflow>(
             async worker =>
@@ -4180,13 +4174,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 Metrics = new() { CustomMetricMeter = meter, MetricPrefix = "some-prefix_" },
             },
         });
-        var client = await TemporalClient.ConnectAsync(
-            new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = runtime,
-            });
+        var client = await ConnectClientWithRuntimeAsync(runtime);
 
         // Run workflow
         var taskQueue = string.Empty;
@@ -4254,13 +4242,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                     },
                 },
             });
-            var client = await TemporalClient.ConnectAsync(
-                new()
-                {
-                    TargetHost = Client.Connection.Options.TargetHost,
-                    Namespace = Client.Options.Namespace,
-                    Runtime = runtime,
-                });
+            var client = await ConnectClientWithRuntimeAsync(runtime);
             var taskQueue = string.Empty;
             await ExecuteWorkerAsync<SimpleWorkflow>(
                 async worker =>
@@ -8300,13 +8282,7 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
                 Metrics = new() { Prometheus = new(promAddr), },
             },
         });
-        var client = await TemporalClient.ConnectAsync(
-            new()
-            {
-                TargetHost = Client.Connection.Options.TargetHost,
-                Namespace = Client.Options.Namespace,
-                Runtime = runtime,
-            });
+        var client = await ConnectClientWithRuntimeAsync(runtime);
 
         await ExecuteWorkerAsync<WaitOnSignalThenActivityWorkflow>(
         async worker =>

--- a/tests/Temporalio.Tests/WorkflowEnvironmentEnvConfigTests.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironmentEnvConfigTests.cs
@@ -3,6 +3,7 @@ namespace Temporalio.Tests;
 using Temporalio.Common.EnvConfig;
 using Xunit;
 
+[CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
 public class WorkflowEnvironmentEnvConfigTests
 {
     [Fact]

--- a/tests/Temporalio.Tests/WorkflowEnvironmentEnvConfigTests.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironmentEnvConfigTests.cs
@@ -3,7 +3,9 @@ namespace Temporalio.Tests;
 using Temporalio.Common.EnvConfig;
 using Xunit;
 
-[CloudTestExclusion(CloudTestExclusionReason.RequiresLocalServer)]
+[CloudTestExclusion(
+    CloudTestExclusionReason.RequiresLocalServer,
+    "Starts a local source server to verify environment-config client options.")]
 public class WorkflowEnvironmentEnvConfigTests
 {
     [Fact]

--- a/tests/Temporalio.Tests/WorkflowEnvironmentTestBase.cs
+++ b/tests/Temporalio.Tests/WorkflowEnvironmentTestBase.cs
@@ -5,6 +5,7 @@ namespace Temporalio.Tests;
 using Temporalio.Api.Enums.V1;
 using Temporalio.Client;
 using Temporalio.Common;
+using Temporalio.Runtime;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -45,6 +46,15 @@ public abstract class WorkflowEnvironmentTestBase : TestBase
     protected WorkflowEnvironment Env { get; private init; }
 
     protected ITemporalClient Client { get; private init; }
+
+    protected async Task<TemporalClient> ConnectClientWithRuntimeAsync(TemporalRuntime runtime)
+    {
+        var connectionOptions = (TemporalConnectionOptions)Client.Connection.Options.Clone();
+        connectionOptions.Runtime = runtime;
+        return new(
+            await TemporalConnection.ConnectAsync(connectionOptions),
+            (TemporalClientOptions)Client.Options.Clone());
+    }
 
     /// <summary>Check for Worker Versioning feature support.</summary>
     /// <returns>True if the server supports it.</returns>


### PR DESCRIPTION
## What was changed

This change makes Cloud test eligibility part of xUnit discovery. Tests are eligible by default and
can be excluded at the class or method level with a typed `CloudTestExclusion` trait that records
whether they require a local server, depend on functionality unavailable in Cloud CI, or still need
Cloud adaptation.

The ephemeral mTLS lane introduced by #822 now runs the eligible suite with a standard `dotnet test`
filter and uploads TRX results after cleanup. Tests that create custom-runtime clients clone the
active connection options so envconfig-provided TLS and authentication are retained. The README
documents commands for executing and inventorying both eligible and excluded tests.

Added:
```
dotnet test tests/Temporalio.Tests --list-tests --filter "CloudTestExclusionReason=NeedsCloudAdaptation"
```
to inventory tests that have been skipped against cloud (can filter by any cloud exclusion reason).

## Why?

Running one hand-picked smoke test cannot show which parts of the SDK suite work against Cloud.
Runner-native exclusion metadata makes that segregation automated, queryable, and reviewable
without maintaining a separate file whose entries can drift from xUnit discovery.

The ephemeral namespace lifecycle required by this lane was added in #822 and is now available on
`main`. This PR therefore contains only the suite-segregation and Cloud-execution changes.

## Checklist

1. Closes N/A

2. How was this tested:

   - `dotnet format --verify-no-changes --no-restore`
   - `dotnet test --no-restore` (683 passed, 13 skipped)
   - Targeted exclusion metadata tests (3 passed)
   - xUnit inventory filters for all three exclusion reasons
   - `actionlint .github/workflows/ci.yml`
   - Ephemeral mTLS Cloud suite in GitHub Actions (pending)

3. Any docs updates needed?

   The README documents Cloud eligibility, execution, inventory, and exclusion reasons. This is an
   internal test/CI change, so no changelog entry is needed.
