### PR TITLE
Report non-retryable PayloadValidationError as BadRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Changed
+
+- A non-retryable `ApplicationFailureException` with error type `PayloadValidationError` thrown by a
+  payload codec or payload converter while decoding Nexus operation input is now reported as a
+  non-retryable `BadRequest` handler exception (with the application failure as its cause) instead of
+  an `Internal` one. This lets a data converter signal that the input itself is invalid. The handler
+  exception is reported as `Invalid operation input`, which is distinct from the `failed to decode
+  Nexus operation input` message used when decoding itself fails. Application failures of any other
+  error type, and retryable `PayloadValidationError` failures, keep their existing behavior.
+
 ## [1.18.0] - 2026-08-13
 
 ### :boom: Breaking Changes

--- a/src/Temporalio/Worker/NexusPayloadSerializer.cs
+++ b/src/Temporalio/Worker/NexusPayloadSerializer.cs
@@ -15,6 +15,14 @@ namespace Temporalio.Worker
     /// </summary>
     internal class NexusPayloadSerializer : ISerializer
     {
+        /// <summary>
+        /// Error type of an <see cref="ApplicationFailureException"/> reserved for payload
+        /// validation failures raised by a data converter. A non-retryable failure of this type
+        /// means the input itself is invalid, so it is reported as a bad request rather than a
+        /// handler failure.
+        /// </summary>
+        private const string PayloadValidationErrorType = "PayloadValidationError";
+
         private readonly DataConverter dataConverter;
 
         /// <summary>
@@ -56,7 +64,8 @@ namespace Temporalio.Worker
             // retryable INTERNAL errors since they are typically transient (e.g. a remote
             // decryption service is temporarily down). Application failures and handler
             // exceptions are passed through untouched so users can control the resulting
-            // Nexus error.
+            // Nexus error, except non-retryable payload validation failures which report
+            // invalid input and therefore become non-retryable BAD_REQUEST errors.
             if (dataConverter.PayloadCodec != null)
             {
                 try
@@ -68,6 +77,14 @@ namespace Temporalio.Worker
                         throw new ArgumentException($"Expected 1 payload, found {decoded.Count}");
                     }
                     payload = decoded.First();
+                }
+                catch (Exception e) when (IsPayloadValidationFailure(e))
+                {
+                    throw new HandlerException(
+                        HandlerErrorType.BadRequest,
+                        "Invalid operation input",
+                        e,
+                        HandlerErrorRetryBehavior.NonRetryable);
                 }
                 catch (Exception e) when (
                     e is not ApplicationFailureException && e is not HandlerException)
@@ -83,11 +100,20 @@ namespace Temporalio.Worker
             // BAD_REQUEST errors since the payload data doesn't match the expected type/format
             // and retrying with the same input will never succeed. Application failures and
             // handler exceptions are passed through untouched so users can control the
-            // resulting Nexus error.
+            // resulting Nexus error, except non-retryable payload validation failures which
+            // report invalid input and therefore become non-retryable BAD_REQUEST errors.
             object? result;
             try
             {
                 result = dataConverter.PayloadConverter.ToValue(payload, type);
+            }
+            catch (Exception e) when (IsPayloadValidationFailure(e))
+            {
+                throw new HandlerException(
+                    HandlerErrorType.BadRequest,
+                    "Invalid operation input",
+                    e,
+                    HandlerErrorRetryBehavior.NonRetryable);
             }
             catch (Exception e) when (
                 e is not ApplicationFailureException && e is not HandlerException)
@@ -108,5 +134,16 @@ namespace Temporalio.Worker
             }
             return result;
         }
+
+        /// <summary>
+        /// Whether the given exception reports that the payload itself is invalid, i.e. it is a
+        /// non-retryable application failure with the reserved payload validation error type.
+        /// </summary>
+        /// <param name="e">Exception to check.</param>
+        /// <returns>True if the exception reports an invalid payload.</returns>
+        private static bool IsPayloadValidationFailure(Exception e) =>
+            e is ApplicationFailureException appExc &&
+            appExc.NonRetryable &&
+            appExc.ErrorType == PayloadValidationErrorType;
     }
 }

--- a/tests/Temporalio.Tests/Worker/NexusPayloadSerializerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusPayloadSerializerTests.cs
@@ -1,0 +1,182 @@
+namespace Temporalio.Tests.Worker;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using NexusRpc;
+using NexusRpc.Handlers;
+using Temporalio.Api.Common.V1;
+using Temporalio.Converters;
+using Temporalio.Exceptions;
+using Temporalio.Worker;
+using Xunit;
+
+/// <summary>
+/// Server-independent unit tests for how <see cref="NexusPayloadSerializer"/> translates data
+/// converter failures into Nexus handler errors.
+/// </summary>
+public class NexusPayloadSerializerTests
+{
+    [Fact]
+    public async Task DeserializeAsync_ConverterPayloadValidationFailure_BecomesBadRequest()
+    {
+        var cause = new ApplicationFailureException(
+            "Intentional payload validation failure",
+            errorType: "PayloadValidationError",
+            nonRetryable: true);
+        var serializer = new NexusPayloadSerializer(DataConverter.Default with
+        {
+            PayloadConverter = new ThrowingPayloadConverter(cause),
+        });
+        var content = await CreateContentAsync("some-input");
+
+        var exc = await Assert.ThrowsAsync<HandlerException>(
+            () => serializer.DeserializeAsync(content, typeof(string)));
+        Assert.Equal(HandlerErrorType.BadRequest, exc.ErrorType);
+        Assert.Equal(HandlerErrorRetryBehavior.NonRetryable, exc.ErrorRetryBehavior);
+        // A validation failure gets its own message, distinct from the generic decode failure
+        Assert.Equal("Invalid operation input", exc.Message);
+        Assert.Same(cause, exc.InnerException);
+        var inner = Assert.IsType<ApplicationFailureException>(exc.InnerException);
+        Assert.Equal("Intentional payload validation failure", inner.Message);
+        Assert.Equal("PayloadValidationError", inner.ErrorType);
+        Assert.True(inner.NonRetryable);
+    }
+
+    [Fact]
+    public async Task DeserializeAsync_CodecPayloadValidationFailure_BecomesBadRequest()
+    {
+        var cause = new ApplicationFailureException(
+            "Intentional payload validation failure",
+            errorType: "PayloadValidationError",
+            nonRetryable: true);
+        var serializer = new NexusPayloadSerializer(DataConverter.Default with
+        {
+            PayloadCodec = new ThrowingPayloadCodec(cause),
+        });
+        var content = await CreateContentAsync("some-input");
+
+        var exc = await Assert.ThrowsAsync<HandlerException>(
+            () => serializer.DeserializeAsync(content, typeof(string)));
+        Assert.Equal(HandlerErrorType.BadRequest, exc.ErrorType);
+        Assert.Equal(HandlerErrorRetryBehavior.NonRetryable, exc.ErrorRetryBehavior);
+        // A validation failure gets its own message, distinct from the generic decode failure
+        Assert.Equal("Invalid operation input", exc.Message);
+        Assert.Same(cause, exc.InnerException);
+        var inner = Assert.IsType<ApplicationFailureException>(exc.InnerException);
+        Assert.Equal("Intentional payload validation failure", inner.Message);
+        Assert.Equal("PayloadValidationError", inner.ErrorType);
+        Assert.True(inner.NonRetryable);
+    }
+
+    [Fact]
+    public async Task DeserializeAsync_ConverterOtherFailure_KeepsGenericDecodeMessage()
+    {
+        var cause = new InvalidOperationException("Simulated converter failure");
+        var serializer = new NexusPayloadSerializer(DataConverter.Default with
+        {
+            PayloadConverter = new ThrowingPayloadConverter(cause),
+        });
+        var content = await CreateContentAsync("some-input");
+
+        var exc = await Assert.ThrowsAsync<HandlerException>(
+            () => serializer.DeserializeAsync(content, typeof(string)));
+        Assert.Equal(HandlerErrorType.BadRequest, exc.ErrorType);
+        Assert.Equal(HandlerErrorRetryBehavior.NonRetryable, exc.ErrorRetryBehavior);
+        Assert.Equal("Payload converter failed to decode Nexus operation input", exc.Message);
+        Assert.Same(cause, exc.InnerException);
+    }
+
+    [Fact]
+    public async Task DeserializeAsync_CodecOtherFailure_KeepsGenericDecodeMessage()
+    {
+        var cause = new InvalidOperationException("Simulated codec failure");
+        var serializer = new NexusPayloadSerializer(DataConverter.Default with
+        {
+            PayloadCodec = new ThrowingPayloadCodec(cause),
+        });
+        var content = await CreateContentAsync("some-input");
+
+        var exc = await Assert.ThrowsAsync<HandlerException>(
+            () => serializer.DeserializeAsync(content, typeof(string)));
+        Assert.Equal(HandlerErrorType.Internal, exc.ErrorType);
+        Assert.Equal("Payload codec failed to decode Nexus operation input", exc.Message);
+        Assert.Same(cause, exc.InnerException);
+    }
+
+    // Only a non-retryable failure with the exact reserved error type is a bad request, everything
+    // else is passed through untouched for the regular error handling path to convert.
+    [Theory]
+    [InlineData(false, "PayloadValidationError")]
+    [InlineData(true, "SomeOtherError")]
+    [InlineData(false, "SomeOtherError")]
+    [InlineData(true, null)]
+    public async Task DeserializeAsync_ConverterOtherApplicationFailure_IsPassedThrough(
+        bool nonRetryable, string? errorType)
+    {
+        var cause = new ApplicationFailureException(
+            "Intentional failure", errorType: errorType, nonRetryable: nonRetryable);
+        var serializer = new NexusPayloadSerializer(DataConverter.Default with
+        {
+            PayloadConverter = new ThrowingPayloadConverter(cause),
+        });
+        var content = await CreateContentAsync("some-input");
+
+        var exc = await Assert.ThrowsAsync<ApplicationFailureException>(
+            () => serializer.DeserializeAsync(content, typeof(string)));
+        Assert.Same(cause, exc);
+    }
+
+    [Theory]
+    [InlineData(false, "PayloadValidationError")]
+    [InlineData(true, "SomeOtherError")]
+    [InlineData(false, "SomeOtherError")]
+    [InlineData(true, null)]
+    public async Task DeserializeAsync_CodecOtherApplicationFailure_IsPassedThrough(
+        bool nonRetryable, string? errorType)
+    {
+        var cause = new ApplicationFailureException(
+            "Intentional failure", errorType: errorType, nonRetryable: nonRetryable);
+        var serializer = new NexusPayloadSerializer(DataConverter.Default with
+        {
+            PayloadCodec = new ThrowingPayloadCodec(cause),
+        });
+        var content = await CreateContentAsync("some-input");
+
+        var exc = await Assert.ThrowsAsync<ApplicationFailureException>(
+            () => serializer.DeserializeAsync(content, typeof(string)));
+        Assert.Same(cause, exc);
+    }
+
+    private static async Task<ISerializer.Content> CreateContentAsync(string value)
+    {
+        var payload = await DataConverter.Default.ToPayloadAsync(value);
+        return new(payload.ToByteArray());
+    }
+
+    private class ThrowingPayloadConverter : IPayloadConverter
+    {
+        private readonly IPayloadConverter inner = DataConverter.Default.PayloadConverter;
+        private readonly Exception exception;
+
+        public ThrowingPayloadConverter(Exception exception) => this.exception = exception;
+
+        public Payload ToPayload(object? value) => inner.ToPayload(value);
+
+        public object? ToValue(Payload payload, Type type) => throw exception;
+    }
+
+    private class ThrowingPayloadCodec : IPayloadCodec
+    {
+        private readonly Exception exception;
+
+        public ThrowingPayloadCodec(Exception exception) => this.exception = exception;
+
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(
+            IReadOnlyCollection<Payload> payloads) => Task.FromResult(payloads);
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(
+            IReadOnlyCollection<Payload> payloads) => throw exception;
+    }
+}

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1964,7 +1964,139 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
         Assert.Equal(HandlerErrorType.Internal, exc3.ErrorType);
         Assert.DoesNotContain("Payload converter failed to decode", exc3.Message);
-        Assert.DoesNotContain("Payload converter rejected", exc3.Message);
+        Assert.DoesNotContain("Invalid operation input", exc3.Message);
+        var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
+        Assert.Equal("Intentional application failure", exc4.Message);
+        Assert.Equal("SomeOtherError", exc4.ErrorType);
+    }
+
+    private class ApplicationFailureCodec : IPayloadCodec
+    {
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(IReadOnlyCollection<Payload> payloads) =>
+            Task.FromResult(payloads);
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(IReadOnlyCollection<Payload> payloads)
+        {
+            // Only fail for the Nexus input so unrelated decodes (e.g. workflow failure
+            // details on the caller side) are unaffected
+            if (payloads.Any(p => p.Data.ToStringUtf8().Contains("codec-payload-validation-error")))
+            {
+                throw new ApplicationFailureException(
+                    "Intentional payload validation failure",
+                    errorType: "PayloadValidationError",
+                    nonRetryable: true);
+            }
+            if (payloads.Any(p => p.Data.ToStringUtf8().Contains("codec-other-application-error")))
+            {
+                throw new ApplicationFailureException(
+                    "Intentional application failure",
+                    errorType: "SomeOtherError",
+                    nonRetryable: true);
+            }
+            return Task.FromResult(payloads);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_CodecPayloadValidationFailure_IsBadRequest()
+    {
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadCodec = new ApplicationFailureCodec(),
+        };
+        var codecClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) => $"Hello, {name}")));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(
+                        svc => svc.DoSomething("codec-payload-validation-error"),
+                        // Bound the operation so a regression (i.e. keeping the retryable
+                        // INTERNAL handler exception) fails the test instead of hanging
+                        new() { ScheduleToCloseTimeout = TimeSpan.FromSeconds(20) });
+                return null;
+            })));
+
+        using var worker = new TemporalWorker(codecClient, workerOptions);
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(
+            () => worker.ExecuteAsync(async () =>
+            {
+                var handle = await codecClient.StartWorkflowAsync(
+                    (CustomFuncWorkflow wf) => wf.RunAsync(),
+                    new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+                await handle.GetResultAsync();
+            }));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        // A non-retryable payload validation failure means the input itself is invalid, so it
+        // becomes a non-retryable BAD_REQUEST instead of the retryable INTERNAL a codec failure
+        // would otherwise get
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
+        Assert.Equal(HandlerErrorType.BadRequest, exc3.ErrorType);
+        Assert.Equal(HandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
+        // A validation failure gets its own message, distinct from the generic decode failure
+        Assert.Contains("Invalid operation input", exc3.Message);
+        Assert.DoesNotContain("Payload codec failed to decode", exc3.Message);
+        var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
+        Assert.Equal("Intentional payload validation failure", exc4.Message);
+        Assert.Equal("PayloadValidationError", exc4.ErrorType);
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_CodecApplicationFailure_IsInternal()
+    {
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadCodec = new ApplicationFailureCodec(),
+        };
+        var codecClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) => $"Hello, {name}")));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(
+                        svc => svc.DoSomething("codec-other-application-error"),
+                        new() { ScheduleToCloseTimeout = TimeSpan.FromSeconds(20) });
+                return null;
+            })));
+
+        using var worker = new TemporalWorker(codecClient, workerOptions);
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(
+            () => worker.ExecuteAsync(async () =>
+            {
+                var handle = await codecClient.StartWorkflowAsync(
+                    (CustomFuncWorkflow wf) => wf.RunAsync(),
+                    new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+                await handle.GetResultAsync();
+            }));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        // The BAD_REQUEST translation only applies to the reserved payload validation error type,
+        // any other application failure keeps its INTERNAL treatment
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
+        Assert.Equal(HandlerErrorType.Internal, exc3.ErrorType);
+        Assert.DoesNotContain("Payload codec failed to decode", exc3.Message);
+        Assert.DoesNotContain("Invalid operation input", exc3.Message);
         var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
         Assert.Equal("Intentional application failure", exc4.Message);
         Assert.Equal("SomeOtherError", exc4.ErrorType);

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1844,6 +1844,132 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         Assert.DoesNotContain("Payload converter failed to decode", exc3.Message);
     }
 
+    private class ApplicationFailurePayloadConverter : IPayloadConverter
+    {
+        private readonly IPayloadConverter inner = DataConverter.Default.PayloadConverter;
+
+        public Payload ToPayload(object? value) => inner.ToPayload(value);
+
+        public object? ToValue(Payload payload, Type type)
+        {
+            var value = inner.ToValue(payload, type);
+            // Only fail for the Nexus input so unrelated conversions are unaffected
+            switch (value as string)
+            {
+                case "payload-validation-error":
+                    throw new ApplicationFailureException(
+                        "Intentional payload validation failure",
+                        errorType: "PayloadValidationError",
+                        nonRetryable: true);
+                case "other-application-error":
+                    throw new ApplicationFailureException(
+                        "Intentional application failure",
+                        errorType: "SomeOtherError",
+                        nonRetryable: true);
+            }
+            return value;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_ConverterPayloadValidationFailure_IsBadRequest()
+    {
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadConverter = new ApplicationFailurePayloadConverter(),
+        };
+        var converterClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) => $"Hello, {name}")));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("payload-validation-error"));
+                return null;
+            })));
+
+        using var worker = new TemporalWorker(converterClient, workerOptions);
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(
+            () => worker.ExecuteAsync(async () =>
+            {
+                var handle = await converterClient.StartWorkflowAsync(
+                    (CustomFuncWorkflow wf) => wf.RunAsync(),
+                    new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+                await handle.GetResultAsync();
+            }));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        // A non-retryable payload validation failure means the input itself is invalid, so it
+        // becomes a non-retryable BAD_REQUEST instead of an INTERNAL handler error
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
+        Assert.Equal(HandlerErrorType.BadRequest, exc3.ErrorType);
+        Assert.Equal(HandlerErrorRetryBehavior.NonRetryable, exc3.ErrorRetryBehavior);
+        // A validation failure gets its own message, distinct from the generic decode failure
+        Assert.Contains(
+            "Invalid operation input", exc3.Message);
+        Assert.DoesNotContain("Payload converter failed to decode", exc3.Message);
+        var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
+        Assert.Equal("Intentional payload validation failure", exc4.Message);
+        Assert.Equal("PayloadValidationError", exc4.ErrorType);
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_ConverterApplicationFailure_IsInternal()
+    {
+        var newOptions = (TemporalClientOptions)Client.Options.Clone();
+        newOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadConverter = new ApplicationFailurePayloadConverter(),
+        };
+        var converterClient = new TemporalClient(Client.Connection, newOptions);
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>((ctx, name) => $"Hello, {name}")));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
+        workerOptions.Interceptors = new IWorkerInterceptor[] { new XunitExceptionInterceptor() };
+        workerOptions.AddWorkflow(WorkflowDefinition.Create(
+            typeof(CustomFuncWorkflow),
+            null,
+            _args => new CustomFuncWorkflow(async () =>
+            {
+                await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("other-application-error"));
+                return null;
+            })));
+
+        using var worker = new TemporalWorker(converterClient, workerOptions);
+        var exc1 = await Assert.ThrowsAsync<WorkflowFailedException>(
+            () => worker.ExecuteAsync(async () =>
+            {
+                var handle = await converterClient.StartWorkflowAsync(
+                    (CustomFuncWorkflow wf) => wf.RunAsync(),
+                    new($"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
+                await handle.GetResultAsync();
+            }));
+        var exc2 = Assert.IsType<NexusOperationFailureException>(exc1.InnerException);
+        // The BAD_REQUEST translation only applies to the reserved payload validation error type,
+        // any other application failure keeps its INTERNAL treatment
+        var exc3 = Assert.IsType<HandlerException>(exc2.InnerException);
+        Assert.Equal(HandlerErrorType.Internal, exc3.ErrorType);
+        Assert.DoesNotContain("Payload converter failed to decode", exc3.Message);
+        Assert.DoesNotContain("Payload converter rejected", exc3.Message);
+        var exc4 = Assert.IsType<ApplicationFailureException>(exc3.InnerException);
+        Assert.Equal("Intentional application failure", exc4.Message);
+        Assert.Equal("SomeOtherError", exc4.ErrorType);
+    }
+
     [Fact]
     public async Task ExecuteNexusOperationAsync_GenericHandler_StartWorkflow_Succeeds()
     {


### PR DESCRIPTION
## What changed

A payload codec or payload converter can now signal that a Nexus operation's input is invalid by throwing a non-retryable `ApplicationFailureException` with error type `PayloadValidationError` while decoding the input. Such a failure is translated into a non-retryable `BadRequest` `HandlerException` with the message `Invalid operation input`, retaining the original failure as its inner exception.

Previously such a failure became an `Internal` handler exception on the codec path, which callers retry — so a caller sending invalid input was retried until timeout instead of failing fast. On the converter path the type was already `BadRequest`, but it shared the generic `Payload converter failed to decode Nexus operation input` message, so a validation rejection was indistinguishable from a genuine decode failure; it now gets its own message.

## Unchanged

- `ApplicationFailureException` of any other error type → `Internal` on the codec path (as before)
- A **retryable** `PayloadValidationError` → unchanged; non-retryable is required
- `HandlerException` thrown by the codec/converter → passed through untouched
- The generic decode-failure messages are untouched for non-validation failures
- The serialize/output path is untouched — `BadRequest` would be wrong for a result-encoding failure

## Tests

- `NexusPayloadSerializerTests.cs` (new): 10 server-independent cases covering both the codec and converter stages — positive cases asserting `BadRequest`, `NonRetryable`, the wrapper message, and that the inner exception is an `ApplicationFailureException` with its message and `ErrorType` preserved; plus a `[Theory]` over the negative combinations (retryable + validation type, non-retryable + other type, retryable + other type, null type) asserting the failure propagates unwrapped.
- `NexusWorkerTests.cs`: functional coverage against a real dev server for the converter path, asserting the caller sees a non-retryable `BadRequest` with an `ApplicationFailureException` cause, and a negative test that another error type still yields `Internal`.

## Cross-SDK

Part of a coordinated change; equivalent PRs exist for Go, Java, TypeScript and Python. The wrapper message wording is aligned across SDKs, adapted to each SDK's message style.