### PR TITLE
feat: report .NET runtime in heartbeats with opt-out option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ to docs, or any other relevant information.
   backs a Nexus operation with a standalone activity (async only). Cancellation of
   activity-execution operations can be customized by overriding
   `TemporalOperationHandler<TInput, TResult>.CancelActivityExecutionAsync`.
+- Worker heartbeats now report the hosting .NET runtime and its version. Set the new
+  `TemporalRuntimeOptions.DisableEnvironmentInfo` to omit all runtime, hosting, and platform
+  information from heartbeats.
 
 ### Changed
 

--- a/src/Temporalio/Bridge/DotnetRuntimeInfo.cs
+++ b/src/Temporalio/Bridge/DotnetRuntimeInfo.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Diagnostics;
+
+namespace Temporalio.Bridge
+{
+    /// <summary>
+    /// Details of the .NET runtime hosting this process, reported to Core for inclusion in worker
+    /// environment heartbeats.
+    /// </summary>
+    internal static class DotnetRuntimeInfo
+    {
+        private const string DotnetCoreCoreLibName = "System.Private.CoreLib";
+
+        /// <summary>
+        /// Gets the kind of .NET runtime hosting this process, or
+        /// <see cref="Interop.TemporalCoreRuntimeType.Unspecified" /> if it cannot be determined.
+        /// </summary>
+        public static Interop.TemporalCoreRuntimeType RuntimeType { get; } = DetectRuntimeType();
+
+        /// <summary>
+        /// Gets the version of the runtime named by <see cref="RuntimeType" />, or an empty string
+        /// if it cannot be determined.
+        /// </summary>
+        public static string Version { get; } = DetectRuntimeVersion(DetectRuntimeType());
+
+        /// <summary>
+        /// Determine the hosting runtime from CoreLib's simple assembly name.
+        /// </summary>
+        /// <param name="coreLibSimpleName">Simple name of the assembly declaring
+        /// <see cref="object" />.</param>
+        /// <returns>Runtime kind implied by the name.</returns>
+        internal static Interop.TemporalCoreRuntimeType RuntimeTypeOf(string? coreLibSimpleName)
+        {
+            // .NET Core renamed CoreLib; .NET Framework and Mono kept mscorlib.
+            return coreLibSimpleName == DotnetCoreCoreLibName ?
+                Interop.TemporalCoreRuntimeType.DotnetCore :
+                Interop.TemporalCoreRuntimeType.DotnetFramework;
+        }
+
+        /// <summary>
+        /// Determine the version of the given runtime, as version numbers only, or an empty string
+        /// if it cannot be determined.
+        /// </summary>
+        /// <param name="runtimeType">Runtime to report the version of.</param>
+        /// <returns>Version numbers only, or an empty string.</returns>
+        internal static string DetectRuntimeVersion(Interop.TemporalCoreRuntimeType runtimeType)
+        {
+            // Normalized here rather than per-source so every runtime reports numbers only. .NET
+            // Framework needs the file version because Environment.Version reports 4.0.30319 on
+            // every 4.x. Kept separate from RuntimeType so a failed read still reports the runtime.
+            try
+            {
+                return NumericVersionPrefix(runtimeType switch
+                {
+                    Interop.TemporalCoreRuntimeType.DotnetCore => Environment.Version.ToString(),
+                    Interop.TemporalCoreRuntimeType.DotnetFramework =>
+                        FileProductVersion(typeof(object).Assembly.Location),
+                    _ => string.Empty,
+                });
+            }
+#pragma warning disable CA1031
+            catch (Exception)
+            {
+                return string.Empty;
+            }
+#pragma warning restore CA1031
+        }
+
+        /// <summary>
+        /// Read the product version recorded in an assembly file, which is free-form and may carry
+        /// a label, or an empty string when it cannot be read.
+        /// </summary>
+        /// <param name="assemblyLocation">Assembly file to read, empty when unavailable.</param>
+        /// <returns>Product version as recorded, or an empty string.</returns>
+        internal static string FileProductVersion(string assemblyLocation)
+        {
+            // An empty location (single-file apps) is rejected first because GetVersionInfo throws
+            // on it rather than reporting nothing.
+            if (assemblyLocation.Length == 0)
+            {
+                return string.Empty;
+            }
+            try
+            {
+                return FileVersionInfo.GetVersionInfo(assemblyLocation).ProductVersion ??
+                    string.Empty;
+            }
+#pragma warning disable CA1031
+            catch (Exception)
+            {
+                return string.Empty;
+            }
+#pragma warning restore CA1031
+        }
+
+        /// <summary>
+        /// Take the leading run of version numbers from a version string, dropping any trailing
+        /// label.
+        /// </summary>
+        /// <param name="version">Version string, possibly labeled.</param>
+        /// <returns>Leading dotted-numeric run, or an empty string if there is none.</returns>
+        internal static string NumericVersionPrefix(string version)
+        {
+            // A product version is free-form and routinely carries a label the heartbeat should not
+            // report: SemVer prerelease and build metadata on .NET Core, or a trailing note such as
+            // "4.8.9037.0 built by: NET48REL1" on some Windows builds.
+            var end = 0;
+            while (end < version.Length &&
+                ((version[end] >= '0' && version[end] <= '9') || version[end] == '.'))
+            {
+                end++;
+            }
+            while (end > 0 && version[end - 1] == '.')
+            {
+                end--;
+            }
+            return end == version.Length ? version : version.Substring(0, end);
+        }
+
+        private static Interop.TemporalCoreRuntimeType DetectRuntimeType()
+        {
+            // Only the netstandard2.0 asset can be loaded by either runtime, so the others are known
+            // at compile time and skip a reflection call that can fail.
+#if NETFRAMEWORK
+            return Interop.TemporalCoreRuntimeType.DotnetFramework;
+#elif NETCOREAPP
+            return Interop.TemporalCoreRuntimeType.DotnetCore;
+#else
+            // A throw here would become a TypeInitializationException that the CLR caches,
+            // permanently failing runtime creation over telemetry.
+            try
+            {
+                return RuntimeTypeOf(typeof(object).Assembly.GetName().Name);
+            }
+#pragma warning disable CA1031
+            catch (Exception)
+            {
+                return Interop.TemporalCoreRuntimeType.Unspecified;
+            }
+#pragma warning restore CA1031
+#endif
+        }
+    }
+}

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -31,11 +31,27 @@ namespace Temporalio.Bridge
             this Temporalio.Runtime.TemporalRuntimeOptions options,
             Scope scope)
         {
+            // Core does not assume a runtime for the C bridge, so the array must be supplied here
+            // or heartbeats report no runtime at all.
+            var runtimeInfo = new[]
+            {
+                new Interop.TemporalCoreRuntimeInfo
+                {
+                    runtime_type = DotnetRuntimeInfo.RuntimeType,
+                    version = scope.ByteArray(DotnetRuntimeInfo.Version),
+                },
+            };
             return new Interop.TemporalCoreRuntimeOptions()
             {
                 telemetry = scope.Pointer(options.Telemetry.ToInteropOptions(scope)),
                 worker_heartbeat_interval_millis =
                     (ulong)(options.WorkerHeartbeatInterval?.TotalMilliseconds ?? 0),
+                runtime_info = new Interop.TemporalCoreRuntimeInfoArray
+                {
+                    data = scope.ArrayPointer(runtimeInfo),
+                    size = (UIntPtr)runtimeInfo.Length,
+                },
+                disable_environment_info = (byte)(options.DisableEnvironmentInfo ? 1 : 0),
             };
         }
 

--- a/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
+++ b/src/Temporalio/Runtime/TemporalRuntimeOptions.cs
@@ -31,6 +31,12 @@ namespace Temporalio.Runtime
         public TimeSpan? WorkerHeartbeatInterval { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
+        /// Gets or sets a value indicating whether worker heartbeats omit all runtime, hosting, and
+        /// platform information.
+        /// </summary>
+        public bool DisableEnvironmentInfo { get; set; }
+
+        /// <summary>
         /// Create a shallow copy of these options.
         /// </summary>
         /// <returns>A shallow copy of these options and any transitive options fields.</returns>

--- a/tests/Temporalio.Tests/Runtime/DotnetRuntimeInfoTests.cs
+++ b/tests/Temporalio.Tests/Runtime/DotnetRuntimeInfoTests.cs
@@ -1,0 +1,109 @@
+namespace Temporalio.Tests.Runtime;
+
+using System;
+using System.IO;
+using System.Text;
+using Temporalio.Bridge;
+using Temporalio.Runtime;
+using Xunit;
+
+public class DotnetRuntimeInfoTests
+{
+    // The runtime type is internal, so it cannot appear in a public xunit test signature.
+    [Theory]
+    [InlineData("System.Private.CoreLib", true)]
+    [InlineData("mscorlib", false)]
+    [InlineData(null, false)]
+    public void RuntimeTypeOf_CoreLibName_SelectsRuntime(
+        string? coreLibSimpleName, bool expectDotnetCore) =>
+        Assert.Equal(
+            expectDotnetCore ?
+                Bridge.Interop.TemporalCoreRuntimeType.DotnetCore :
+                Bridge.Interop.TemporalCoreRuntimeType.DotnetFramework,
+            DotnetRuntimeInfo.RuntimeTypeOf(coreLibSimpleName));
+
+    [Theory]
+    [InlineData("10.0.9-servicing.26270.113+901ca941248413c79832d2fdbd709da0c4386353", "10.0.9")]
+    [InlineData("10.0.9-servicing.26270.113", "10.0.9")]
+    [InlineData("10.0.9-servicing", "10.0.9")]
+    [InlineData("4.8.9037.0 built by: NET48REL1", "4.8.9037.0")]
+    [InlineData("4.8.9037.0", "4.8.9037.0")]
+    [InlineData("10.0.9+901ca94", "10.0.9")]
+    [InlineData("10.0.", "10.0")]
+    [InlineData("preview", "")]
+    [InlineData("", "")]
+    public void NumericVersionPrefix_LabeledVersion_KeepsNumbersOnly(
+        string productVersion, string expected) =>
+        Assert.Equal(expected, DotnetRuntimeInfo.NumericVersionPrefix(productVersion));
+
+    [Fact]
+    public void FileProductVersion_CoreLibOnDisk_ReturnsProductVersion() =>
+        Assert.NotEmpty(DotnetRuntimeInfo.FileProductVersion(typeof(object).Assembly.Location));
+
+    [Fact]
+    public void FileProductVersion_UnreadableLocation_ReturnsEmpty()
+    {
+        Assert.Empty(DotnetRuntimeInfo.FileProductVersion(string.Empty));
+        Assert.Empty(DotnetRuntimeInfo.FileProductVersion(
+            Path.Combine(Path.GetTempPath(), "temporalio-absent-corelib.dll")));
+    }
+
+    [Fact]
+    public void DetectRuntimeVersion_DotnetCore_ReportsEnvironmentVersion() =>
+        Assert.Equal(
+            Environment.Version.ToString(),
+            DotnetRuntimeInfo.DetectRuntimeVersion(
+                Bridge.Interop.TemporalCoreRuntimeType.DotnetCore));
+
+    [Fact]
+    public void DetectRuntimeVersion_DotnetFramework_ReturnsNumbersOnly()
+    {
+        // Under this suite the .NET Framework path reads CoreLib, whose product version is labeled,
+        // so a parseable result is what proves normalization reaches a real file.
+        var version = DotnetRuntimeInfo.DetectRuntimeVersion(
+            Bridge.Interop.TemporalCoreRuntimeType.DotnetFramework);
+        Assert.NotEmpty(version);
+        Assert.True(Version.TryParse(version, out _), version);
+    }
+
+    [Fact]
+    public void DetectRuntimeVersion_Unspecified_ReturnsEmpty() =>
+        Assert.Empty(DotnetRuntimeInfo.DetectRuntimeVersion(
+            Bridge.Interop.TemporalCoreRuntimeType.Unspecified));
+
+    [Fact]
+    public void DotnetRuntimeInfo_RunningOnDotnetCore_ReportsTypeAndVersion()
+    {
+        // Tests consume the netcoreapp3.1 asset, where the type is a compile-time constant;
+        // RuntimeTypeOf and DetectRuntimeVersion cover the .NET Framework side.
+        Assert.Equal(
+            Bridge.Interop.TemporalCoreRuntimeType.DotnetCore, DotnetRuntimeInfo.RuntimeType);
+        Assert.Equal(Environment.Version.ToString(), DotnetRuntimeInfo.Version);
+    }
+
+    [Fact]
+    public unsafe void ToInteropOptions_Default_ReportsSingleRuntime()
+    {
+        using var scope = new Scope();
+        var options = new TemporalRuntimeOptions().ToInteropOptions(scope);
+
+        Assert.Equal((UIntPtr)1, options.runtime_info.size);
+        Assert.Equal((byte)0, options.disable_environment_info);
+
+        var runtime = options.runtime_info.data[0];
+        Assert.Equal(Bridge.Interop.TemporalCoreRuntimeType.DotnetCore, runtime.runtime_type);
+        Assert.Equal(
+            DotnetRuntimeInfo.Version,
+            Encoding.UTF8.GetString(runtime.version.data, (int)runtime.version.size));
+    }
+
+    [Fact]
+    public unsafe void ToInteropOptions_DisableEnvironmentInfo_SetsFlag()
+    {
+        using var scope = new Scope();
+        var options = new TemporalRuntimeOptions { DisableEnvironmentInfo = true }.
+            ToInteropOptions(scope);
+
+        Assert.Equal((byte)1, options.disable_environment_info);
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Report runtime type and version in worker heartbeat.
- Allow opting out of collection of environment information.

## Why?

Better insights into which runtimes and versions are used to help properly prioritize support.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: New unit tests

1. Any docs updates needed? No
