### PR TITLE
Document root workflow namespace omission

### DIFF
--- a/src/Temporalio/Workflows/WorkflowInfo.cs
+++ b/src/Temporalio/Workflows/WorkflowInfo.cs
@@ -21,7 +21,9 @@ namespace Temporalio.Workflows
     /// <param name="Priority">The Priority of this workflow.</param>
     /// <param name="RetryPolicy">Retry policy for the workflow.</param>
     /// <param name="Root">Root information for the workflow. This is nil in pre-1.27.0 server
-    /// versions or if there is no root (i.e. the root is itself).</param>
+    /// versions or if there is no root (i.e. the root is itself). Its namespace is not retained
+    /// and may differ from this workflow's namespace for cross-namespace child workflows. Track it
+    /// separately if needed.</param>
     /// <param name="RunId">Run ID for the workflow.</param>
     /// <param name="RunTimeout">Run timeout for the workflow.</param>
     /// <param name="StartTime">Time when the first workflow task started.</param>
@@ -85,7 +87,9 @@ namespace Temporalio.Workflows
             string WorkflowId);
 
         /// <summary>
-        /// Information about a parent of a workflow.
+        /// Information about the root of a workflow. Its namespace is not retained and may differ
+        /// from the current workflow's namespace for cross-namespace child workflows. Track it
+        /// separately if needed.
         /// </summary>
         /// <param name="RunId">Run ID for the root.</param>
         /// <param name="WorkflowId">Workflow ID for the root.</param>


### PR DESCRIPTION
## What was changed
Document that root workflow execution information omits its namespace. The root namespace may differ for cross-namespace child workflows and must be tracked separately.

## Why?
Completes the documentation requirement from temporalio/features#605.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no runtime or API behavior impact.
> 
> **Overview**
> **Documentation-only** updates to `WorkflowInfo` and `RootInfo` XML comments so developers know root execution info does **not** include namespace.
> 
> The `Root` parameter docs now state that namespace is not retained and can differ from the current workflow’s namespace for **cross-namespace child workflows**, and that callers should track root namespace separately if they need it. The `RootInfo` summary is corrected from “parent” to **root** workflow and repeats the same namespace caveat (aligned with temporalio/features#605).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f4030265fe404b228e1035316998417f1353260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->