### PR TITLE
build(deps): update Swatinem/rust-cache action to latest release version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,8 +37,7 @@ runs:
 
     - name: Setup Rust cache
       if: ${{ inputs.install != 'false' }}
-      # Fixed version due to https://github.com/Swatinem/rust-cache/issues/183#issuecomment-1893979126
-      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       with:
         workspaces: src/Temporalio/Bridge/sdk-core
         key: ${{ inputs.rust-cache-key }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Update the `Swatinem/rust-cache` GitHub action to the latest release version

## Why?

Currently using some intermediate version and dependabot is updating to latest from main. Should use release versions unless other specific need makes it necessary to use an off-release version.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: CI

1. Any docs updates needed? No
