### PR TITLE
Deflake premature worker disposal test

### DIFF
--- a/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/WorkflowWorkerTests.cs
@@ -8455,18 +8455,18 @@ public class WorkflowWorkerTests : WorkflowEnvironmentTestBase
     [Fact]
     public async Task ExecuteWorkflowAsync_PrematureDispose_WorkflowCompletes()
     {
-        using var waitEvent = new AutoResetEvent(false);
+        var waitSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var worker = new TemporalWorker(Client, PrepareWorkerOptions<SimpleWorkflow>(new()));
         Task task = worker.ExecuteAsync(async () =>
         {
-            waitEvent.WaitOne();
+            await waitSource.Task;
             var result = await Client.ExecuteWorkflowAsync(
                 (SimpleWorkflow wf) => wf.RunAsync("Temporal"),
                 new(id: $"dotnet-workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
             Assert.Equal("Hello, Temporal!", result);
         });
         worker.Dispose();
-        waitEvent.Set();
+        waitSource.SetResult();
         await task;
     }
 


### PR DESCRIPTION
Recreating #841 due to CLA issues with the GitHub identity of the bot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change with no production code impact.
> 
> **Overview**
> **Deflakes** `ExecuteWorkflowAsync_PrematureDispose_WorkflowCompletes` (issue #500) by replacing `AutoResetEvent` with a `TaskCompletionSource` using `RunContinuationsAsynchronously`.
> 
> The test still blocks `ExecuteAsync` until signaled, then disposes the worker and completes the wait so the workflow can finish—same scenario, but async coordination avoids race-prone `WaitOne`/`Set` timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e606ded1890deae0b7279e6b4828faab55e2c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->