### PR TITLE
Expose Core console log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ to docs, or any other relevant information.
   you disable size enforcement by setting `DisablePayloadErrorLimit` to `true` on the worker.
 ### Added
 
+- Added `LoggingOptions.Format` to select compact, pretty, or newline-delimited JSON output for
+  Core logs written to the console.
 - Added experimental SDK payload converter support for values and target types that expose
   Temporal transfer type conversion hooks. This lets hook-aware types delegate
   their wire representation to the configured payload converter, preserving SDK

--- a/src/Temporalio/Bridge/Interop/Interop.cs
+++ b/src/Temporalio/Bridge/Interop/Interop.cs
@@ -37,6 +37,14 @@ namespace Temporalio.Bridge.Interop
         UpDownCounterInteger,
     }
 
+    internal enum TemporalCoreConsoleLogFormat
+    {
+        Unspecified = 0,
+        Compact = 1,
+        Pretty = 2,
+        Json = 3,
+    }
+
     internal enum TemporalCoreForwardedLogLevel
     {
         Trace = 0,
@@ -454,6 +462,9 @@ namespace Temporalio.Bridge.Interop
         [NativeTypeName("struct TemporalCoreByteArrayRef")]
         public TemporalCoreByteArrayRef filter;
 
+        [NativeTypeName("enum TemporalCoreConsoleLogFormat")]
+        public TemporalCoreConsoleLogFormat format;
+
         [NativeTypeName("TemporalCoreForwardedLogCallback")]
         public IntPtr forward_to;
     }
@@ -769,7 +780,7 @@ namespace Temporalio.Bridge.Interop
     {
         public TemporalCoreWorkerVersioningStrategy_Tag tag;
 
-        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L639_C3")]
+        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L647_C3")]
         public _Anonymous_e__Union Anonymous;
 
         internal ref TemporalCoreWorkerVersioningNone none
@@ -809,15 +820,15 @@ namespace Temporalio.Bridge.Interop
         internal unsafe partial struct _Anonymous_e__Union
         {
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L640_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L648_C5")]
             public _Anonymous1_1_e__Struct Anonymous1_1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L643_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L651_C5")]
             public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L646_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L654_C5")]
             public _Anonymous3_1_e__Struct Anonymous3_1;
 
             internal partial struct _Anonymous1_1_e__Struct
@@ -938,7 +949,7 @@ namespace Temporalio.Bridge.Interop
     {
         public TemporalCoreSlotInfo_Tag tag;
 
-        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L713_C3")]
+        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L721_C3")]
         public _Anonymous_e__Union Anonymous;
 
         internal ref TemporalCoreWorkflowSlotInfo_Body workflow_slot_info
@@ -1079,7 +1090,7 @@ namespace Temporalio.Bridge.Interop
     {
         public TemporalCoreSlotSupplier_Tag tag;
 
-        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L819_C3")]
+        [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L827_C3")]
         public _Anonymous_e__Union Anonymous;
 
         internal ref TemporalCoreFixedSizeSlotSupplier fixed_size
@@ -1119,15 +1130,15 @@ namespace Temporalio.Bridge.Interop
         internal unsafe partial struct _Anonymous_e__Union
         {
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L820_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L828_C5")]
             public _Anonymous1_1_e__Struct Anonymous1_1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L823_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L831_C5")]
             public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [FieldOffset(0)]
-            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L826_C5")]
+            [NativeTypeName("__AnonymousRecord_temporal-sdk-core-c-bridge_L834_C5")]
             public _Anonymous3_1_e__Struct Anonymous3_1;
 
             internal partial struct _Anonymous1_1_e__Struct

--- a/src/Temporalio/Bridge/OptionsExtensions.cs
+++ b/src/Temporalio/Bridge/OptionsExtensions.cs
@@ -174,6 +174,17 @@ namespace Temporalio.Bridge
             return new Interop.TemporalCoreLoggingOptions()
             {
                 filter = scope.ByteArray(options.Filter.FilterString),
+                format = options.Format switch
+                {
+                    null => Interop.TemporalCoreConsoleLogFormat.Unspecified,
+                    Temporalio.Runtime.ConsoleLogFormat.Compact =>
+                        Interop.TemporalCoreConsoleLogFormat.Compact,
+                    Temporalio.Runtime.ConsoleLogFormat.Pretty =>
+                        Interop.TemporalCoreConsoleLogFormat.Pretty,
+                    Temporalio.Runtime.ConsoleLogFormat.Json =>
+                        Interop.TemporalCoreConsoleLogFormat.Json,
+                    _ => throw new ArgumentException("Unrecognized console log format"),
+                },
                 // Forward callback is set in the Runtime constructor
                 // forward_to = <set-elsewhere>
             };

--- a/src/Temporalio/Runtime/ConsoleLogFormat.cs
+++ b/src/Temporalio/Runtime/ConsoleLogFormat.cs
@@ -1,0 +1,23 @@
+namespace Temporalio.Runtime
+{
+    /// <summary>
+    /// Format for Core logs written to the console.
+    /// </summary>
+    public enum ConsoleLogFormat
+    {
+        /// <summary>
+        /// Compact single-line text output.
+        /// </summary>
+        Compact,
+
+        /// <summary>
+        /// Human-readable multi-line output.
+        /// </summary>
+        Pretty,
+
+        /// <summary>
+        /// Newline-delimited JSON output.
+        /// </summary>
+        Json,
+    }
+}

--- a/src/Temporalio/Runtime/LoggingOptions.cs
+++ b/src/Temporalio/Runtime/LoggingOptions.cs
@@ -26,6 +26,13 @@ namespace Temporalio.Runtime
         public TelemetryFilterOptions Filter { get; set; } = new();
 
         /// <summary>
+        /// Gets or sets the format for Core logs written to the console. If unset, Core preserves
+        /// its existing output selection, including <c>TEMPORAL_CORE_PRETTY_LOGS</c> support.
+        /// This is ignored when <see cref="Forwarding" /> is set.
+        /// </summary>
+        public ConsoleLogFormat? Format { get; set; }
+
+        /// <summary>
         /// Gets or sets log forwarding options. If not set, logs are not forwarded.
         /// </summary>
         public LogForwardingOptions? Forwarding { get; set; }

--- a/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
+++ b/tests/Temporalio.Tests/Runtime/TemporalRuntimeTests.cs
@@ -20,6 +20,17 @@ public class TemporalRuntimeTests : WorkflowEnvironmentTestBase
     }
 
     [Fact]
+    public unsafe void Runtime_ConsoleLogFormat_ConvertsToInterop()
+    {
+        using var scope = new Scope();
+        var options = new LoggingOptions { Format = ConsoleLogFormat.Json };
+
+        var interopOptions = options.ToInteropOptions(scope);
+
+        Assert.Equal(3, Convert.ToInt32(interopOptions.format));
+    }
+
+    [Fact]
     public async Task Runtime_Separate_BothUsed()
     {
         // Create two clients in separate runtimes with Prometheus endpoints and make calls on them


### PR DESCRIPTION
## What was changed

Added `LoggingOptions.Format` and the `ConsoleLogFormat` enum so applications can select compact, pretty, or newline-delimited JSON output for Core logs written to the console. The option is passed through the generated C interop layer to Core.

## Why?

Applications that ingest logs as structured data need Core to emit JSON directly instead of human-oriented text with ANSI formatting.

## Checklist

1. Closes https://github.com/temporalio/sdk-dotnet/issues/820
2. How was this tested:
   - `dotnet format --verify-no-changes --no-restore`
   - `dotnet pack -c Debug`
   - `dotnet test --filter FullyQualifiedName~TemporalRuntimeTests.Runtime_ConsoleLogFormat_ConvertsToInterop`
3. Any docs updates needed? XML API documentation and the changelog are updated.

Depends on https://github.com/temporalio/sdk-rust/pull/1490.
