### PR TITLE
Nexus: raw activity starts inherit request ID and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ to docs, or any other relevant information.
   carry the optional `reason`.
 - A Nexus operation backed by a workflow query now fails when the query fails or is
   rejected, rather than being retried until the operation times out.
+- An activity started using the ambient `TemporalClient` directly from inside a synchronous Nexus
+  operation handler now inherits the handler's request ID and inbound links, same as the guarded
+  start already gets.
 
 ## [1.18.0] - 2026-08-13
 

--- a/src/Temporalio/Client/TemporalClient.Activity.cs
+++ b/src/Temporalio/Client/TemporalClient.Activity.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using NexusRpc.Handlers;
 using Temporalio.Api.Common.V1;
 using Temporalio.Api.TaskQueue.V1;
 using Temporalio.Api.WorkflowService.V1;
@@ -96,6 +97,7 @@ namespace Temporalio.Client
                 {
                     throw new ArgumentException("StartDelay must be non-negative");
                 }
+                input = ApplyNexusWiringForRawActivityStart(input);
                 try
                 {
                     // Activity-specific data converter
@@ -304,6 +306,32 @@ namespace Temporalio.Client
                         .ToList()
                         .AsReadOnly(),
                     NextPageToken: resp.NextPageToken.IsEmpty ? null : resp.NextPageToken.ToByteArray());
+            }
+
+            // Give a raw start the same request ID and inbound links a guarded start already gets.
+            private static StartActivityInput ApplyNexusWiringForRawActivityStart(StartActivityInput input)
+            {
+                if (!NexusOperationExecutionContext.HasCurrent ||
+                    input.Options.RequestId != null ||
+                    NexusOperationExecutionContext.Current.HandlerContext is not
+                        OperationStartContext nexusStartContext)
+                {
+                    return input;
+                }
+                var options = (StartActivityOptions)input.Options.Clone();
+                var links = NexusOperationStartHelper.CreateInboundLinks(
+                    nexusStartContext, NexusOperationExecutionContext.Current);
+                if (links != null)
+                {
+                    options.Links = options.Links is { } existingLinks ?
+                        existingLinks.Concat(links).ToList() : links;
+                }
+                options.OnConflictOptions = NexusOperationStartHelper.CreateActivityOnConflictOptions(
+                    options.IdConflictPolicy,
+                    hasLinks: options.Links is { Count: > 0 },
+                    hasCompletionCallback: false);
+                options.RequestId = nexusStartContext.RequestId;
+                return input with { Options = options };
             }
 
 #if NETCOREAPP3_0_OR_GREATER

--- a/src/Temporalio/Nexus/NexusActivityStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusActivityStartHelper.cs
@@ -42,25 +42,21 @@ namespace Temporalio.Nexus
             // Build the callback-header token without a run ID (we don't have it yet).
             var callbackToken = NexusActivityExecutionToken.Create(namespace_, activityId, runId: null);
 
-            if (options.IdConflictPolicy == Api.Enums.V1.ActivityIdConflictPolicy.UseExisting)
-            {
-                options.OnConflictOptions = new()
-                {
-                    AttachLinks = true,
-                    AttachCompletionCallbacks = true,
-                    AttachRequestId = true,
-                };
-            }
-            if (NexusOperationStartHelper.CreateInboundLinks(
-                    nexusStartContext, temporalContext) is { } links)
+            var links = NexusOperationStartHelper.CreateInboundLinks(nexusStartContext, temporalContext);
+            if (links != null)
             {
                 options.Links = links;
             }
-            if (NexusOperationStartHelper.CreateCallback(
-                    nexusStartContext, callbackToken, options.Links) is { } callback)
+            var callback = NexusOperationStartHelper.CreateCallback(
+                nexusStartContext, callbackToken, options.Links);
+            if (callback != null)
             {
                 options.CompletionCallbacks = new[] { callback };
             }
+            options.OnConflictOptions = NexusOperationStartHelper.CreateActivityOnConflictOptions(
+                options.IdConflictPolicy,
+                hasLinks: options.Links is { Count: > 0 },
+                hasCompletionCallback: callback != null);
             options.RequestId = nexusStartContext.RequestId;
 
             // Do the start call

--- a/src/Temporalio/Nexus/NexusOperationStartHelper.cs
+++ b/src/Temporalio/Nexus/NexusOperationStartHelper.cs
@@ -91,5 +91,34 @@ namespace Temporalio.Nexus
             }
             return callback;
         }
+
+        /// <summary>
+        /// Build on-conflict options for an activity start under a <c>UseExisting</c> ID conflict
+        /// policy, attaching only the artifacts the start actually carries. The server rejects
+        /// attaching a request ID with no accompanying link or completion callback, so this
+        /// returns <c>null</c> unless there is at least one to attach.
+        /// </summary>
+        /// <param name="idConflictPolicy">The activity ID conflict policy.</param>
+        /// <param name="hasLinks">Whether the start carries links to attach.</param>
+        /// <param name="hasCompletionCallback">Whether the start carries a completion callback to
+        /// attach.</param>
+        /// <returns>On-conflict options, or <c>null</c> if not applicable.</returns>
+        internal static Api.Common.V1.OnConflictOptions? CreateActivityOnConflictOptions(
+            Api.Enums.V1.ActivityIdConflictPolicy idConflictPolicy,
+            bool hasLinks,
+            bool hasCompletionCallback)
+        {
+            if (idConflictPolicy != Api.Enums.V1.ActivityIdConflictPolicy.UseExisting ||
+                (!hasLinks && !hasCompletionCallback))
+            {
+                return null;
+            }
+            return new()
+            {
+                AttachLinks = hasLinks,
+                AttachCompletionCallbacks = hasCompletionCallback,
+                AttachRequestId = true,
+            };
+        }
     }
 }

--- a/src/Temporalio/Worker/NexusWorker.cs
+++ b/src/Temporalio/Worker/NexusWorker.cs
@@ -169,6 +169,11 @@ namespace Temporalio.Worker
             // Create context
             RemoveInvalidHeaders(task.Request.Header);
             var startOp = task.Request.StartOperation;
+            if (string.IsNullOrEmpty(startOp.RequestId))
+            {
+                throw new HandlerException(
+                    HandlerErrorType.Internal, "Nexus start-operation task is missing a request ID");
+            }
             var context = new OperationStartContext(
                 Service: startOp.Service,
                 Operation: startOp.Operation,

--- a/tests/Temporalio.Tests/Nexus/NexusOperationExecutionContextTests.cs
+++ b/tests/Temporalio.Tests/Nexus/NexusOperationExecutionContextTests.cs
@@ -29,6 +29,13 @@ public class NexusOperationExecutionContextTests
     }
 
     [Fact]
+    public void HandlerContext_IsOperationStartContext()
+    {
+        var context = NewContext();
+        Assert.IsType<OperationStartContext>(context.HandlerContext);
+    }
+
+    [Fact]
     public void TryAddResponseLink_AppendsWorkflowEventLink()
     {
         var context = NewContext();

--- a/tests/Temporalio.Tests/Nexus/NexusOperationStartHelperTests.cs
+++ b/tests/Temporalio.Tests/Nexus/NexusOperationStartHelperTests.cs
@@ -1,0 +1,57 @@
+namespace Temporalio.Tests.Nexus;
+
+using Temporalio.Api.Enums.V1;
+using Temporalio.Nexus;
+using Xunit;
+
+public class NexusOperationStartHelperTests
+{
+    [Fact]
+    public void CreateActivityOnConflictOptions_NotUseExisting_ReturnsNull()
+    {
+        var result = NexusOperationStartHelper.CreateActivityOnConflictOptions(
+            ActivityIdConflictPolicy.Fail, hasLinks: true, hasCompletionCallback: true);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void CreateActivityOnConflictOptions_UseExistingWithNeitherArtifact_ReturnsNull()
+    {
+        var result = NexusOperationStartHelper.CreateActivityOnConflictOptions(
+            ActivityIdConflictPolicy.UseExisting, hasLinks: false, hasCompletionCallback: false);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void CreateActivityOnConflictOptions_UseExistingWithLinksOnly_AttachesLinksAndRequestIdOnly()
+    {
+        var result = NexusOperationStartHelper.CreateActivityOnConflictOptions(
+            ActivityIdConflictPolicy.UseExisting, hasLinks: true, hasCompletionCallback: false);
+        Assert.NotNull(result);
+        Assert.True(result.AttachLinks);
+        Assert.False(result.AttachCompletionCallbacks);
+        Assert.True(result.AttachRequestId);
+    }
+
+    [Fact]
+    public void CreateActivityOnConflictOptions_UseExistingWithCallbackOnly_AttachesCallbackAndRequestIdOnly()
+    {
+        var result = NexusOperationStartHelper.CreateActivityOnConflictOptions(
+            ActivityIdConflictPolicy.UseExisting, hasLinks: false, hasCompletionCallback: true);
+        Assert.NotNull(result);
+        Assert.False(result.AttachLinks);
+        Assert.True(result.AttachCompletionCallbacks);
+        Assert.True(result.AttachRequestId);
+    }
+
+    [Fact]
+    public void CreateActivityOnConflictOptions_UseExistingWithBoth_AttachesAll()
+    {
+        var result = NexusOperationStartHelper.CreateActivityOnConflictOptions(
+            ActivityIdConflictPolicy.UseExisting, hasLinks: true, hasCompletionCallback: true);
+        Assert.NotNull(result);
+        Assert.True(result.AttachLinks);
+        Assert.True(result.AttachCompletionCallbacks);
+        Assert.True(result.AttachRequestId);
+    }
+}

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1,5 +1,7 @@
 namespace Temporalio.Tests.Worker;
 
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging.Abstractions;
 using NexusRpc;
 using NexusRpc.Handlers;
 using Temporalio.Activities;
@@ -2372,6 +2374,15 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         public static Task<string> EchoAsync(string input) =>
             Task.FromResult($"echo-activity:{input}");
 
+        public static ConcurrentDictionary<string, int> EchoRunCounts { get; } = new();
+
+        [Activity]
+        public static Task<string> CountingEchoAsync(string input)
+        {
+            EchoRunCounts.AddOrUpdate(input, 1, (_, count) => count + 1);
+            return Task.FromResult($"echo-activity:{input}");
+        }
+
         [Activity]
         public static async Task WaitForCancelAsync()
         {
@@ -2384,6 +2395,307 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             }
             ctx.CancellationToken.ThrowIfCancellationRequested();
         }
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_RawActivityStartFromSyncHandler_TwoActivitiesBothSucceed()
+    {
+        await RunRawActivityStartTwoActivitiesAsync();
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_RawActivityStartFromSyncHandler_ActivitiesCarryInboundLink()
+    {
+        var (activityIds, callerWorkflowId) = await RunRawActivityStartTwoActivitiesAsync();
+        foreach (var activityId in activityIds)
+        {
+            var desc = await Client.GetActivityHandle(activityId).DescribeAsync();
+            var link = Assert.Single(desc.RawInfo.Links);
+            Assert.Equal(callerWorkflowId, link.WorkflowEvent.WorkflowId);
+            Assert.Equal(
+                Api.Enums.V1.EventType.NexusOperationScheduled,
+                link.WorkflowEvent.EventRef.EventType);
+        }
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_RawActivityStartFromSyncHandler_PreservesCallerSuppliedLinks()
+    {
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (ctx, input) =>
+                {
+                    var client = NexusOperationExecutionContext.Current.TemporalClient;
+                    var callerLink = new Link
+                    {
+                        WorkflowEvent = new()
+                        {
+                            Namespace = "caller-supplied-namespace",
+                            WorkflowId = "caller-supplied-workflow-id",
+                            RunId = Guid.NewGuid().ToString(),
+                            EventRef = new()
+                            {
+                                EventId = 1,
+                                EventType = Api.Enums.V1.EventType.WorkflowExecutionStarted,
+                            },
+                        },
+                    };
+                    var handle = await client.StartActivityAsync<string>(
+                        () => ActivityStubs.EchoAsync(input),
+                        new()
+                        {
+                            Id = $"act-{Guid.NewGuid()}",
+                            TaskQueue = NexusOperationExecutionContext.Current.Info.TaskQueue,
+                            ScheduleToCloseTimeout = TimeSpan.FromMinutes(1),
+                            Links = new[] { callerLink },
+                        });
+                    return handle.Id;
+                }))).
+            AddActivity(ActivityStubs.EchoAsync);
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        string? activityId = null;
+        await RunInWorkflowAsync(workerOptions, async () =>
+        {
+            activityId = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                ExecuteNexusOperationAsync(svc => svc.DoSomething("hello"));
+        });
+
+        var desc = await Client.GetActivityHandle(activityId!).DescribeAsync();
+        Assert.Equal(2, desc.RawInfo.Links.Count);
+        Assert.Contains(
+            desc.RawInfo.Links,
+            l => l.WorkflowEvent.WorkflowId == "caller-supplied-workflow-id");
+        Assert.Contains(
+            desc.RawInfo.Links,
+            l => l.WorkflowEvent.EventRef.EventType == Api.Enums.V1.EventType.NexusOperationScheduled);
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_RawActivityStartUseExistingWithoutInboundLinks_Succeeds()
+    {
+        var activityId = $"act-{Guid.NewGuid()}";
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (ctx, input) =>
+                {
+                    var client = NexusOperationExecutionContext.Current.TemporalClient;
+                    await client.StartActivityAsync(
+                        "WaitForCancel",
+                        Array.Empty<object?>(),
+                        new()
+                        {
+                            Id = input,
+                            TaskQueue = NexusOperationExecutionContext.Current.Info.TaskQueue,
+                            ScheduleToCloseTimeout = TimeSpan.FromMinutes(2),
+                            IdConflictPolicy = ActivityIdConflictPolicy.UseExisting,
+                        });
+                    return "attached";
+                }))).
+            AddActivity(ActivityStubs.WaitForCancelAsync);
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        using var worker = new TemporalWorker(Client, workerOptions);
+        await worker.ExecuteAsync(async () =>
+        {
+            var existingHandle = await Client.StartActivityAsync(
+                "WaitForCancel",
+                Array.Empty<object?>(),
+                new()
+                {
+                    Id = activityId,
+                    TaskQueue = workerOptions.TaskQueue!,
+                    ScheduleToCloseTimeout = TimeSpan.FromMinutes(2),
+                    HeartbeatTimeout = TimeSpan.FromSeconds(10),
+                });
+
+            var result = await Client.CreateNexusClient<IStringService>(endpoint).
+                ExecuteNexusOperationAsync<string>(
+                    svc => svc.DoSomething(activityId),
+                    new($"op-{Guid.NewGuid()}") { ScheduleToCloseTimeout = TimeSpan.FromMinutes(5) });
+            Assert.Equal("attached", result);
+
+            await existingHandle.CancelAsync();
+        });
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_RawActivityStartUseExistingWithCallerSuppliedLinksOnly_AttachesCallerLinks()
+    {
+        var activityId = $"act-{Guid.NewGuid()}";
+        var callerLink = new Link
+        {
+            WorkflowEvent = new()
+            {
+                Namespace = "caller-supplied-namespace",
+                WorkflowId = "caller-supplied-workflow-id",
+                RunId = Guid.NewGuid().ToString(),
+                EventRef = new()
+                {
+                    EventId = 1,
+                    EventType = Api.Enums.V1.EventType.WorkflowExecutionStarted,
+                },
+            },
+        };
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (ctx, input) =>
+                {
+                    var client = NexusOperationExecutionContext.Current.TemporalClient;
+                    await client.StartActivityAsync(
+                        "WaitForCancel",
+                        Array.Empty<object?>(),
+                        new()
+                        {
+                            Id = input,
+                            TaskQueue = NexusOperationExecutionContext.Current.Info.TaskQueue,
+                            ScheduleToCloseTimeout = TimeSpan.FromMinutes(2),
+                            IdConflictPolicy = ActivityIdConflictPolicy.UseExisting,
+                            Links = new[] { callerLink },
+                        });
+                    return "attached";
+                }))).
+            AddActivity(ActivityStubs.WaitForCancelAsync);
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        using var worker = new TemporalWorker(Client, workerOptions);
+        await worker.ExecuteAsync(async () =>
+        {
+            var existingHandle = await Client.StartActivityAsync(
+                "WaitForCancel",
+                Array.Empty<object?>(),
+                new()
+                {
+                    Id = activityId,
+                    TaskQueue = workerOptions.TaskQueue!,
+                    ScheduleToCloseTimeout = TimeSpan.FromMinutes(2),
+                    HeartbeatTimeout = TimeSpan.FromSeconds(10),
+                });
+
+            var result = await Client.CreateNexusClient<IStringService>(endpoint).
+                ExecuteNexusOperationAsync<string>(
+                    svc => svc.DoSomething(activityId),
+                    new($"op-{Guid.NewGuid()}") { ScheduleToCloseTimeout = TimeSpan.FromMinutes(5) });
+            Assert.Equal("attached", result);
+
+            var desc = await existingHandle.DescribeAsync();
+            Assert.Contains(
+                desc.RawInfo.Links,
+                l => l.WorkflowEvent?.WorkflowId == "caller-supplied-workflow-id");
+
+            await existingHandle.CancelAsync();
+        });
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_RawActivityStartUseExistingWithMalformedInboundLinks_Succeeds()
+    {
+        var activityId = $"act-{Guid.NewGuid()}";
+        var taskQueue = $"tq-{Guid.NewGuid()}";
+        var workerOptions = new TemporalWorkerOptions(taskQueue).
+            AddActivity(ActivityStubs.WaitForCancelAsync);
+
+        using var worker = new TemporalWorker(Client, workerOptions);
+        await worker.ExecuteAsync(async () =>
+        {
+            var existingHandle = await Client.StartActivityAsync(
+                () => ActivityStubs.WaitForCancelAsync(),
+                new()
+                {
+                    Id = activityId,
+                    TaskQueue = taskQueue,
+                    ScheduleToCloseTimeout = TimeSpan.FromMinutes(2),
+                    HeartbeatTimeout = TimeSpan.FromSeconds(10),
+                });
+
+            // Simulate a Nexus start context whose only inbound link is unrecognized, which
+            // NexusOperationStartHelper.CreateInboundLinks drops, yielding a non-null but empty
+            // collection.
+            var handlerContext = new OperationStartContext(
+                Service: "svc",
+                Operation: "op",
+                CancellationToken: CancellationToken.None,
+                RequestId: Guid.NewGuid().ToString())
+            {
+                InboundLinks = new[] { new NexusLink(new Uri("https://example.com"), "unrecognized-type") },
+            };
+            var executionContext = new NexusOperationExecutionContext(
+                handlerContext: handlerContext,
+                info: new(Client.Options.Namespace, taskQueue, "endpoint"),
+                logger: NullLogger.Instance,
+                runtimeMetricMeter: new Lazy<MetricMeter>(
+                    () => throw new InvalidOperationException("metric meter not expected in test")),
+                temporalClient: Client);
+            NexusOperationExecutionContext.AsyncLocalCurrent.Value = executionContext;
+            try
+            {
+                // Should not be rejected by the server for attaching a request ID with no link or
+                // completion callback to accompany it.
+                var conflictHandle = await Client.StartActivityAsync(
+                    () => ActivityStubs.WaitForCancelAsync(),
+                    new()
+                    {
+                        Id = activityId,
+                        TaskQueue = taskQueue,
+                        ScheduleToCloseTimeout = TimeSpan.FromMinutes(2),
+                        IdConflictPolicy = ActivityIdConflictPolicy.UseExisting,
+                    });
+                Assert.Equal(existingHandle.Id, conflictHandle.Id);
+            }
+            finally
+            {
+                NexusOperationExecutionContext.AsyncLocalCurrent.Value = null;
+            }
+
+            await existingHandle.CancelAsync();
+        });
+    }
+
+    [Fact]
+    public async Task StartActivityAsync_RawActivityStartFromSyncHandler_DedupsAcrossRedelivery()
+    {
+        var activityKey = $"redelivery-{Guid.NewGuid()}";
+        var invocationCount = 0;
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (ctx, input) =>
+                {
+                    var attempt = Interlocked.Increment(ref invocationCount);
+                    var client = NexusOperationExecutionContext.Current.TemporalClient;
+                    var handle = await client.StartActivityAsync<string>(
+                        () => ActivityStubs.CountingEchoAsync(input),
+                        new()
+                        {
+                            Id = $"act-{input}",
+                            TaskQueue = NexusOperationExecutionContext.Current.Info.TaskQueue,
+                            ScheduleToCloseTimeout = TimeSpan.FromMinutes(2),
+                        });
+                    var result = await handle.GetResultAsync();
+                    if (attempt == 1)
+                    {
+                        // Forces a real server-driven redelivery of this StartOperation task.
+                        throw new InvalidOperationException("Simulated failure to force redelivery");
+                    }
+                    return result;
+                }))).
+            AddActivity(ActivityStubs.CountingEchoAsync);
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        using var worker = new TemporalWorker(Client, workerOptions);
+        await worker.ExecuteAsync(async () =>
+        {
+            var result = await Client.CreateNexusClient<IStringService>(endpoint).
+                ExecuteNexusOperationAsync<string>(
+                    svc => svc.DoSomething(activityKey),
+                    new($"op-{Guid.NewGuid()}")
+                    {
+                        ScheduleToCloseTimeout = TimeSpan.FromMinutes(3),
+                        Rpc = new() { Timeout = TimeSpan.FromMinutes(3) },
+                    });
+            Assert.Equal($"echo-activity:{activityKey}", result);
+        });
+
+        Assert.Equal(1, ActivityStubs.EchoRunCounts.GetValueOrDefault(activityKey));
     }
 
     [Fact]
@@ -2877,6 +3189,53 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         var name = $"nexus-endpoint-{taskQueue}";
         await Env.TestEnv.CreateNexusEndpointAsync(name, taskQueue);
         return name;
+    }
+
+    private async Task<(string[] ActivityIds, string CallerWorkflowId)>
+        RunRawActivityStartTwoActivitiesAsync()
+    {
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddNexusService(new HandlerFactoryStringService(() =>
+                OperationHandler.Sync<string, string>(async (ctx, input) =>
+                {
+                    var client = NexusOperationExecutionContext.Current.TemporalClient;
+                    var taskQueue = NexusOperationExecutionContext.Current.Info.TaskQueue;
+                    var first = await client.StartActivityAsync<string>(
+                        () => ActivityStubs.EchoAsync($"{input}-a"),
+                        new()
+                        {
+                            Id = $"act-a-{Guid.NewGuid()}",
+                            TaskQueue = taskQueue,
+                            ScheduleToCloseTimeout = TimeSpan.FromMinutes(1),
+                        });
+                    var second = await client.StartActivityAsync<string>(
+                        () => ActivityStubs.EchoAsync($"{input}-b"),
+                        new()
+                        {
+                            Id = $"act-b-{Guid.NewGuid()}",
+                            TaskQueue = taskQueue,
+                            ScheduleToCloseTimeout = TimeSpan.FromMinutes(1),
+                        });
+                    return $"{first.Id}|{second.Id}|{await first.GetResultAsync()}|" +
+                        $"{await second.GetResultAsync()}";
+                }))).
+            AddActivity(ActivityStubs.EchoAsync);
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        var callerWorkflowId = $"caller-{Guid.NewGuid()}";
+        string[]? activityIds = null;
+        await RunInWorkflowAsync(
+            workerOptions,
+            async () =>
+            {
+                var result = await Workflow.CreateNexusWorkflowClient<IStringService>(endpoint).
+                    ExecuteNexusOperationAsync(svc => svc.DoSomething("hello"));
+                var parts = result.Split('|');
+                Assert.Equal("echo-activity:hello-a|echo-activity:hello-b", $"{parts[2]}|{parts[3]}");
+                activityIds = new[] { parts[0], parts[1] };
+            },
+            callerWorkflowId: callerWorkflowId);
+        return (activityIds!, callerWorkflowId);
     }
 
     [Workflow]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

A raw activity start issued from inside a synchronous Nexus operation handler now inherits the handler's request ID and inbound links, same as the guarded path already does.

## Why?

Previously a raw activity client call made inside a Nexus handler was not carrying none of the Nexus-aware wiring: no inbound links, and no redelivery-safe request ID. This change aligns with the equivalent fixes in sdk-typescript (#2369), sdk-go (#2633), and sdk-java (#3048).

## Checklist

1. Closes N/A Aligns SDK behaviour for link and request id propagation in raw activity starts, see `Why` for related PRs in other SDKs.<!-- add issue number here -->

2. How was this tested:
   - New tests added to `TemporalClientNexusOperationTests`
   - Full suite passes locally, including the inbound-link assertion against the pinned dev-server build.

3. Any docs updates needed?
   - No
