### PR TITLE
fix(test): deflake ExecuteWorkflowAsync_PrematureDispose_WorkflowCompletes

### DIFF
--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -8451,22 +8451,21 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
             new TemporalWorkerOptions(parentTaskQueue).AddAllActivities(acts));
     }
 
-    // See https://github.com/temporalio/sdk-dotnet/issues/500
     [Fact]
     public async Task ExecuteWorkflowAsync_PrematureDispose_WorkflowCompletes()
     {
-        using var waitEvent = new AutoResetEvent(false);
+        var waitSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var worker = new TemporalWorker(Client, PrepareWorkerOptions<SimpleWorkflow>(new()));
         Task task = worker.ExecuteAsync(async () =>
         {
-            waitEvent.WaitOne();
+            await waitSource.Task;
             var result = await Client.ExecuteWorkflowAsync(
                 (SimpleWorkflow wf) => wf.RunAsync("Temporal"),
                 new(id: $"dotnet-workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
             Assert.Equal("Hello, Temporal!", result);
         });
         worker.Dispose();
-        waitEvent.Set();
+        waitSource.SetResult();
         await task;
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Switch from using `AutoResetEvent` to `TaskCompletionSource` in the `ExecuteWorkflowAsync_PrematureDispose_WorkflowCompletes` test.

## Why?

The test will frequently stall in the CI. Likely cause is that execution reaches the inner lambda without even yielding once, which causes the execution to block. Since it never yielded, that thread cannot continue on to dispose the worker and set the wait event. Solution is to use a TCS to allow the inner lambda to yield at an await point instead of synchronously block.

## Checklist
<!--- add/delete as needed --->

1. Closes #838 