### PR TITLE
Support generic transfer type converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Experimental Temporal transfer type conversion now supports constructed generic models whose
+  attributes reference generic converter type definitions. Model type arguments close the converter
+  directly in declaration order, with matching generic arity and compatible constraints required.
 - Added `PayloadValidationError.CreateException`, which payload converters and codecs can use to
   report invalid Nexus operation input with structured details.
 

--- a/src/Temporalio/Converters/TemporalTransferTypeConverterAttribute.cs
+++ b/src/Temporalio/Converters/TemporalTransferTypeConverterAttribute.cs
@@ -9,6 +9,11 @@ namespace Temporalio.Converters
     /// This is used by the SDK payload converter to delegate hook-aware values to the configured
     /// payload converter using the transfer type representation provided by
     /// <see cref="ITemporalTransferTypeConverter"/>.
+    /// A constructed generic type may specify a generic converter type definition. The SDK
+    /// closes the converter with all generic arguments from the marked type in declaration order.
+    /// The marked type and converter must have the same generic arity, and the arguments must
+    /// satisfy the converter's generic constraints. Closed converter types remain supported for
+    /// both generic and non-generic marked types.
     /// This API is experimental and may change in a future release.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
@@ -18,8 +23,9 @@ namespace Temporalio.Converters
         /// Initializes a new instance of the
         /// <see cref="TemporalTransferTypeConverterAttribute"/> class.
         /// </summary>
-        /// <param name="converterType">Converter type implementing
-        /// <see cref="ITemporalTransferTypeConverter"/>.</param>
+        /// <param name="converterType">Closed converter type implementing
+        /// <see cref="ITemporalTransferTypeConverter"/>, or a generic converter type
+        /// definition whose generic parameters directly match those of the marked type.</param>
         public TemporalTransferTypeConverterAttribute(Type converterType) =>
             ConverterType = converterType;
 

--- a/src/Temporalio/Converters/TemporalTransferTypePayloadConverter.cs
+++ b/src/Temporalio/Converters/TemporalTransferTypePayloadConverter.cs
@@ -111,12 +111,12 @@ namespace Temporalio.Converters
                 {
                     converterType = converterType.MakeGenericType(typeArguments);
                 }
-                catch (ArgumentException err)
+                catch (ArgumentException e)
                 {
                     throw new InvalidOperationException(
                         $"Type {type} cannot close Temporal transfer type converter type " +
                         $"{attr.ConverterType} because its generic arguments do not satisfy the converter constraints.",
-                        err);
+                        e);
                 }
             }
 
@@ -130,12 +130,6 @@ namespace Temporalio.Converters
             {
                 throw new InvalidOperationException(
                     $"Type {type} has an abstract Temporal transfer type converter type " +
-                    $"{converterType}.");
-            }
-            if (converterType.ContainsGenericParameters)
-            {
-                throw new InvalidOperationException(
-                    $"Type {type} has an open generic Temporal transfer type converter type " +
                     $"{converterType}.");
             }
             if (!converterType.IsValueType &&

--- a/src/Temporalio/Converters/TemporalTransferTypePayloadConverter.cs
+++ b/src/Temporalio/Converters/TemporalTransferTypePayloadConverter.cs
@@ -83,43 +83,80 @@ namespace Temporalio.Converters
                 return null;
             }
 
-            if (!typeof(ITemporalTransferTypeConverter).IsAssignableFrom(attr.ConverterType))
+            var converterType = attr.ConverterType;
+            if (converterType.ContainsGenericParameters)
+            {
+                if (!type.IsGenericType || type.ContainsGenericParameters)
+                {
+                    throw new InvalidOperationException(
+                        $"Type {type} declares open generic Temporal transfer type converter type " +
+                        $"{attr.ConverterType}, but the marked type is not a closed constructed generic type.");
+                }
+                if (!converterType.IsGenericTypeDefinition)
+                {
+                    throw new InvalidOperationException(
+                        $"Type {type} declares open generic Temporal transfer type converter type " +
+                        $"{attr.ConverterType}, which cannot be closed because it is not a generic type definition.");
+                }
+
+                var typeArguments = type.GetGenericArguments();
+                if (converterType.GetGenericArguments().Length != typeArguments.Length)
+                {
+                    throw new InvalidOperationException(
+                        $"Type {type} and its open generic Temporal transfer type converter type " +
+                        $"{attr.ConverterType} have different generic arities.");
+                }
+
+                try
+                {
+                    converterType = converterType.MakeGenericType(typeArguments);
+                }
+                catch (ArgumentException err)
+                {
+                    throw new InvalidOperationException(
+                        $"Type {type} cannot close Temporal transfer type converter type " +
+                        $"{attr.ConverterType} because its generic arguments do not satisfy the converter constraints.",
+                        err);
+                }
+            }
+
+            if (!typeof(ITemporalTransferTypeConverter).IsAssignableFrom(converterType))
             {
                 throw new InvalidOperationException(
                     $"Type {type} has a Temporal transfer type converter type " +
-                    $"{attr.ConverterType} that does not implement {nameof(ITemporalTransferTypeConverter)}.");
+                    $"{converterType} that does not implement {nameof(ITemporalTransferTypeConverter)}.");
             }
-            if (attr.ConverterType.IsAbstract)
+            if (converterType.IsAbstract)
             {
                 throw new InvalidOperationException(
                     $"Type {type} has an abstract Temporal transfer type converter type " +
-                    $"{attr.ConverterType}.");
+                    $"{converterType}.");
             }
-            if (attr.ConverterType.ContainsGenericParameters)
+            if (converterType.ContainsGenericParameters)
             {
                 throw new InvalidOperationException(
                     $"Type {type} has an open generic Temporal transfer type converter type " +
-                    $"{attr.ConverterType}.");
+                    $"{converterType}.");
             }
-            if (!attr.ConverterType.IsValueType &&
-                attr.ConverterType.GetConstructor(Type.EmptyTypes) == null)
+            if (!converterType.IsValueType &&
+                converterType.GetConstructor(Type.EmptyTypes) == null)
             {
                 throw new InvalidOperationException(
                     $"Type {type} has a Temporal transfer type converter type " +
-                    $"{attr.ConverterType} without a public parameterless constructor.");
+                    $"{converterType} without a public parameterless constructor.");
             }
 
-            if (Activator.CreateInstance(attr.ConverterType) is not ITemporalTransferTypeConverter converter)
+            if (Activator.CreateInstance(converterType) is not ITemporalTransferTypeConverter converter)
             {
                 throw new InvalidOperationException(
                     $"Type {type} has a Temporal transfer type converter type " +
-                    $"{attr.ConverterType} that could not be instantiated.");
+                    $"{converterType} that could not be instantiated.");
             }
             if (converter.TransferType == null)
             {
                 throw new InvalidOperationException(
                     $"Type {type} has a Temporal transfer type converter type " +
-                    $"{attr.ConverterType} with a null transfer type.");
+                    $"{converterType} with a null transfer type.");
             }
 
             return converter;

--- a/tests/Temporalio.Tests/Converters/PayloadConverterTests.cs
+++ b/tests/Temporalio.Tests/Converters/PayloadConverterTests.cs
@@ -157,10 +157,70 @@ public class PayloadConverterTests : TestBase
         Assert.Equal(value, converter.ToValue(payload, typeof(AnnotatedDerivedTransferTypeHookValue)));
     }
 
+    [Fact]
+    public void ToPayload_TransferTypeHooks_GenericConverter_Succeeds()
+    {
+        var converter = TemporalTransferTypePayloadConverter.Wrap(new DefaultPayloadConverter());
+        var stringValue = new GenericTransferTypeHookValue<string>("payload-value");
+        var intValue = new GenericTransferTypeHookValue<int>(1234);
+
+        var stringPayload = converter.ToPayload(stringValue);
+        var intPayload = converter.ToPayload(intValue);
+
+        Assert.Equal(
+            stringValue,
+            converter.ToValue(stringPayload, typeof(GenericTransferTypeHookValue<string>)));
+        Assert.Equal(
+            intValue,
+            converter.ToValue(intPayload, typeof(GenericTransferTypeHookValue<int>)));
+    }
+
+    [Fact]
+    public void ToPayload_TransferTypeHooks_OpenGenericConverterPreservesArgumentOrder_Succeeds()
+    {
+        var converter = TemporalTransferTypePayloadConverter.Wrap(new DefaultPayloadConverter());
+        var value = new OrderedGenericTransferTypeHookValue<string, int>("payload-value", 1234);
+
+        var payload = converter.ToPayload(value);
+
+        Assert.Equal(
+            value,
+            converter.ToValue(
+                payload,
+                typeof(OrderedGenericTransferTypeHookValue<string, int>)));
+    }
+
+    [Fact]
+    public void ToPayload_TransferTypeHooks_ClosedConverterOnGenericType_Succeeds()
+    {
+        var converter = TemporalTransferTypePayloadConverter.Wrap(new DefaultPayloadConverter());
+        var value = new ClosedConverterGenericTransferTypeHookValue<int>("payload-value");
+
+        var payload = converter.ToPayload(value);
+
+        Assert.Equal(
+            value,
+            converter.ToValue(
+                payload,
+                typeof(ClosedConverterGenericTransferTypeHookValue<int>)));
+    }
+
+    [Fact]
+    public void ToPayload_TransferTypeHooks_NestedOpenGenericConverter_Succeeds()
+    {
+        var converter = TemporalTransferTypePayloadConverter.Wrap(new DefaultPayloadConverter());
+        var value = new NestedGenericTransferTypeHookValue<int>(1234);
+
+        var payload = converter.ToPayload(value);
+
+        Assert.Equal(
+            value,
+            converter.ToValue(payload, typeof(NestedGenericTransferTypeHookValue<int>)));
+    }
+
     [Theory]
     [InlineData(typeof(NonAssignableConverterHookValue), "does not implement")]
     [InlineData(typeof(AbstractConverterHookValue), "abstract")]
-    [InlineData(typeof(OpenGenericConverterHookValue), "open generic")]
     [InlineData(typeof(ParameterConstructorConverterHookValue), "public parameterless constructor")]
     [InlineData(typeof(PrivateConstructorConverterHookValue), "public parameterless constructor")]
     public void ToPayload_TransferTypeHooks_InvalidConverterType_Fails(
@@ -173,6 +233,34 @@ public class PayloadConverterTests : TestBase
         var exception = Assert.Throws<InvalidOperationException>(() => converter.ToPayload(value));
 
         Assert.Contains(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(
+        typeof(OpenGenericConverterHookValue),
+        typeof(GenericTransferTypeHookValueConverter<>),
+        "not a closed constructed generic type")]
+    [InlineData(
+        typeof(GenericArityMismatchConverterHookValue<string>),
+        typeof(OrderedGenericTransferTypeHookValueConverter<,>),
+        "different generic arities")]
+    [InlineData(
+        typeof(GenericConstraintConverterHookValue<string>),
+        typeof(StructGenericTransferTypeHookValueConverter<>),
+        "do not satisfy the converter constraints")]
+    public void ToPayload_TransferTypeHooks_InvalidGenericConverterType_Fails(
+        Type type,
+        Type declaredConverterType,
+        string expectedMessage)
+    {
+        var converter = TemporalTransferTypePayloadConverter.Wrap(new DefaultPayloadConverter());
+        var value = Activator.CreateInstance(type, "payload-value");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => converter.ToPayload(value));
+
+        Assert.Contains(expectedMessage, exception.Message);
+        Assert.Contains(type.ToString(), exception.Message);
+        Assert.Contains(declaredConverterType.ToString(), exception.Message);
     }
 
     private static Payload AssertPayload(
@@ -306,11 +394,87 @@ public class PayloadConverterTests : TestBase
     }
 
     [TemporalTransferTypeConverter(typeof(GenericTransferTypeHookValueConverter<>))]
-    public sealed record OpenGenericConverterHookValue(string Value);
+    public sealed record GenericTransferTypeHookValue<T>(T Value);
 
     public class GenericTransferTypeHookValueConverter<T> : ITemporalTransferTypeConverter
     {
+        public Type TransferType => typeof(T);
+
+        public object? ToTransferType(object? value) =>
+            ((GenericTransferTypeHookValue<T>)value!).Value;
+
+        public object? FromTransferType(object? transferType) =>
+            new GenericTransferTypeHookValue<T>((T)transferType!);
+    }
+
+    [TemporalTransferTypeConverter(typeof(OrderedGenericTransferTypeHookValueConverter<,>))]
+    public sealed record OrderedGenericTransferTypeHookValue<TFirst, TSecond>(
+        TFirst First,
+        TSecond Second);
+
+    public class OrderedGenericTransferTypeHookValueConverter<TFirst, TSecond> :
+        ITemporalTransferTypeConverter
+    {
         public Type TransferType => typeof(string);
+
+        public object? ToTransferType(object? value)
+        {
+            var genericValue = (OrderedGenericTransferTypeHookValue<TFirst, TSecond>)value!;
+            return $"{genericValue.First}|{genericValue.Second}";
+        }
+
+        public object? FromTransferType(object? transferType)
+        {
+            var values = ((string)transferType!).Split('|');
+            return new OrderedGenericTransferTypeHookValue<TFirst, TSecond>(
+                (TFirst)Convert.ChangeType(values[0], typeof(TFirst)),
+                (TSecond)Convert.ChangeType(values[1], typeof(TSecond)));
+        }
+    }
+
+    [TemporalTransferTypeConverter(typeof(ClosedGenericTransferTypeHookValueConverter))]
+    public sealed record ClosedConverterGenericTransferTypeHookValue<T>(string Value);
+
+    public class ClosedGenericTransferTypeHookValueConverter : ITemporalTransferTypeConverter
+    {
+        public Type TransferType => typeof(string);
+
+        public object? ToTransferType(object? value) =>
+            ((ClosedConverterGenericTransferTypeHookValue<int>)value!).Value;
+
+        public object? FromTransferType(object? transferType) =>
+            new ClosedConverterGenericTransferTypeHookValue<int>((string)transferType!);
+    }
+
+    [TemporalTransferTypeConverter(typeof(NestedGenericTransferTypeHookValue<>.Converter))]
+    public sealed record NestedGenericTransferTypeHookValue<T>(T Value)
+    {
+        public class Converter : ITemporalTransferTypeConverter
+        {
+            public Type TransferType => typeof(T);
+
+            public object? ToTransferType(object? value) =>
+                ((NestedGenericTransferTypeHookValue<T>)value!).Value;
+
+            public object? FromTransferType(object? transferType) =>
+                new NestedGenericTransferTypeHookValue<T>((T)transferType!);
+        }
+    }
+
+    [TemporalTransferTypeConverter(typeof(GenericTransferTypeHookValueConverter<>))]
+    public sealed record OpenGenericConverterHookValue(string Value);
+
+    [TemporalTransferTypeConverter(typeof(OrderedGenericTransferTypeHookValueConverter<,>))]
+    public sealed record GenericArityMismatchConverterHookValue<T>(T Value);
+
+    [TemporalTransferTypeConverter(typeof(StructGenericTransferTypeHookValueConverter<>))]
+    public sealed record GenericConstraintConverterHookValue<T>(T Value);
+
+    public class StructGenericTransferTypeHookValueConverter<T> :
+        ITemporalTransferTypeConverter
+        where T : struct
+    {
+        public Type TransferType => typeof(T);
 
         public object? ToTransferType(object? value) => throw new NotImplementedException();
 

--- a/tests/Temporalio.Tests/Converters/PayloadConverterTests.cs
+++ b/tests/Temporalio.Tests/Converters/PayloadConverterTests.cs
@@ -241,8 +241,8 @@ public class PayloadConverterTests : TestBase
         typeof(GenericTransferTypeHookValueConverter<>),
         "not a closed constructed generic type")]
     [InlineData(
-        typeof(GenericArityMismatchConverterHookValue<string>),
-        typeof(OrderedGenericTransferTypeHookValueConverter<,>),
+        typeof(GenericArityMismatchConverterHookValue<string, int>),
+        typeof(ThreeArgumentGenericTransferTypeHookValueConverter<,,>),
         "different generic arities")]
     [InlineData(
         typeof(GenericConstraintConverterHookValue<string>),
@@ -464,8 +464,18 @@ public class PayloadConverterTests : TestBase
     [TemporalTransferTypeConverter(typeof(GenericTransferTypeHookValueConverter<>))]
     public sealed record OpenGenericConverterHookValue(string Value);
 
-    [TemporalTransferTypeConverter(typeof(OrderedGenericTransferTypeHookValueConverter<,>))]
-    public sealed record GenericArityMismatchConverterHookValue<T>(T Value);
+    [TemporalTransferTypeConverter(typeof(ThreeArgumentGenericTransferTypeHookValueConverter<,,>))]
+    public sealed record GenericArityMismatchConverterHookValue<TFirst, TSecond>(TFirst Value);
+
+    public class ThreeArgumentGenericTransferTypeHookValueConverter<TFirst, TSecond, TThird> :
+        ITemporalTransferTypeConverter
+    {
+        public Type TransferType => typeof(TFirst);
+
+        public object? ToTransferType(object? value) => throw new NotImplementedException();
+
+        public object? FromTransferType(object? transferType) => throw new NotImplementedException();
+    }
 
     [TemporalTransferTypeConverter(typeof(StructGenericTransferTypeHookValueConverter<>))]
     public sealed record GenericConstraintConverterHookValue<T>(T Value);


### PR DESCRIPTION
## What was changed

- Generic transfer type converters can now be applied to models that have the same number of type arguments. 


## Why?

- This is needed to support transfer type conversion where the type arguments are not known until runtime.

## Checklist

1. Closes: N/A

2. How was this tested:

- Added tests covering newly supported generic models.


