### PR TITLE
Pass through Nexus handler exceptions in payload serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ to docs, or any other relevant information.
 - Hardened read-only workflow context enforcement so queries, update validators, and patch activation
   callbacks cannot mutate handlers or workflow details, invoke patches, or schedule workflow work.
   Patch activation callbacks also cannot use workflow randomness or issue workflow commands.
+- A `NexusRpc.Handlers.HandlerException` thrown by a payload codec or payload converter while
+  decoding Nexus operation input is now propagated as-is instead of being wrapped in an `Internal`
+  (codec) or `BadRequest` (converter) handler exception. This matches the existing pass-through
+  behavior for `ApplicationFailureException` and lets codecs and converters control the resulting
+  Nexus error type and retry behavior.
 
 ### [1.17.0] - 2026-07-13
 

--- a/src/Temporalio/Worker/NexusPayloadSerializer.cs
+++ b/src/Temporalio/Worker/NexusPayloadSerializer.cs
@@ -54,7 +54,9 @@ namespace Temporalio.Worker
 
             // Decode with payload codec if configured. Codec failures are treated as
             // retryable INTERNAL errors since they are typically transient (e.g. a remote
-            // decryption service is temporarily down).
+            // decryption service is temporarily down). Application failures and handler
+            // exceptions are passed through untouched so users can control the resulting
+            // Nexus error.
             if (dataConverter.PayloadCodec != null)
             {
                 try
@@ -67,7 +69,8 @@ namespace Temporalio.Worker
                     }
                     payload = decoded.First();
                 }
-                catch (Exception e) when (e is not ApplicationFailureException)
+                catch (Exception e) when (
+                    e is not ApplicationFailureException && e is not HandlerException)
                 {
                     throw new HandlerException(
                         HandlerErrorType.Internal,
@@ -78,13 +81,16 @@ namespace Temporalio.Worker
 
             // Convert with payload converter. Converter failures are non-retryable
             // BAD_REQUEST errors since the payload data doesn't match the expected type/format
-            // and retrying with the same input will never succeed.
+            // and retrying with the same input will never succeed. Application failures and
+            // handler exceptions are passed through untouched so users can control the
+            // resulting Nexus error.
             object? result;
             try
             {
                 result = dataConverter.PayloadConverter.ToValue(payload, type);
             }
-            catch (Exception e) when (e is not ApplicationFailureException)
+            catch (Exception e) when (
+                e is not ApplicationFailureException && e is not HandlerException)
             {
                 throw new HandlerException(
                     HandlerErrorType.BadRequest,

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1713,6 +1713,137 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             exc3.Message);
     }
 
+    private class HandlerExceptionCodec : IPayloadCodec
+    {
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult(payloads);
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads)
+        {
+            // Only fail for the Nexus input so unrelated decodes (e.g. workflow failure
+            // details on the caller side) are unaffected
+            if (payloads.Any(p => p.Data.ToStringUtf8().Contains("codec-handler-error")))
+            {
+                throw new HandlerException(
+                    HandlerErrorType.NotFound, "Intentional codec handler exception");
+            }
+            return Task.FromResult(payloads);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_CodecHandlerException_IsPassedThrough()
+    {
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadCodec = new HandlerExceptionCodec(),
+        };
+        var codecClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) => $"Hello, {name}")));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(
+                        svc => svc.DoSomething("codec-handler-error"),
+                        // Bound the operation so a regression (i.e. wrapping in a retryable
+                        // INTERNAL handler exception) fails the test instead of hanging
+                        new() { ScheduleToCloseTimeout = TimeSpan.FromSeconds(20) });
+                return null;
+            })));
+
+        using var worker = new TemporalWorker(codecClient, workerOptions);
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(
+            () => worker.ExecuteAsync(async () =>
+            {
+                var handle = await codecClient.StartWorkflowAsync(
+                    (CustomFuncWorkflow wf) => wf.RunAsync(),
+                    new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+                await handle.GetResultAsync();
+            }));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        // The user's handler exception is passed through instead of being wrapped in an
+        // INTERNAL handler exception
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
+        Assert.Equal(HandlerErrorType.NotFound, exc3.ErrorType);
+        Assert.Contains("Intentional codec handler exception", exc3.Message);
+        Assert.DoesNotContain("Payload codec failed to decode", exc3.Message);
+    }
+
+    private class HandlerExceptionPayloadConverter : IPayloadConverter
+    {
+        private readonly IPayloadConverter inner = DataConverter.Default.PayloadConverter;
+
+        public Payload ToPayload(object? value) => inner.ToPayload(value);
+
+        public object? ToValue(Payload payload, Type type)
+        {
+            var value = inner.ToValue(payload, type);
+            // Only fail for the Nexus input so unrelated conversions are unaffected
+            if (value as string == "converter-handler-error")
+            {
+                throw new HandlerException(
+                    HandlerErrorType.NotFound, "Intentional converter handler exception");
+            }
+            return value;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_ConverterHandlerException_IsPassedThrough()
+    {
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadConverter = new HandlerExceptionPayloadConverter(),
+        };
+        var converterClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) => $"Hello, {name}")));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("converter-handler-error"));
+                return null;
+            })));
+
+        using var worker = new TemporalWorker(converterClient, workerOptions);
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(
+            () => worker.ExecuteAsync(async () =>
+            {
+                var handle = await converterClient.StartWorkflowAsync(
+                    (CustomFuncWorkflow wf) => wf.RunAsync(),
+                    new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+                await handle.GetResultAsync();
+            }));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        // The user's handler exception is passed through instead of being wrapped in a
+        // BAD_REQUEST handler exception
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
+        Assert.Equal(HandlerErrorType.NotFound, exc3.ErrorType);
+        Assert.Contains("Intentional converter handler exception", exc3.Message);
+        Assert.DoesNotContain("Payload converter failed to decode", exc3.Message);
+    }
+
     [Fact]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartWorkflow_Succeeds()
     {


### PR DESCRIPTION
The Nexus payload serializer already let ApplicationFailureException from a payload codec or converter propagate untouched. Do the same for HandlerException so users can control the resulting Nexus error type and retry behavior instead of having it rewrapped as INTERNAL (codec) or BAD_REQUEST (converter).

Matches the behavior of Python and TypeScript SDKs, and to some degree Java and Go with the recent changes in https://github.com/temporalio/sdk-java/pull/3002 and https://github.com/temporalio/sdk-go/pull/2549.