### PR TITLE
fix(ci): pin .NET 10 alpine image

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -41,9 +41,13 @@ runs:
         PACKAGE_SOURCE: ${{ inputs.package-source }}
         VERSION: ${{ inputs.version }}
       run: |
+        # The SDK preinstalled in this image is the one that runs the smoke test, so this
+        # tag must stay on a patch within global.json's feature band and must be bumped
+        # whenever that band changes; the floating 10.0-alpine tag jumps bands
+        # (10.0.302 -> 10.0.400) and breaks SDK resolution.
         docker run --rm -v "$(pwd):/workspace" -w /workspace \
           -e PACKAGE_SOURCE -e VERSION \
-          mcr.microsoft.com/dotnet/sdk:10.0-alpine \
+          mcr.microsoft.com/dotnet/sdk:10.0.302-alpine3.24 \
           sh -c '
             version_arg=""
             [ -n "$VERSION" ] && version_arg="--version $VERSION"

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -41,13 +41,13 @@ jobs:
             out-file: libtemporalio_sdk_core_c_bridge.so
             out-prefix: linux-musl-x64
             # Need Alpine container since GH runner doesn't have one
-            container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+            container: mcr.microsoft.com/dotnet/sdk:10.0.302-alpine3.24
             runsOn: ubuntu-latest
           - os: alpine-arm
             out-file: libtemporalio_sdk_core_c_bridge.so
             out-prefix: linux-musl-arm64
             # Need Alpine container since GH runner doesn't have one
-            container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+            container: mcr.microsoft.com/dotnet/sdk:10.0.302-alpine3.24
             runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-intel
             out-file: libtemporalio_sdk_core_c_bridge.dylib


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Pin the .NET 10 SDK Alpine image so it is compatible with the global.json SDK patch version.

## Why?

The .NET 10 SDK floating tag (`10.0-alpine`) was updated to .NET 10 SDK 10.0.400 within the last day. This is incompatible with the global.json feature band (10.0.3xx). For now, pin the Alpine image to the latest image in the feature band and then migrate to .NET 10 SDK 10.0.4xx after the cooldown period.