### PR TITLE
💥 Update ActivityExecutionDescription to support new API, rename StaticSummary to Summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,20 +21,27 @@ to docs, or any other relevant information.
 
 ### :boom: Breaking Changes
 
-- Changes to experimental `ActivityExecutionDescription` class and related classes:
-  - `StaticSummary` and `ScheduledTime` were renamed to `Summary` and `ScheduleTime` respectively.
-  - `LongPollToken` and `StateTransitionCount` were removed.
+- Renamed and removed several experimental methods and properties in Standalone Activities APIs:
+  - `StartActivityOptions.StaticSummary` renamed to `Summary`.
+  - `ActivityExecutionDescription.GetStaticSummaryAsync` renamed to `GetSummaryAsync`.
+  - `ActivityExecution.ScheduledTime` renamed to `ScheduleTime`.
+  - Removed `ActivityExecution.StateTransitionCount`.
+  - Removed `ActivityExecutionDescription.LongPollToken`.
+  - Removed `ActivityDescribeOptions.LongPollToken`.
 - Removed the experimental `SignalWithStartWorkflowOptions.RequestId`. Request IDs for
   workflow-side signal-with-start are now assigned internally and are no longer user-settable.
 
 ### Added
 
+- New options in `ActivityDescribeOptions` that can be used to retrieve data associated with
+  activity execution, such as input and result.
+- New properties and methods in `ActivityExecution` and `ActivityExecutionDescription`:
+  `ExecutionTime`, `LastDeploymentVersion`, `Priority`, `RetryPolicy`, `StartDelay`,
+  `TotalHeartbeatCount`, `GetLastFailureAsync`, `GetOutcomeFailureAsync`, `GetResultAsync`,
+  and access to raw Proto objects from the response.
 - Added operation-specific outbound workflow interceptors for Temporal System Nexus operations.
   `SignalWithStartWorkflowAsync` can now be intercepted before the existing
   `ScheduleSystemNexusOperationAsync` hook.
-- New options in `ActivityDescribeOptions` that can be used to retrieve data associated with
-  activity execution, such as input and result.
-- More properties in `ActivityDescribeOptions`.
 - Experimental Temporal transfer type conversion now supports constructed generic models whose
   attributes reference generic converter type definitions. Model type arguments close the converter
   directly in declaration order, with matching generic arity and compatible constraints required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ to docs, or any other relevant information.
 
 ### :boom: Breaking Changes
 
+- Changes to experimental `ActivityExecutionDescription` class and related classes:
+  - `StaticSummary` and `ScheduledTime` were renamed to `Summary` and `ScheduleTime` respectively.
+  - `LongPollToken` and `StateTransitionCount` were removed.
 - Removed the experimental `SignalWithStartWorkflowOptions.RequestId`. Request IDs for
   workflow-side signal-with-start are now assigned internally and are no longer user-settable.
 
@@ -29,6 +32,9 @@ to docs, or any other relevant information.
 - Added operation-specific outbound workflow interceptors for Temporal System Nexus operations.
   `SignalWithStartWorkflowAsync` can now be intercepted before the existing
   `ScheduleSystemNexusOperationAsync` hook.
+- New options in `ActivityDescribeOptions` that can be used to retrieve data associated with
+  activity execution, such as input and result.
+- More properties in `ActivityDescribeOptions`.
 - Experimental Temporal transfer type conversion now supports constructed generic models whose
   attributes reference generic converter type definitions. Model type arguments close the converter
   directly in declaration order, with matching generic arity and compatible constraints required.

--- a/src/Temporalio/Client/ActivityDescribeOptions.cs
+++ b/src/Temporalio/Client/ActivityDescribeOptions.cs
@@ -9,10 +9,32 @@ namespace Temporalio.Client
     public class ActivityDescribeOptions : ICloneable
     {
         /// <summary>
-        /// Gets or sets a long-poll token from a previous describe response. When set, the
-        /// describe call will long-poll for state changes.
+        /// Gets or sets a value indicating whether to include input in the response if available.
         /// </summary>
-        public byte[]? LongPollToken { get; set; }
+        /// <seealso cref="ActivityExecutionDescription.HasInput"/>
+        public bool IncludeInput { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include outcome in the response if available.
+        /// </summary>
+        /// <seealso cref="ActivityExecutionDescription.HasResult"/>
+        /// <seealso cref="ActivityExecutionDescription.HasOutcomeFailure"/>
+        /// <seealso cref="ActivityExecutionDescription.GetResultAsync"/>
+        /// <seealso cref="ActivityExecutionDescription.GetOutcomeFailureAsync"/>
+        public bool IncludeOutcome { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include heartbeat details in the response if available.
+        /// </summary>
+        /// <seealso cref="ActivityExecutionDescription.HasHeartbeatDetails"/>
+        public bool IncludeHeartbeatDetails { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include last failure in the response if available.
+        /// </summary>
+        /// <seealso cref="ActivityExecutionDescription.HasLastFailure"/>
+        /// <seealso cref="ActivityExecutionDescription.GetLastFailureAsync"/>
+        public bool IncludeLastFailure { get; set; }
 
         /// <summary>
         /// Gets or sets RPC options for describing the activity.

--- a/src/Temporalio/Client/ActivityExecution.cs
+++ b/src/Temporalio/Client/ActivityExecution.cs
@@ -29,8 +29,8 @@ namespace Temporalio.Client
                 activityType: rawInfo.ActivityType?.Name ?? string.Empty,
                 closeTime: rawInfo.CloseTime?.ToDateTime(),
                 executionDuration: rawInfo.ExecutionDuration?.ToTimeSpan(),
-                scheduledTime: rawInfo.ScheduleTime?.ToDateTime() ?? default,
-                stateTransitionCount: rawInfo.StateTransitionCount,
+                executionTime: rawInfo.ExecutionTime?.ToDateTime(),
+                scheduleTime: rawInfo.ScheduleTime?.ToDateTime() ?? default,
                 status: rawInfo.Status,
                 taskQueue: rawInfo.TaskQueue,
                 searchAttributesFactory: () => rawInfo.SearchAttributes == null ?
@@ -49,8 +49,8 @@ namespace Temporalio.Client
         /// <param name="activityType">Activity type name.</param>
         /// <param name="closeTime">Close time.</param>
         /// <param name="executionDuration">Execution duration.</param>
-        /// <param name="scheduledTime">Scheduled time.</param>
-        /// <param name="stateTransitionCount">State transition count.</param>
+        /// <param name="executionTime">Execution time.</param>
+        /// <param name="scheduleTime">Schedule time.</param>
         /// <param name="status">Activity status.</param>
         /// <param name="taskQueue">Task queue.</param>
         /// <param name="searchAttributesFactory">Factory for lazy search attribute creation.</param>
@@ -61,8 +61,8 @@ namespace Temporalio.Client
             string activityType,
             DateTime? closeTime,
             TimeSpan? executionDuration,
-            DateTime scheduledTime,
-            long stateTransitionCount,
+            DateTime? executionTime,
+            DateTime scheduleTime,
             ActivityExecutionStatus status,
             string taskQueue,
             Func<SearchAttributeCollection> searchAttributesFactory)
@@ -73,8 +73,8 @@ namespace Temporalio.Client
             ActivityType = activityType;
             CloseTime = closeTime;
             ExecutionDuration = executionDuration;
-            ScheduledTime = scheduledTime;
-            StateTransitionCount = stateTransitionCount;
+            ExecutionTime = executionTime;
+            ScheduleTime = scheduleTime;
             Status = status;
             TaskQueue = taskQueue;
             searchAttributes = new(searchAttributesFactory, LazyThreadSafetyMode.PublicationOnly);
@@ -83,52 +83,53 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets the activity ID.
         /// </summary>
-        public string ActivityId { get; private init; }
+        public string ActivityId { get; }
 
         /// <summary>
         /// Gets the activity run ID.
         /// </summary>
-        public string? ActivityRunId { get; private init; }
+        public string? ActivityRunId { get; }
 
         /// <summary>
         /// Gets the activity type name.
         /// </summary>
-        public string ActivityType { get; private init; }
+        public string ActivityType { get; }
 
         /// <summary>
         /// Gets when the activity was closed if in a terminal state.
         /// </summary>
-        public DateTime? CloseTime { get; private init; }
+        public DateTime? CloseTime { get; }
 
         /// <summary>
         /// Gets the total execution duration if the activity is closed.
         /// </summary>
-        public TimeSpan? ExecutionDuration { get; private init; }
+        public TimeSpan? ExecutionDuration { get; }
+
+        /// <summary>
+        /// Gets the time at which the first activity task is made available for dispatch,
+        /// computed as schedule time + start delay.
+        /// </summary>
+        public DateTime? ExecutionTime { get; }
 
         /// <summary>
         /// Gets the namespace.
         /// </summary>
-        public string Namespace { get; private init; }
+        public string Namespace { get; }
 
         /// <summary>
         /// Gets when the activity was originally scheduled.
         /// </summary>
-        public DateTime ScheduledTime { get; private init; }
-
-        /// <summary>
-        /// Gets the number of state transitions.
-        /// </summary>
-        public long StateTransitionCount { get; private init; }
+        public DateTime ScheduleTime { get; }
 
         /// <summary>
         /// Gets the status of the activity.
         /// </summary>
-        public ActivityExecutionStatus Status { get; private init; }
+        public ActivityExecutionStatus Status { get; }
 
         /// <summary>
         /// Gets the task queue for the activity.
         /// </summary>
-        public string TaskQueue { get; private init; }
+        public string TaskQueue { get; }
 
         /// <summary>
         /// Gets the search attributes on the activity.
@@ -139,6 +140,7 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets the raw proto list info, or null if this was created from a describe call.
         /// </summary>
-        internal ActivityExecutionListInfo? RawInfo { get; private init; }
+        /// <seealso cref="ActivityExecutionDescription.RawInfo"/>
+        internal ActivityExecutionListInfo? RawInfo { get; }
     }
 }

--- a/src/Temporalio/Client/ActivityExecution.cs
+++ b/src/Temporalio/Client/ActivityExecution.cs
@@ -17,27 +17,27 @@ namespace Temporalio.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityExecution"/> class from list info.
         /// </summary>
-        /// <param name="rawInfo">Raw proto list info.</param>
+        /// <param name="rawListInfo">Raw proto list info.</param>
         /// <param name="clientNamespace">Client namespace.</param>
         /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
         protected internal ActivityExecution(
-            ActivityExecutionListInfo rawInfo, string clientNamespace)
+            ActivityExecutionListInfo rawListInfo, string clientNamespace)
             : this(
                 clientNamespace: clientNamespace,
-                activityId: rawInfo.ActivityId,
-                activityRunId: string.IsNullOrEmpty(rawInfo.RunId) ? null : rawInfo.RunId,
-                activityType: rawInfo.ActivityType?.Name ?? string.Empty,
-                closeTime: rawInfo.CloseTime?.ToDateTime(),
-                executionDuration: rawInfo.ExecutionDuration?.ToTimeSpan(),
-                executionTime: rawInfo.ExecutionTime?.ToDateTime(),
-                scheduleTime: rawInfo.ScheduleTime?.ToDateTime() ?? default,
-                status: rawInfo.Status,
-                taskQueue: rawInfo.TaskQueue,
-                searchAttributesFactory: () => rawInfo.SearchAttributes == null ?
+                activityId: rawListInfo.ActivityId,
+                activityRunId: string.IsNullOrEmpty(rawListInfo.RunId) ? null : rawListInfo.RunId,
+                activityType: rawListInfo.ActivityType?.Name ?? string.Empty,
+                closeTime: rawListInfo.CloseTime?.ToDateTime(),
+                executionDuration: rawListInfo.ExecutionDuration?.ToTimeSpan(),
+                executionTime: rawListInfo.ExecutionTime?.ToDateTime(),
+                scheduleTime: rawListInfo.ScheduleTime?.ToDateTime() ?? default,
+                status: rawListInfo.Status,
+                taskQueue: rawListInfo.TaskQueue,
+                searchAttributesFactory: () => rawListInfo.SearchAttributes == null ?
                     SearchAttributeCollection.Empty :
-                    SearchAttributeCollection.FromProto(rawInfo.SearchAttributes))
+                    SearchAttributeCollection.FromProto(rawListInfo.SearchAttributes))
         {
-            RawInfo = rawInfo;
+            RawListInfo = rawListInfo;
         }
 
         /// <summary>
@@ -141,6 +141,6 @@ namespace Temporalio.Client
         /// Gets the raw proto list info, or null if this was created from a describe call.
         /// </summary>
         /// <seealso cref="ActivityExecutionDescription.RawInfo"/>
-        internal ActivityExecutionListInfo? RawInfo { get; }
+        public ActivityExecutionListInfo? RawListInfo { get; }
     }
 }

--- a/src/Temporalio/Client/ActivityExecutionDescription.cs
+++ b/src/Temporalio/Client/ActivityExecutionDescription.cs
@@ -18,6 +18,7 @@ namespace Temporalio.Client
     /// <remarks>WARNING: Standalone activities are experimental.</remarks>
     public class ActivityExecutionDescription : ActivityExecution
     {
+        private readonly ActivityDescribeOptions requestOptions;
         private readonly DataConverter dataConverter;
         private readonly Lazy<Task<(string? Summary, string? Details)>> userMetadata;
         private readonly Lazy<Task<Exception?>> lastFailure;
@@ -26,11 +27,13 @@ namespace Temporalio.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityExecutionDescription"/> class.
         /// </summary>
+        /// <param name="requestOptions">Options used to make the request.</param>
         /// <param name="resp">Raw proto response.</param>
         /// <param name="clientNamespace">Client namespace.</param>
         /// <param name="dataConverter">Data converter.</param>
         /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
         protected internal ActivityExecutionDescription(
+            ActivityDescribeOptions? requestOptions,
             DescribeActivityExecutionResponse resp,
             string clientNamespace,
             DataConverter dataConverter)
@@ -49,8 +52,9 @@ namespace Temporalio.Client
                     SearchAttributeCollection.Empty :
                     SearchAttributeCollection.FromProto(resp.Info.SearchAttributes))
         {
-            RawResponse = resp;
+            this.requestOptions = requestOptions ?? new();
             this.dataConverter = dataConverter;
+            RawResponse = resp;
             var info = resp.Info;
             Attempt = info.Attempt;
             CanceledReason = string.IsNullOrEmpty(info.CanceledReason) ? null : info.CanceledReason;
@@ -73,8 +77,8 @@ namespace Temporalio.Client
             TotalHeartbeatCount = info.TotalHeartbeatCount;
 #pragma warning disable VSTHRD011 // This should not be able to deadlock
             userMetadata = new(() => dataConverter.FromUserMetadataAsync(info.UserMetadata));
-            lastFailure = new(async () => info.LastFailure == null ? null : await dataConverter.ToExceptionAsync(info.LastFailure).ConfigureAwait(false));
-            outcomeFailure = new(async () => resp.Outcome?.Failure == null ? null : await dataConverter.ToExceptionAsync(resp.Outcome.Failure).ConfigureAwait(false));
+            lastFailure = new(async () => info.LastFailure == null ? null : await dataConverter.ToExceptionAsync(info.LastFailure.Clone()).ConfigureAwait(false));
+            outcomeFailure = new(async () => resp.Outcome?.Failure == null ? null : await dataConverter.ToExceptionAsync(resp.Outcome.Failure.Clone()).ConfigureAwait(false));
 #pragma warning restore VSTHRD011
         }
 
@@ -105,33 +109,34 @@ namespace Temporalio.Client
         /// Always false if <see cref="ActivityDescribeOptions.IncludeHeartbeatDetails"/> was false.
         /// <para>Heartbeat details payloads can be accessed via <c>RawInfo.HeartbeatDetails.Payloads_</c>.</para>
         /// </remarks>
-        public bool HasHeartbeatDetails => RawInfo.HeartbeatDetails?.Payloads_?.Count > 0;
+        public bool HasHeartbeatDetails => requestOptions.IncludeHeartbeatDetails && RawInfo.HeartbeatDetails?.Payloads_?.Count > 0;
 
         /// <summary>
-        /// Gets a value indicating whether input is available.
+        /// Gets a value indicating whether the activity input is available.
         /// </summary>
         /// <remarks>
         /// Always false if <see cref="ActivityDescribeOptions.IncludeInput"/> was false.
         /// <para>Input payloads can be accessed via <see cref="RawInput"/>.</para>
         /// </remarks>
-        public bool HasInput => RawInput?.Count > 0;
+        public bool HasInput => requestOptions.IncludeInput && RawInput?.Count > 0;
 
         /// <summary>
         /// Gets a value indicating whether the last failure is available.
         /// </summary>
-        /// Always false if <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.
+        /// <remarks>Always false if <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</remarks>
         /// <seealso cref="GetLastFailureAsync"/>
-        public bool HasLastFailure => RawInfo.LastFailure != null;
+        public bool HasLastFailure => requestOptions.IncludeLastFailure && RawInfo.LastFailure != null;
 
         /// <summary>
-        /// Gets a value indicating whether the last failure is available.
+        /// Gets a value indicating whether the activity result is available.
         /// </summary>
         /// <remarks>
-        /// Activity outcome failure is only available if the activity has closed with a failure.
+        /// Activity result is only available if the activity has completed successfully.
         /// <para>Always false if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
         /// </remarks>
-        /// <seealso cref="GetOutcomeFailureAsync"/>
-        public bool HasResult => RawOutcome?.Result?.Payloads_.Count == 1; // 0 means missing, more than 1 is invalid
+        /// <seealso cref="GetResultAsync"/>
+        /// <seealso cref="HasOutcomeFailure"/>
+        public bool HasResult => requestOptions.IncludeOutcome && RawOutcome?.Result?.Payloads_.Count == 1; // 0 means missing, more than 1 is invalid
 
         /// <summary>
         /// Gets a value indicating whether the outcome failure is available.
@@ -141,7 +146,8 @@ namespace Temporalio.Client
         /// <para>Always false if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
         /// </remarks>
         /// <seealso cref="GetOutcomeFailureAsync"/>
-        public bool HasOutcomeFailure => RawOutcome?.Failure != null;
+        /// <seealso cref="HasResult"/>
+        public bool HasOutcomeFailure => requestOptions.IncludeOutcome && RawOutcome?.Failure != null;
 
         /// <summary>
         /// Gets the heartbeat timeout.
@@ -262,38 +268,52 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets the failure from the last failed attempt, or null if not available.
         /// </summary>
-        /// <remarks>Always false if <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</remarks>
         /// <returns>Last failure, or null if not available.</returns>
+        /// <exception cref="InvalidOperationException">If <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</exception>
         /// <seealso cref="HasLastFailure"/>
-        public async Task<Exception?> GetLastFailureAsync() =>
-            await lastFailure.Value.ConfigureAwait(false);
+        public async Task<Exception?> GetLastFailureAsync()
+        {
+            if (!requestOptions.IncludeLastFailure)
+            {
+                throw new InvalidOperationException("ActivityDescribeOptions.IncludeLastFailure must be set to true.");
+            }
+            return await lastFailure.Value.ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Gets the failure of the activity execution, or null if not available.
         /// </summary>
-        /// <remarks>
-        /// Activity outcome failure is only available if the activity has closed with a failure.
-        /// <para>Always false if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
-        /// </remarks>
         /// <returns>Activity outcome failure, or null if not available.</returns>
+        /// <exception cref="InvalidOperationException">If <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</exception>
+        /// <remarks>Activity outcome failure is only available if the activity has closed with a failure.</remarks>
+        /// <seealso cref="GetResultAsync"/>
         /// <seealso cref="HasOutcomeFailure"/>
-        public async Task<Exception?> GetOutcomeFailureAsync() =>
-            await outcomeFailure.Value.ConfigureAwait(false);
+        public async Task<Exception?> GetOutcomeFailureAsync()
+        {
+            if (!requestOptions.IncludeOutcome)
+            {
+                throw new InvalidOperationException("ActivityDescribeOptions.IncludeOutcome must be set to true.");
+            }
+            return await outcomeFailure.Value.ConfigureAwait(false);
+        }
 #pragma warning restore VSTHRD003
 
         /// <summary>
         /// Gets the result of the activity execution.
         /// </summary>
         /// <typeparam name="T">Type to convert the result into.</typeparam>
-        /// <exception cref="InvalidOperationException">If result is not available. See <see cref="HasResult"/>.</exception>
-        /// <remarks>
-        /// Activity result is only available if the activity has completed successfully.
-        /// <para>Always false if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
-        /// </remarks>
         /// <returns>Activity result.</returns>
+        /// <exception cref="InvalidOperationException">If result is not available. See <see cref="HasResult"/>.</exception>
+        /// <exception cref="InvalidOperationException">If <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</exception>
+        /// <remarks>Activity result is only available if the activity has completed successfully.</remarks>
+        /// <seealso cref="GetOutcomeFailureAsync"/>
         /// <seealso cref="HasResult"/>
         public async Task<T> GetResultAsync<T>()
         {
+            if (!requestOptions.IncludeOutcome)
+            {
+                throw new InvalidOperationException("ActivityDescribeOptions.IncludeOutcome must be set to true.");
+            }
             if (!HasResult)
             {
                 throw new InvalidOperationException("Result unavailable.");

--- a/src/Temporalio/Client/ActivityExecutionDescription.cs
+++ b/src/Temporalio/Client/ActivityExecutionDescription.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Temporalio.Api.Activity.V1;
+using Temporalio.Api.Common.V1;
 using Temporalio.Api.Enums.V1;
 using Temporalio.Api.WorkflowService.V1;
 using Temporalio.Common;
 using Temporalio.Converters;
+using Priority = Temporalio.Common.Priority;
+using RetryPolicy = Temporalio.Common.RetryPolicy;
 
 namespace Temporalio.Client
 {
@@ -13,162 +18,287 @@ namespace Temporalio.Client
     /// <remarks>WARNING: Standalone activities are experimental.</remarks>
     public class ActivityExecutionDescription : ActivityExecution
     {
+        private readonly DataConverter dataConverter;
         private readonly Lazy<Task<(string? Summary, string? Details)>> userMetadata;
+        private readonly Lazy<Task<Exception?>> lastFailure;
+        private readonly Lazy<Task<Exception?>> outcomeFailure;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityExecutionDescription"/> class.
         /// </summary>
-        /// <param name="rawDescription">Raw proto description.</param>
+        /// <param name="resp">Raw proto response.</param>
         /// <param name="clientNamespace">Client namespace.</param>
         /// <param name="dataConverter">Data converter.</param>
         /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
         protected internal ActivityExecutionDescription(
-            DescribeActivityExecutionResponse rawDescription,
+            DescribeActivityExecutionResponse resp,
             string clientNamespace,
             DataConverter dataConverter)
             : base(
                 clientNamespace: clientNamespace,
-                activityId: rawDescription.Info.ActivityId,
-                activityRunId: string.IsNullOrEmpty(rawDescription.Info.RunId) ? null : rawDescription.Info.RunId,
-                activityType: rawDescription.Info.ActivityType?.Name ?? string.Empty,
-                closeTime: rawDescription.Info.CloseTime?.ToDateTime(),
-                executionDuration: rawDescription.Info.ExecutionDuration?.ToTimeSpan(),
-                scheduledTime: rawDescription.Info.ScheduleTime?.ToDateTime() ?? default,
-                stateTransitionCount: rawDescription.Info.StateTransitionCount,
-                status: rawDescription.Info.Status,
-                taskQueue: rawDescription.Info.TaskQueue,
-                searchAttributesFactory: () => rawDescription.Info.SearchAttributes == null ?
+                activityId: resp.Info.ActivityId,
+                activityRunId: string.IsNullOrEmpty(resp.Info.RunId) ? null : resp.Info.RunId,
+                activityType: resp.Info.ActivityType?.Name ?? string.Empty,
+                closeTime: resp.Info.CloseTime?.ToDateTime(),
+                executionDuration: resp.Info.ExecutionDuration?.ToTimeSpan(),
+                executionTime: resp.Info.ExecutionTime?.ToDateTime(),
+                scheduleTime: resp.Info.ScheduleTime?.ToDateTime() ?? default,
+                status: resp.Info.Status,
+                taskQueue: resp.Info.TaskQueue,
+                searchAttributesFactory: () => resp.Info.SearchAttributes == null ?
                     SearchAttributeCollection.Empty :
-                    SearchAttributeCollection.FromProto(rawDescription.Info.SearchAttributes))
+                    SearchAttributeCollection.FromProto(resp.Info.SearchAttributes))
         {
-            RawDescription = rawDescription;
-            var info = rawDescription.Info;
+            RawResponse = resp;
+            this.dataConverter = dataConverter;
+            var info = resp.Info;
             Attempt = info.Attempt;
             CanceledReason = string.IsNullOrEmpty(info.CanceledReason) ? null : info.CanceledReason;
             CurrentRetryInterval = info.CurrentRetryInterval?.ToTimeSpan();
             ExpirationTime = info.ExpirationTime?.ToDateTime();
             HeartbeatTimeout = info.HeartbeatTimeout?.ToTimeSpan();
             LastAttemptCompleteTime = info.LastAttemptCompleteTime?.ToDateTime();
+            LastDeploymentVersion = info.LastDeploymentVersion == null ? null : WorkerDeploymentVersion.FromProto(info.LastDeploymentVersion);
             LastHeartbeatTime = info.LastHeartbeatTime?.ToDateTime();
             LastStartedTime = info.LastStartedTime?.ToDateTime();
             LastWorkerIdentity = string.IsNullOrEmpty(info.LastWorkerIdentity) ? null : info.LastWorkerIdentity;
-            LongPollToken = rawDescription.LongPollToken.IsEmpty ? null : rawDescription.LongPollToken.ToByteArray();
             NextAttemptScheduleTime = info.NextAttemptScheduleTime?.ToDateTime();
-            RetryPolicy = info.RetryPolicy == null ? null : Common.RetryPolicy.FromProto(info.RetryPolicy);
+            Priority = new(info.Priority);
+            RetryPolicy = info.RetryPolicy == null ? null : RetryPolicy.FromProto(info.RetryPolicy);
             RunState = info.RunState;
             ScheduleToCloseTimeout = info.ScheduleToCloseTimeout?.ToTimeSpan();
             ScheduleToStartTimeout = info.ScheduleToStartTimeout?.ToTimeSpan();
+            StartDelay = info.StartDelay?.ToTimeSpan();
             StartToCloseTimeout = info.StartToCloseTimeout?.ToTimeSpan();
+            TotalHeartbeatCount = info.TotalHeartbeatCount;
 #pragma warning disable VSTHRD011 // This should not be able to deadlock
             userMetadata = new(() => dataConverter.FromUserMetadataAsync(info.UserMetadata));
+            lastFailure = new(async () => info.LastFailure == null ? null : await dataConverter.ToExceptionAsync(info.LastFailure).ConfigureAwait(false));
+            outcomeFailure = new(async () => resp.Outcome?.Failure == null ? null : await dataConverter.ToExceptionAsync(resp.Outcome.Failure).ConfigureAwait(false));
 #pragma warning restore VSTHRD011
         }
 
         /// <summary>
         /// Gets the current attempt number, starting at 1.
         /// </summary>
-        public int Attempt { get; private init; }
+        public int Attempt { get; }
 
         /// <summary>
         /// Gets the reason for cancellation, if cancel was requested.
         /// </summary>
-        public string? CanceledReason { get; private init; }
+        public string? CanceledReason { get; }
 
         /// <summary>
         /// Gets the time until the next retry, if applicable.
         /// </summary>
-        public TimeSpan? CurrentRetryInterval { get; private init; }
+        public TimeSpan? CurrentRetryInterval { get; }
 
         /// <summary>
-        /// Gets the scheduled time plus schedule-to-close timeout.
+        /// Gets the schedule time plus schedule-to-close timeout.
         /// </summary>
-        public DateTime? ExpirationTime { get; private init; }
+        public DateTime? ExpirationTime { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether heartbeat details are available.
+        /// </summary>
+        /// <remarks>
+        /// Always false if <see cref="ActivityDescribeOptions.IncludeHeartbeatDetails"/> was false.
+        /// <para>Heartbeat details payloads can be accessed via <c>RawInfo.HeartbeatDetails.Payloads_</c>.</para>
+        /// </remarks>
+        public bool HasHeartbeatDetails => RawInfo.HeartbeatDetails?.Payloads_?.Count > 0;
+
+        /// <summary>
+        /// Gets a value indicating whether input is available.
+        /// </summary>
+        /// <remarks>
+        /// Always false if <see cref="ActivityDescribeOptions.IncludeInput"/> was false.
+        /// <para>Input payloads can be accessed via <see cref="RawInput"/>.</para>
+        /// </remarks>
+        public bool HasInput => RawInput?.Count > 0;
+
+        /// <summary>
+        /// Gets a value indicating whether the last failure is available.
+        /// </summary>
+        /// Always false if <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.
+        /// <seealso cref="GetLastFailureAsync"/>
+        public bool HasLastFailure => RawInfo.LastFailure != null;
+
+        /// <summary>
+        /// Gets a value indicating whether the last failure is available.
+        /// </summary>
+        /// <remarks>
+        /// Activity outcome failure is only available if the activity has closed with a failure.
+        /// <para>Always false if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
+        /// </remarks>
+        /// <seealso cref="GetOutcomeFailureAsync"/>
+        public bool HasResult => RawOutcome?.Result?.Payloads_.Count == 1; // 0 means missing, more than 1 is invalid
+
+        /// <summary>
+        /// Gets a value indicating whether the outcome failure is available.
+        /// </summary>
+        /// <remarks>
+        /// Activity outcome failure is only available if the activity has closed with a failure.
+        /// <para>Always false if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
+        /// </remarks>
+        /// <seealso cref="GetOutcomeFailureAsync"/>
+        public bool HasOutcomeFailure => RawOutcome?.Failure != null;
 
         /// <summary>
         /// Gets the heartbeat timeout.
         /// </summary>
-        public TimeSpan? HeartbeatTimeout { get; private init; }
+        public TimeSpan? HeartbeatTimeout { get; }
 
         /// <summary>
         /// Gets when the last attempt completed.
         /// </summary>
-        public DateTime? LastAttemptCompleteTime { get; private init; }
+        public DateTime? LastAttemptCompleteTime { get; }
+
+        /// <summary>
+        /// Gets the worker deployment version this activity was dispatched to most recently.
+        /// </summary>
+        public WorkerDeploymentVersion? LastDeploymentVersion { get; }
 
         /// <summary>
         /// Gets the time of the last heartbeat.
         /// </summary>
-        public DateTime? LastHeartbeatTime { get; private init; }
+        public DateTime? LastHeartbeatTime { get; }
 
         /// <summary>
         /// Gets when the last attempt was started.
         /// </summary>
-        public DateTime? LastStartedTime { get; private init; }
+        public DateTime? LastStartedTime { get; }
 
         /// <summary>
         /// Gets the identity of the last worker that processed the activity.
         /// </summary>
-        public string? LastWorkerIdentity { get; private init; }
-
-        /// <summary>
-        /// Gets the token for follow-on long-poll requests, or null if the activity is complete.
-        /// </summary>
-        public byte[]? LongPollToken { get; private init; }
+        public string? LastWorkerIdentity { get; }
 
         /// <summary>
         /// Gets when the next attempt will be scheduled.
         /// </summary>
-        public DateTime? NextAttemptScheduleTime { get; private init; }
+        public DateTime? NextAttemptScheduleTime { get; }
+
+        /// <summary>
+        /// Gets the priority metadata.
+        /// </summary>
+        public Priority Priority { get; }
 
         /// <summary>
         /// Gets the retry policy for the activity.
         /// </summary>
-        public RetryPolicy? RetryPolicy { get; private init; }
+        public RetryPolicy? RetryPolicy { get; }
 
         /// <summary>
         /// Gets the more detailed run state if the activity status is running.
         /// </summary>
-        public PendingActivityState RunState { get; private init; }
+        public PendingActivityState RunState { get; }
 
         /// <summary>
         /// Gets the schedule-to-close timeout.
         /// </summary>
-        public TimeSpan? ScheduleToCloseTimeout { get; private init; }
+        public TimeSpan? ScheduleToCloseTimeout { get; }
 
         /// <summary>
         /// Gets the schedule-to-start timeout.
         /// </summary>
-        public TimeSpan? ScheduleToStartTimeout { get; private init; }
+        public TimeSpan? ScheduleToStartTimeout { get; }
+
+        /// <summary>
+        /// Gets the time to wait before making the first activity task available for dispatch.
+        /// </summary>
+        public TimeSpan? StartDelay { get; }
 
         /// <summary>
         /// Gets the start-to-close timeout.
         /// </summary>
-        public TimeSpan? StartToCloseTimeout { get; private init; }
+        public TimeSpan? StartToCloseTimeout { get; }
+
+        /// <summary>
+        /// Gets the total number of heartbeats recorded across all attempts of this activity, including retries.
+        /// <para>
+        /// Zero if the activity has not sent any heartbeats or if the server didn't report heartbeat count.
+        /// </para>
+        /// </summary>
+        public long TotalHeartbeatCount { get; }
+
+        /// <summary>
+        /// Gets the raw proto info.
+        /// </summary>
+        public new ActivityExecutionInfo RawInfo => RawResponse.Info;
+
+        /// <summary>
+        /// Gets the raw proto input.
+        /// </summary>
+        public IReadOnlyCollection<Payload>? RawInput => RawResponse.Input?.Payloads_;
+
+        /// <summary>
+        /// Gets the raw proto outcome.
+        /// </summary>
+        public ActivityExecutionOutcome? RawOutcome => RawResponse.Outcome;
 
         /// <summary>
         /// Gets the raw proto description.
         /// </summary>
-        internal DescribeActivityExecutionResponse RawDescription { get; private init; }
+        internal DescribeActivityExecutionResponse RawResponse { get; }
 
+#pragma warning disable VSTHRD003 // Awaiting our own lazily-created tasks
         /// <summary>
         /// Gets the single-line fixed summary for this activity execution that may appear in
         /// UI/CLI. This can be in single-line Temporal markdown format.
         /// </summary>
-        /// <remarks>WARNING: Standalone activities are experimental.</remarks>
-        /// <returns>Static summary.</returns>
-#pragma warning disable VSTHRD003 // Awaiting our own lazily-created task
-        public async Task<string?> GetStaticSummaryAsync() =>
+        /// <returns>Activity summary.</returns>
+        public async Task<string?> GetSummaryAsync() =>
             (await userMetadata.Value.ConfigureAwait(false)).Summary;
-#pragma warning restore VSTHRD003
 
         /// <summary>
         /// Gets the general fixed details for this activity execution that may appear in UI/CLI.
         /// This can be in Temporal markdown format and can span multiple lines.
         /// </summary>
-        /// <remarks>WARNING: Standalone activities are experimental.</remarks>
+        /// <remarks>WARNING: This method is experimental.</remarks>
         /// <returns>Static details.</returns>
-#pragma warning disable VSTHRD003 // Awaiting our own lazily-created task
         public async Task<string?> GetStaticDetailsAsync() =>
             (await userMetadata.Value.ConfigureAwait(false)).Details;
+
+        /// <summary>
+        /// Gets the failure from the last failed attempt, or null if not available.
+        /// </summary>
+        /// <remarks>Always false if <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</remarks>
+        /// <returns>Last failure, or null if not available.</returns>
+        /// <seealso cref="HasLastFailure"/>
+        public async Task<Exception?> GetLastFailureAsync() =>
+            await lastFailure.Value.ConfigureAwait(false);
+
+        /// <summary>
+        /// Gets the failure of the activity execution, or null if not available.
+        /// </summary>
+        /// <remarks>
+        /// Activity outcome failure is only available if the activity has closed with a failure.
+        /// <para>Always false if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
+        /// </remarks>
+        /// <returns>Activity outcome failure, or null if not available.</returns>
+        /// <seealso cref="HasOutcomeFailure"/>
+        public async Task<Exception?> GetOutcomeFailureAsync() =>
+            await outcomeFailure.Value.ConfigureAwait(false);
 #pragma warning restore VSTHRD003
+
+        /// <summary>
+        /// Gets the result of the activity execution.
+        /// </summary>
+        /// <typeparam name="T">Type to convert the result into.</typeparam>
+        /// <exception cref="InvalidOperationException">If result is not available. See <see cref="HasResult"/>.</exception>
+        /// <remarks>
+        /// Activity result is only available if the activity has completed successfully.
+        /// <para>Always false if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
+        /// </remarks>
+        /// <returns>Activity result.</returns>
+        /// <seealso cref="HasResult"/>
+        public async Task<T> GetResultAsync<T>()
+        {
+            if (!HasResult)
+            {
+                throw new InvalidOperationException("Result unavailable.");
+            }
+            return await dataConverter.ToSingleValueAsync<T>(RawOutcome!.Result.Payloads_).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Temporalio/Client/ActivityExecutionDescription.cs
+++ b/src/Temporalio/Client/ActivityExecutionDescription.cs
@@ -282,23 +282,26 @@ namespace Temporalio.Client
 #pragma warning restore VSTHRD003
 
         /// <summary>
-        /// Gets the result of the activity execution.
+        /// Gets the result of the activity execution, or null if not available.
         /// </summary>
         /// <typeparam name="T">Type to convert the result into.</typeparam>
-        /// <returns>Activity result.</returns>
-        /// <exception cref="InvalidOperationException">If result is not available. See <see cref="HasResult"/>.</exception>
-        /// <exception cref="InvalidOperationException">If <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</exception>
+        /// <returns>Activity result, or null if not available.</returns>
         /// <remarks>
         /// Activity result is only available if the activity has completed successfully.
         /// <para>Always null if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
+        /// <para>
+        /// If <typeparamref name="T"/> is a non-nullable value type, an unavailable result is indistinguishable from
+        /// a converted one. Use a nullable type argument (<c>GetResultAsync&lt;int?&gt;()</c>) or check
+        /// <see cref="HasResult"/> to disambiguate.
+        /// </para>
         /// </remarks>
         /// <seealso cref="GetOutcomeFailureAsync"/>
         /// <seealso cref="HasResult"/>
-        public async Task<T> GetResultAsync<T>()
+        public async Task<T?> GetResultAsync<T>()
         {
             if (!HasResult)
             {
-                throw new InvalidOperationException("Result unavailable.");
+                return default;
             }
             return await dataConverter.ToSingleValueAsync<T>(RawOutcome!.Result.Payloads_).ConfigureAwait(false);
         }

--- a/src/Temporalio/Client/ActivityExecutionDescription.cs
+++ b/src/Temporalio/Client/ActivityExecutionDescription.cs
@@ -18,7 +18,6 @@ namespace Temporalio.Client
     /// <remarks>WARNING: Standalone activities are experimental.</remarks>
     public class ActivityExecutionDescription : ActivityExecution
     {
-        private readonly ActivityDescribeOptions requestOptions;
         private readonly DataConverter dataConverter;
         private readonly Lazy<Task<(string? Summary, string? Details)>> userMetadata;
         private readonly Lazy<Task<Exception?>> lastFailure;
@@ -27,13 +26,11 @@ namespace Temporalio.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityExecutionDescription"/> class.
         /// </summary>
-        /// <param name="requestOptions">Options used to make the request.</param>
         /// <param name="resp">Raw proto response.</param>
         /// <param name="clientNamespace">Client namespace.</param>
         /// <param name="dataConverter">Data converter.</param>
         /// <remarks>WARNING: This constructor may be mutated in backwards incompatible ways.</remarks>
         protected internal ActivityExecutionDescription(
-            ActivityDescribeOptions? requestOptions,
             DescribeActivityExecutionResponse resp,
             string clientNamespace,
             DataConverter dataConverter)
@@ -52,7 +49,6 @@ namespace Temporalio.Client
                     SearchAttributeCollection.Empty :
                     SearchAttributeCollection.FromProto(resp.Info.SearchAttributes))
         {
-            this.requestOptions = requestOptions ?? new();
             this.dataConverter = dataConverter;
             RawResponse = resp;
             var info = resp.Info;
@@ -109,7 +105,7 @@ namespace Temporalio.Client
         /// Always false if <see cref="ActivityDescribeOptions.IncludeHeartbeatDetails"/> was false.
         /// <para>Heartbeat details payloads can be accessed via <c>RawInfo.HeartbeatDetails.Payloads_</c>.</para>
         /// </remarks>
-        public bool HasHeartbeatDetails => requestOptions.IncludeHeartbeatDetails && RawInfo.HeartbeatDetails?.Payloads_?.Count > 0;
+        public bool HasHeartbeatDetails => RawInfo.HeartbeatDetails?.Payloads_?.Count > 0;
 
         /// <summary>
         /// Gets a value indicating whether the activity input is available.
@@ -118,14 +114,14 @@ namespace Temporalio.Client
         /// Always false if <see cref="ActivityDescribeOptions.IncludeInput"/> was false.
         /// <para>Input payloads can be accessed via <see cref="RawInput"/>.</para>
         /// </remarks>
-        public bool HasInput => requestOptions.IncludeInput && RawInput?.Count > 0;
+        public bool HasInput => RawInput?.Count > 0;
 
         /// <summary>
         /// Gets a value indicating whether the last failure is available.
         /// </summary>
         /// <remarks>Always false if <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</remarks>
         /// <seealso cref="GetLastFailureAsync"/>
-        public bool HasLastFailure => requestOptions.IncludeLastFailure && RawInfo.LastFailure != null;
+        public bool HasLastFailure => RawInfo.LastFailure != null;
 
         /// <summary>
         /// Gets a value indicating whether the activity result is available.
@@ -136,7 +132,7 @@ namespace Temporalio.Client
         /// </remarks>
         /// <seealso cref="GetResultAsync"/>
         /// <seealso cref="HasOutcomeFailure"/>
-        public bool HasResult => requestOptions.IncludeOutcome && RawOutcome?.Result?.Payloads_.Count == 1; // 0 means missing, more than 1 is invalid
+        public bool HasResult => RawOutcome?.Result?.Payloads_.Count == 1; // 0 means missing, more than 1 is invalid
 
         /// <summary>
         /// Gets a value indicating whether the outcome failure is available.
@@ -147,7 +143,7 @@ namespace Temporalio.Client
         /// </remarks>
         /// <seealso cref="GetOutcomeFailureAsync"/>
         /// <seealso cref="HasResult"/>
-        public bool HasOutcomeFailure => requestOptions.IncludeOutcome && RawOutcome?.Failure != null;
+        public bool HasOutcomeFailure => RawOutcome?.Failure != null;
 
         /// <summary>
         /// Gets the heartbeat timeout.
@@ -230,7 +226,7 @@ namespace Temporalio.Client
         /// <summary>
         /// Gets the raw proto info.
         /// </summary>
-        public new ActivityExecutionInfo RawInfo => RawResponse.Info;
+        public ActivityExecutionInfo RawInfo => RawResponse.Info;
 
         /// <summary>
         /// Gets the raw proto input.
@@ -260,7 +256,6 @@ namespace Temporalio.Client
         /// Gets the general fixed details for this activity execution that may appear in UI/CLI.
         /// This can be in Temporal markdown format and can span multiple lines.
         /// </summary>
-        /// <remarks>WARNING: This method is experimental.</remarks>
         /// <returns>Static details.</returns>
         public async Task<string?> GetStaticDetailsAsync() =>
             (await userMetadata.Value.ConfigureAwait(false)).Details;
@@ -269,33 +264,21 @@ namespace Temporalio.Client
         /// Gets the failure from the last failed attempt, or null if not available.
         /// </summary>
         /// <returns>Last failure, or null if not available.</returns>
-        /// <exception cref="InvalidOperationException">If <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</exception>
+        /// <remarks>Always null if <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</remarks>
         /// <seealso cref="HasLastFailure"/>
-        public async Task<Exception?> GetLastFailureAsync()
-        {
-            if (!requestOptions.IncludeLastFailure)
-            {
-                throw new InvalidOperationException("ActivityDescribeOptions.IncludeLastFailure must be set to true.");
-            }
-            return await lastFailure.Value.ConfigureAwait(false);
-        }
+        public async Task<Exception?> GetLastFailureAsync() => await lastFailure.Value.ConfigureAwait(false);
 
         /// <summary>
         /// Gets the failure of the activity execution, or null if not available.
         /// </summary>
         /// <returns>Activity outcome failure, or null if not available.</returns>
-        /// <exception cref="InvalidOperationException">If <see cref="ActivityDescribeOptions.IncludeLastFailure"/> was false.</exception>
-        /// <remarks>Activity outcome failure is only available if the activity has closed with a failure.</remarks>
+        /// <remarks>
+        /// Activity outcome failure is only available if the activity has closed with a failure.
+        /// <para>Always null if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
+        /// </remarks>
         /// <seealso cref="GetResultAsync"/>
         /// <seealso cref="HasOutcomeFailure"/>
-        public async Task<Exception?> GetOutcomeFailureAsync()
-        {
-            if (!requestOptions.IncludeOutcome)
-            {
-                throw new InvalidOperationException("ActivityDescribeOptions.IncludeOutcome must be set to true.");
-            }
-            return await outcomeFailure.Value.ConfigureAwait(false);
-        }
+        public async Task<Exception?> GetOutcomeFailureAsync() => await outcomeFailure.Value.ConfigureAwait(false);
 #pragma warning restore VSTHRD003
 
         /// <summary>
@@ -305,15 +288,14 @@ namespace Temporalio.Client
         /// <returns>Activity result.</returns>
         /// <exception cref="InvalidOperationException">If result is not available. See <see cref="HasResult"/>.</exception>
         /// <exception cref="InvalidOperationException">If <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</exception>
-        /// <remarks>Activity result is only available if the activity has completed successfully.</remarks>
+        /// <remarks>
+        /// Activity result is only available if the activity has completed successfully.
+        /// <para>Always null if <see cref="ActivityDescribeOptions.IncludeOutcome"/> was false.</para>
+        /// </remarks>
         /// <seealso cref="GetOutcomeFailureAsync"/>
         /// <seealso cref="HasResult"/>
         public async Task<T> GetResultAsync<T>()
         {
-            if (!requestOptions.IncludeOutcome)
-            {
-                throw new InvalidOperationException("ActivityDescribeOptions.IncludeOutcome must be set to true.");
-            }
             if (!HasResult)
             {
                 throw new InvalidOperationException("Result unavailable.");

--- a/src/Temporalio/Client/StartActivityOptions.cs
+++ b/src/Temporalio/Client/StartActivityOptions.cs
@@ -89,8 +89,7 @@ namespace Temporalio.Client
         /// Gets or sets a single-line fixed summary for this activity execution that may appear in
         /// UI/CLI. This can be in single-line Temporal markdown format.
         /// </summary>
-        /// <remarks>WARNING: This setting is experimental.</remarks>
-        public string? StaticSummary { get; set; }
+        public string? Summary { get; set; }
 
         /// <summary>
         /// Gets or sets general fixed details for this activity execution that may appear in

--- a/src/Temporalio/Client/TemporalClient.Activity.cs
+++ b/src/Temporalio/Client/TemporalClient.Activity.cs
@@ -228,7 +228,7 @@ namespace Temporalio.Client
                         IncludeLastFailure = input.Options?.IncludeLastFailure ?? false,
                     },
                     DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);
-                return new(resp, Client.Options.Namespace, Client.Options.DataConverter);
+                return new((ActivityDescribeOptions?)input.Options?.Clone(), resp, Client.Options.Namespace, Client.Options.DataConverter);
             }
 
             /// <inheritdoc />

--- a/src/Temporalio/Client/TemporalClient.Activity.cs
+++ b/src/Temporalio/Client/TemporalClient.Activity.cs
@@ -124,7 +124,7 @@ namespace Temporalio.Client
                         IdConflictPolicy = input.Options.IdConflictPolicy,
                         RetryPolicy = input.Options.RetryPolicy?.ToProto(),
                         UserMetadata = await dataConverter.ToUserMetadataAsync(
-                            input.Options.StaticSummary, input.Options.StaticDetails).
+                            input.Options.Summary, input.Options.StaticDetails).
                             ConfigureAwait(false),
                         Priority = input.Options.Priority?.ToProto(),
                         OnConflictOptions = input.Options.OnConflictOptions,
@@ -222,6 +222,10 @@ namespace Temporalio.Client
                         Namespace = Client.Options.Namespace,
                         ActivityId = input.Id,
                         RunId = input.RunId ?? string.Empty,
+                        IncludeInput = input.Options?.IncludeInput ?? false,
+                        IncludeOutcome = input.Options?.IncludeOutcome ?? false,
+                        IncludeHeartbeatDetails = input.Options?.IncludeHeartbeatDetails ?? false,
+                        IncludeLastFailure = input.Options?.IncludeLastFailure ?? false,
                     },
                     DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);
                 return new(resp, Client.Options.Namespace, Client.Options.DataConverter);

--- a/src/Temporalio/Client/TemporalClient.Activity.cs
+++ b/src/Temporalio/Client/TemporalClient.Activity.cs
@@ -228,7 +228,7 @@ namespace Temporalio.Client
                         IncludeLastFailure = input.Options?.IncludeLastFailure ?? false,
                     },
                     DefaultRetryOptions(input.Options?.Rpc)).ConfigureAwait(false);
-                return new((ActivityDescribeOptions?)input.Options?.Clone(), resp, Client.Options.Namespace, Client.Options.DataConverter);
+                return new(resp, Client.Options.Namespace, Client.Options.DataConverter);
             }
 
             /// <inheritdoc />

--- a/src/Temporalio/Common/Priority.cs
+++ b/src/Temporalio/Common/Priority.cs
@@ -33,7 +33,7 @@ namespace Temporalio.Common
         /// Initializes a new instance of the <see cref="Priority"/> class from a proto.
         /// </summary>
         /// <param name="priority">The proto to initialize from.</param>
-        internal Priority(Temporalio.Api.Common.V1.Priority priority)
+        internal Priority(Temporalio.Api.Common.V1.Priority? priority)
             : this(
                 priority?.PriorityKey != 0 ? priority?.PriorityKey : null,
                 !string.IsNullOrEmpty(priority?.FairnessKey) ? priority?.FairnessKey : null,

--- a/src/Temporalio/Common/WorkerDeploymentVersion.cs
+++ b/src/Temporalio/Common/WorkerDeploymentVersion.cs
@@ -40,7 +40,16 @@ namespace Temporalio.Common
         /// <returns>A new <see cref="WorkerDeploymentVersion"/> instance.</returns>
         internal static WorkerDeploymentVersion FromBridge(
             Temporalio.Bridge.Api.Common.WorkerDeploymentVersion bridgeVersion) =>
-        new(bridgeVersion.DeploymentName, bridgeVersion.BuildId);
+            new(bridgeVersion.DeploymentName, bridgeVersion.BuildId);
+
+        /// <summary>
+        /// Returns a new <see cref="WorkerDeploymentVersion"/> instance from a proto version.
+        /// </summary>
+        /// <param name="protoVersion">The proto version to convert.</param>
+        /// <returns>A new <see cref="WorkerDeploymentVersion"/> instance.</returns>
+        internal static WorkerDeploymentVersion FromProto(
+            Temporalio.Api.Deployment.V1.WorkerDeploymentVersion protoVersion) =>
+            new(protoVersion.DeploymentName, protoVersion.BuildId);
 
         /// <summary>
         /// Converts this version to a proto.

--- a/src/Temporalio/CompatibilitySuppressions.xml
+++ b/src/Temporalio/CompatibilitySuppressions.xml
@@ -31,6 +31,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.#ctor(Temporalio.Api.WorkflowService.V1.DescribeActivityExecutionResponse,System.String,Temporalio.Converters.DataConverter)</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Temporalio.Client.ActivityExecutionDescription.get_LongPollToken</Target>
     <Left>lib/net462/Temporalio.dll</Left>
     <Right>lib/net462/Temporalio.dll</Right>
@@ -101,6 +108,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.#ctor(Temporalio.Api.WorkflowService.V1.DescribeActivityExecutionResponse,System.String,Temporalio.Converters.DataConverter)</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Temporalio.Client.ActivityExecutionDescription.get_LongPollToken</Target>
     <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
@@ -165,6 +179,13 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Temporalio.Client.ActivityExecution.get_StateTransitionCount</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.#ctor(Temporalio.Api.WorkflowService.V1.DescribeActivityExecutionResponse,System.String,Temporalio.Converters.DataConverter)</Target>
     <Left>lib/netstandard2.0/Temporalio.dll</Left>
     <Right>lib/netstandard2.0/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Temporalio/CompatibilitySuppressions.xml
+++ b/src/Temporalio/CompatibilitySuppressions.xml
@@ -3,6 +3,62 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityDescribeOptions.get_LongPollToken</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityDescribeOptions.set_LongPollToken(System.Byte[])</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecution.get_ScheduledTime</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecution.get_StateTransitionCount</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.get_LongPollToken</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.GetStaticSummaryAsync</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.StartActivityOptions.get_StaticSummary</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.StartActivityOptions.set_StaticSummary(System.String)</Target>
+    <Left>lib/net462/Temporalio.dll</Left>
+    <Right>lib/net462/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Temporalio.Workflows.SignalWithStartWorkflowOptions.get_RequestId</Target>
     <Left>lib/net462/Temporalio.dll</Left>
     <Right>lib/net462/Temporalio.dll</Right>
@@ -17,6 +73,62 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityDescribeOptions.get_LongPollToken</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityDescribeOptions.set_LongPollToken(System.Byte[])</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecution.get_ScheduledTime</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecution.get_StateTransitionCount</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.get_LongPollToken</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.GetStaticSummaryAsync</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.StartActivityOptions.get_StaticSummary</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.StartActivityOptions.set_StaticSummary(System.String)</Target>
+    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
+    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Temporalio.Workflows.SignalWithStartWorkflowOptions.get_RequestId</Target>
     <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
@@ -27,6 +139,62 @@
     <Target>M:Temporalio.Workflows.SignalWithStartWorkflowOptions.set_RequestId(System.String)</Target>
     <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityDescribeOptions.get_LongPollToken</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityDescribeOptions.set_LongPollToken(System.Byte[])</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecution.get_ScheduledTime</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecution.get_StateTransitionCount</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.get_LongPollToken</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.ActivityExecutionDescription.GetStaticSummaryAsync</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.StartActivityOptions.get_StaticSummary</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Temporalio.Client.StartActivityOptions.set_StaticSummary(System.String)</Target>
+    <Left>lib/netstandard2.0/Temporalio.dll</Left>
+    <Right>lib/netstandard2.0/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>

--- a/src/Temporalio/CompatibilitySuppressions.xml
+++ b/src/Temporalio/CompatibilitySuppressions.xml
@@ -31,13 +31,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Temporalio.Client.ActivityExecutionDescription.#ctor(Temporalio.Api.WorkflowService.V1.DescribeActivityExecutionResponse,System.String,Temporalio.Converters.DataConverter)</Target>
-    <Left>lib/net462/Temporalio.dll</Left>
-    <Right>lib/net462/Temporalio.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Temporalio.Client.ActivityExecutionDescription.get_LongPollToken</Target>
     <Left>lib/net462/Temporalio.dll</Left>
     <Right>lib/net462/Temporalio.dll</Right>
@@ -108,13 +101,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Temporalio.Client.ActivityExecutionDescription.#ctor(Temporalio.Api.WorkflowService.V1.DescribeActivityExecutionResponse,System.String,Temporalio.Converters.DataConverter)</Target>
-    <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
-    <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Temporalio.Client.ActivityExecutionDescription.get_LongPollToken</Target>
     <Left>lib/netcoreapp3.1/Temporalio.dll</Left>
     <Right>lib/netcoreapp3.1/Temporalio.dll</Right>
@@ -179,13 +165,6 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Temporalio.Client.ActivityExecution.get_StateTransitionCount</Target>
-    <Left>lib/netstandard2.0/Temporalio.dll</Left>
-    <Right>lib/netstandard2.0/Temporalio.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Temporalio.Client.ActivityExecutionDescription.#ctor(Temporalio.Api.WorkflowService.V1.DescribeActivityExecutionResponse,System.String,Temporalio.Converters.DataConverter)</Target>
     <Left>lib/netstandard2.0/Temporalio.dll</Left>
     <Right>lib/netstandard2.0/Temporalio.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -1,3 +1,5 @@
+using Temporalio.Converters;
+
 #pragma warning disable xUnit1013 // We want public static methods as activities
 namespace Temporalio.Tests.Client;
 
@@ -37,6 +39,18 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
             await Task.Delay(100, ctx.CancellationToken);
         }
         ctx.CancellationToken.ThrowIfCancellationRequested();
+    }
+
+    [Activity]
+    public static Task<string> FailHeartbeatSucceed(string input)
+    {
+        var ctx = ActivityExecutionContext.Current;
+        ctx.Heartbeat("heartbeat details");
+        if (ActivityExecutionContext.Current.Info.Attempt == 1)
+        {
+            throw new ApplicationFailureException("first attempt failure");
+        }
+        return Task.FromResult("result");
     }
 
     [Fact]
@@ -173,10 +187,10 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
 
             var desc = await handle.DescribeAsync();
             Assert.Equal(ActivityExecutionStatus.Completed, desc.Status);
-            Assert.True(desc.ScheduledTime > DateTime.MinValue);
+            Assert.True(desc.ScheduleTime > DateTime.MinValue);
             Assert.NotNull(desc.LastStartedTime);
             Assert.True(
-                desc.LastStartedTime.Value - desc.ScheduledTime >= startDelay - TimeSpan.FromMilliseconds(500));
+                desc.LastStartedTime.Value - desc.ScheduleTime >= startDelay - TimeSpan.FromMilliseconds(500));
         });
     }
 
@@ -224,7 +238,7 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
                 Assert.Equal(activityId, desc.ActivityId);
                 Assert.Equal("WaitForCancel", desc.ActivityType);
                 Assert.Equal(taskQueue, desc.TaskQueue);
-                Assert.True(desc.ScheduledTime > DateTime.MinValue);
+                Assert.True(desc.ScheduleTime > DateTime.MinValue);
                 Assert.Equal(1, desc.Attempt);
                 Assert.NotNull(desc.ScheduleToCloseTimeout);
                 Assert.NotNull(desc.StartToCloseTimeout);
@@ -252,14 +266,97 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
                 new($"act-{Guid.NewGuid()}", taskQueue)
                 {
                     ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
-                    StaticSummary = "Test summary",
+                    Summary = "Test summary",
                     StaticDetails = "Test details\nLine 2",
                 });
             await handle.GetResultAsync();
 
             var desc = await handle.DescribeAsync();
-            Assert.Equal("Test summary", await desc.GetStaticSummaryAsync());
+            Assert.Equal("Test summary", await desc.GetSummaryAsync());
             Assert.Equal("Test details\nLine 2", await desc.GetStaticDetailsAsync());
+        });
+    }
+
+    [Fact]
+    public async Task DescribeAsync_NoPayloads()
+    {
+        await ExecuteActivityWorkerAsync(FailHeartbeatSucceed, async taskQueue =>
+        {
+            var handle = await Client.StartActivityAsync(
+                () => FailHeartbeatSucceed("input"),
+                new($"act-{Guid.NewGuid()}", taskQueue)
+                {
+                    ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+                });
+            await handle.GetResultAsync();
+
+            var desc = await handle.DescribeAsync();
+            Assert.False(desc.HasInput);
+            Assert.False(desc.HasResult);
+            Assert.False(desc.HasOutcomeFailure);
+            Assert.False(desc.HasHeartbeatDetails);
+            Assert.False(desc.HasLastFailure);
+            Assert.Null(desc.RawInput?.FirstOrDefault());
+            await Assert.ThrowsAsync<InvalidOperationException>(desc.GetResultAsync<string>);
+            Assert.Null(await desc.GetOutcomeFailureAsync());
+            Assert.Null(desc.RawInfo.HeartbeatDetails?.Payloads_?.FirstOrDefault());
+            Assert.Null(await desc.GetLastFailureAsync());
+        });
+    }
+
+    [Fact]
+    public async Task DescribeAsync_IncludePayloads_Success()
+    {
+        await ExecuteActivityWorkerAsync(FailHeartbeatSucceed, async taskQueue =>
+        {
+            var handle = await Client.StartActivityAsync(
+                () => FailHeartbeatSucceed("input"),
+                new($"act-{Guid.NewGuid()}", taskQueue)
+                {
+                    ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+                });
+            await handle.GetResultAsync();
+
+            var desc = await handle.DescribeAsync(new() { IncludeInput = true, IncludeOutcome = true, IncludeHeartbeatDetails = true, IncludeLastFailure = true });
+            Assert.True(desc.HasInput);
+            Assert.True(desc.HasResult);
+            Assert.False(desc.HasOutcomeFailure);
+            Assert.True(desc.HasHeartbeatDetails);
+            Assert.True(desc.HasLastFailure);
+            Assert.Equal("input", await Client.Options.DataConverter.ToSingleValueAsync<string>(desc.RawInput!));
+            Assert.Equal("result", await desc.GetResultAsync<string>());
+            Assert.Null(await desc.GetOutcomeFailureAsync());
+            Assert.Equal("heartbeat details", await Client.Options.DataConverter.ToSingleValueAsync<string>(desc.RawInfo.HeartbeatDetails.Payloads_));
+            Assert.Equal("first attempt failure", ((ApplicationFailureException)(await desc.GetLastFailureAsync())!).Message);
+        });
+    }
+
+    [Fact]
+    public async Task DescribeAsync_IncludePayloads_Failure()
+    {
+        await ExecuteActivityWorkerAsync(FailHeartbeatSucceed, async taskQueue =>
+        {
+            var handle = await Client.StartActivityAsync(
+                () => FailHeartbeatSucceed("input"),
+                new($"act-{Guid.NewGuid()}", taskQueue)
+                {
+                    ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+                    RetryPolicy = new() { MaximumAttempts = 1 },
+                });
+            await Assert.ThrowsAsync<ActivityFailedException>(() => handle.GetResultAsync());
+
+            var desc = await handle.DescribeAsync(new() { IncludeInput = true, IncludeOutcome = true, IncludeHeartbeatDetails = true, IncludeLastFailure = true });
+            Assert.True(desc.HasInput);
+            Assert.False(desc.HasResult);
+            Assert.True(desc.HasOutcomeFailure);
+            Assert.True(desc.HasHeartbeatDetails);
+            Assert.True(desc.HasLastFailure);
+            Assert.Equal("input", await Client.Options.DataConverter.ToSingleValueAsync<string>(desc.RawInput!));
+            await Assert.ThrowsAsync<InvalidOperationException>(desc.GetResultAsync<string>);
+            Assert.IsType<ApplicationFailureException>(await desc.GetLastFailureAsync());
+            Assert.Equal("first attempt failure", ((ApplicationFailureException)(await desc.GetOutcomeFailureAsync())!).Message);
+            Assert.Equal("heartbeat details", await Client.Options.DataConverter.ToSingleValueAsync<string>(desc.RawInfo.HeartbeatDetails.Payloads_));
+            Assert.Equal("first attempt failure", ((ApplicationFailureException)(await desc.GetLastFailureAsync())!).Message);
         });
     }
 

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -298,9 +298,9 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
             Assert.False(desc.HasLastFailure);
             Assert.Null(desc.RawInput?.FirstOrDefault());
             await Assert.ThrowsAsync<InvalidOperationException>(desc.GetResultAsync<string>);
-            Assert.Null(await desc.GetOutcomeFailureAsync());
+            await Assert.ThrowsAsync<InvalidOperationException>(desc.GetOutcomeFailureAsync);
             Assert.Null(desc.RawInfo.HeartbeatDetails?.Payloads_?.FirstOrDefault());
-            Assert.Null(await desc.GetLastFailureAsync());
+            await Assert.ThrowsAsync<InvalidOperationException>(desc.GetLastFailureAsync);
         });
     }
 

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -297,7 +297,7 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
             Assert.False(desc.HasHeartbeatDetails);
             Assert.False(desc.HasLastFailure);
             Assert.Null(desc.RawInput?.FirstOrDefault());
-            await Assert.ThrowsAsync<InvalidOperationException>(desc.GetResultAsync<string>);
+            Assert.Null(await desc.GetResultAsync<string>());
             Assert.Null(await desc.GetOutcomeFailureAsync());
             Assert.Null(desc.RawInfo.HeartbeatDetails?.Payloads_?.FirstOrDefault());
             Assert.Null(await desc.GetLastFailureAsync());
@@ -352,7 +352,7 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
             Assert.True(desc.HasHeartbeatDetails);
             Assert.True(desc.HasLastFailure);
             Assert.Equal("input", await Client.Options.DataConverter.ToSingleValueAsync<string>(desc.RawInput!));
-            await Assert.ThrowsAsync<InvalidOperationException>(desc.GetResultAsync<string>);
+            Assert.Null(await desc.GetResultAsync<string>());
             Assert.IsType<ApplicationFailureException>(await desc.GetLastFailureAsync());
             Assert.Equal("first attempt failure", ((ApplicationFailureException)(await desc.GetOutcomeFailureAsync())!).Message);
             Assert.Equal("heartbeat details", await Client.Options.DataConverter.ToSingleValueAsync<string>(desc.RawInfo.HeartbeatDetails.Payloads_));

--- a/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
+++ b/tests/Temporalio.Tests/Client/TemporalClientActivityTests.cs
@@ -298,9 +298,9 @@ public class TemporalClientActivityTests : WorkflowEnvironmentTestBase
             Assert.False(desc.HasLastFailure);
             Assert.Null(desc.RawInput?.FirstOrDefault());
             await Assert.ThrowsAsync<InvalidOperationException>(desc.GetResultAsync<string>);
-            await Assert.ThrowsAsync<InvalidOperationException>(desc.GetOutcomeFailureAsync);
+            Assert.Null(await desc.GetOutcomeFailureAsync());
             Assert.Null(desc.RawInfo.HeartbeatDetails?.Payloads_?.FirstOrDefault());
-            await Assert.ThrowsAsync<InvalidOperationException>(desc.GetLastFailureAsync);
+            Assert.Null(await desc.GetLastFailureAsync());
         });
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## 💥 **Breaking changes**
Changes to experimental `ActivityExecutionDescription` class and related classes:
- `StaticSummary` and `ScheduledTime` were renamed to `Summary` and `ScheduleTime` respectively.
- `LongPollToken` and `StateTransitionCount` were removed.

## What was changed
<!-- Describe what has changed in this PR -->
- Support requesting optional payload fields in `ActivityHandle.DescribeAsync` and expose them in `ActivityExecutionDescription`.
- Added, removed and renamed properties in `ActivityExecutionDescription` to match latest API.

## Why?
<!-- Tell your future self why have you made these changes -->
- Exposes latest functionality of `DescribeActivityExecution` RPC.
- Aligns exposed APIs with the latest design.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
New tests in `TemporalClientActivityTests`.