### PR TITLE
Add experimental Workflow Streams extension

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @temporalio/sdk
+/src/Temporalio.Extensions.WorkflowStreams/ @temporalio/sdk @temporalio/ai-sdk
+/tests/Temporalio.Tests/Extensions/WorkflowStreams/ @temporalio/sdk @temporalio/ai-sdk

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -170,6 +170,8 @@ jobs:
             src/Temporalio.Extensions.Hosting/bin/Release/*.snupkg
             src/Temporalio.Extensions.OpenTelemetry/bin/Release/*.nupkg
             src/Temporalio.Extensions.OpenTelemetry/bin/Release/*.snupkg
+            src/Temporalio.Extensions.WorkflowStreams/bin/Release/*.nupkg
+            src/Temporalio.Extensions.WorkflowStreams/bin/Release/*.snupkg
 
   run-smoke-test:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Added the experimental `Temporalio.Extensions.WorkflowStreams` package for durable, batched,
+  offset-based publish/subscribe streams hosted by workflows, interoperable with other Temporal
+  SDK Workflow Streams implementations.
 - Added operation-specific outbound workflow interceptors for Temporal System Nexus operations.
   `SignalWithStartWorkflowAsync` can now be intercepted before the existing
   `ScheduleSystemNexusOperationAsync` hook.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="Amazon.Lambda.Core" Version="3.1.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.26.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Extensions:
   Client dependency injection, activity dependency injection, and worker generic host support
 * [Temporalio.Extensions.OpenTelemetry](https://github.com/temporalio/sdk-dotnet/tree/main/src/Temporalio.Extensions.OpenTelemetry) -
   OpenTelemetry tracing support
+* [Temporalio.Extensions.WorkflowStreams](https://github.com/temporalio/sdk-dotnet/tree/main/src/Temporalio.Extensions.WorkflowStreams) -
+  experimental durable, offset-based workflow publish/subscribe streams
 
 ---
 

--- a/Temporalio.slnx
+++ b/Temporalio.slnx
@@ -7,6 +7,7 @@
     <Project Path="src/Temporalio.Extensions.Gcp.CloudRun.OpenTelemetry/Temporalio.Extensions.Gcp.CloudRun.OpenTelemetry.csproj" />
     <Project Path="src/Temporalio.Extensions.Hosting/Temporalio.Extensions.Hosting.csproj" />
     <Project Path="src/Temporalio.Extensions.OpenTelemetry/Temporalio.Extensions.OpenTelemetry.csproj" />
+    <Project Path="src/Temporalio.Extensions.WorkflowStreams/Temporalio.Extensions.WorkflowStreams.csproj" />
     <Project Path="src/Temporalio.SystemNexus.Generator/Temporalio.SystemNexus.Generator.csproj" />
     <Project Path="src/Temporalio/Temporalio.csproj" />
   </Folder>

--- a/src/Temporalio.ApiDoc/docfx.json
+++ b/src/Temporalio.ApiDoc/docfx.json
@@ -10,7 +10,8 @@
             "Temporalio.Extensions.DiagnosticSource/*.csproj",
             "Temporalio.Extensions.Gcp.CloudRun.OpenTelemetry/*.csproj",
             "Temporalio.Extensions.Hosting/*.csproj",
-            "Temporalio.Extensions.OpenTelemetry/*.csproj"
+            "Temporalio.Extensions.OpenTelemetry/*.csproj",
+            "Temporalio.Extensions.WorkflowStreams/*.csproj"
           ],
           "exclude": [
             "**/bin/**",

--- a/src/Temporalio.Extensions.Aws.Lambda.OpenTelemetry/packages.lock.json
+++ b/src/Temporalio.Extensions.Aws.Lambda.OpenTelemetry/packages.lock.json
@@ -55,14 +55,6 @@
           "StyleCop.Analyzers.Unstable": "1.2.0.435"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "vFuwSLj9QJBbNR0NeNO4YVASUbokxs+i/xbuu8B+Fs4FAZg5QaFa6eGrMaRqTzzNI5tAb97T7BhSxtLckFyiRA==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
-      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -282,6 +274,15 @@
         "dependencies": {
           "System.Memory": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "4.5.2"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "10.0.0",
+        "contentHash": "vFuwSLj9QJBbNR0NeNO4YVASUbokxs+i/xbuu8B+Fs4FAZg5QaFa6eGrMaRqTzzNI5tAb97T7BhSxtLckFyiRA==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "Microsoft.Bcl.HashCode": {

--- a/src/Temporalio.Extensions.DiagnosticSource/packages.lock.json
+++ b/src/Temporalio.Extensions.DiagnosticSource/packages.lock.json
@@ -36,14 +36,6 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.NETFramework.ReferenceAssemblies.net462": {
         "type": "Transitive",
         "resolved": "1.0.3",
@@ -131,6 +123,15 @@
           "System.Memory": "4.5.3"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Bcl.HashCode": {
         "type": "CentralTransitive",
         "requested": "[6.0.0, )",
@@ -203,14 +204,6 @@
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -294,6 +287,15 @@
         "dependencies": {
           "System.Memory": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "4.5.2"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.Bcl.HashCode": {

--- a/src/Temporalio.Extensions.Gcp.CloudRun.OpenTelemetry/packages.lock.json
+++ b/src/Temporalio.Extensions.Gcp.CloudRun.OpenTelemetry/packages.lock.json
@@ -46,14 +46,6 @@
           "StyleCop.Analyzers.Unstable": "1.2.0.435"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "vFuwSLj9QJBbNR0NeNO4YVASUbokxs+i/xbuu8B+Fs4FAZg5QaFa6eGrMaRqTzzNI5tAb97T7BhSxtLckFyiRA==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
-      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -260,6 +252,15 @@
         "dependencies": {
           "System.Memory": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "4.5.2"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "10.0.0",
+        "contentHash": "vFuwSLj9QJBbNR0NeNO4YVASUbokxs+i/xbuu8B+Fs4FAZg5QaFa6eGrMaRqTzzNI5tAb97T7BhSxtLckFyiRA==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "Microsoft.Bcl.HashCode": {

--- a/src/Temporalio.Extensions.Hosting/packages.lock.json
+++ b/src/Temporalio.Extensions.Hosting/packages.lock.json
@@ -58,14 +58,6 @@
           "StyleCop.Analyzers.Unstable": "1.2.0.435"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -393,6 +385,15 @@
           "System.Memory": "4.5.3"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Bcl.HashCode": {
         "type": "CentralTransitive",
         "requested": "[6.0.0, )",
@@ -533,14 +534,6 @@
         "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
         "dependencies": {
           "StyleCop.Analyzers.Unstable": "1.2.0.435"
-        }
-      },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.Extensions.Configuration": {
@@ -882,6 +875,15 @@
         "dependencies": {
           "System.Memory": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "4.5.2"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.Bcl.HashCode": {

--- a/src/Temporalio.Extensions.OpenTelemetry/packages.lock.json
+++ b/src/Temporalio.Extensions.OpenTelemetry/packages.lock.json
@@ -45,14 +45,6 @@
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.NETFramework.ReferenceAssemblies.net462": {
         "type": "Transitive",
         "resolved": "1.0.3",
@@ -140,6 +132,15 @@
           "System.Memory": "4.5.3"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Bcl.HashCode": {
         "type": "CentralTransitive",
         "requested": "[6.0.0, )",
@@ -223,14 +224,6 @@
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "1.1.0",
@@ -312,6 +305,15 @@
         "dependencies": {
           "System.Memory": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "4.5.2"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.Bcl.HashCode": {

--- a/src/Temporalio.Extensions.WorkflowStreams/.editorconfig
+++ b/src/Temporalio.Extensions.WorkflowStreams/.editorconfig
@@ -1,0 +1,13 @@
+[*.workflow.cs]
+
+# The protocol's established public name intentionally describes a stream.
+dotnet_diagnostic.CA1711.severity = none
+
+# Workflow continuations must remain on Temporal's deterministic task scheduler.
+dotnet_diagnostic.CA2007.severity = none
+
+# Workflow tasks intentionally use the current deterministic scheduler.
+dotnet_diagnostic.CA2008.severity = none
+
+# Workflow continuations intentionally use the current deterministic scheduler.
+dotnet_diagnostic.VSTHRD105.severity = none

--- a/src/Temporalio.Extensions.WorkflowStreams/FlushTimeoutException.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/FlushTimeoutException.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>
+    /// Exception thrown when an ambiguously delivered publish batch exceeds its retry duration.
+    /// </summary>
+    /// <remarks>
+    /// The batch is dropped locally. It is present in the workflow log if the signal reached the
+    /// server, and otherwise is lost. WARNING: Workflow Streams is experimental and may change.
+    /// </remarks>
+    public class FlushTimeoutException : Exception
+    {
+        /// <summary>Initializes a new instance of the <see cref="FlushTimeoutException"/> class.</summary>
+        /// <param name="message">Description of the expired ambiguous-delivery window.</param>
+        internal FlushTimeoutException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/PayloadWire.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/PayloadWire.cs
@@ -1,0 +1,29 @@
+using System;
+using Google.Protobuf;
+using Temporalio.Api.Common.V1;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>Preserves payload metadata in cross-language JSON envelopes.</summary>
+    internal static class PayloadWire
+    {
+        /// <summary>Encodes a payload as base64 protobuf bytes.</summary>
+        /// <param name="payload">Payload to encode.</param>
+        /// <returns>The padded base64 wire value.</returns>
+        internal static string Encode(Payload payload) =>
+            Convert.ToBase64String(payload.ToByteArray());
+
+        /// <summary>Decodes base64 protobuf bytes into a payload.</summary>
+        /// <param name="data">Padded base64 wire value.</param>
+        /// <returns>The decoded payload.</returns>
+        internal static Payload Decode(string data) =>
+            Payload.Parser.ParseFrom(Convert.FromBase64String(data));
+
+        /// <summary>Approximates an item's JSON response contribution consistently with peers.</summary>
+        /// <param name="encodedData">Base64 payload data.</param>
+        /// <param name="topic">Item topic.</param>
+        /// <returns>The approximate byte contribution.</returns>
+        internal static int EstimateSize(string encodedData, string topic) =>
+            encodedData.Length + topic.Length;
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/PollInput.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/PollInput.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>The cross-language update input for polling stream items.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed class PollInput
+    {
+        private IReadOnlyCollection<string> topics = Array.Empty<string>();
+
+        /// <summary>Gets or sets the topic filter. Empty means all topics.</summary>
+        [JsonPropertyName("topics")]
+        public IReadOnlyCollection<string> Topics
+        {
+            get => topics;
+            set => topics = value?.Select(topic => topic ?? string.Empty).ToArray() ??
+                Array.Empty<string>();
+        }
+
+        /// <summary>Gets or sets the global offset at which polling begins.</summary>
+        [JsonPropertyName("from_offset")]
+        public long FromOffset { get; set; }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/PollResult.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/PollResult.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>The cross-language result returned by the poll update.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed class PollResult
+    {
+        private IReadOnlyCollection<WireItem> items = Array.Empty<WireItem>();
+
+        /// <summary>Gets or sets the items returned by this page.</summary>
+        [JsonPropertyName("items")]
+        public IReadOnlyCollection<WireItem> Items
+        {
+            get => items;
+            set => items = value ?? Array.Empty<WireItem>();
+        }
+
+        /// <summary>Gets or sets the offset for the next poll.</summary>
+        [JsonPropertyName("next_offset")]
+        public long NextOffset { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether another page is immediately available.</summary>
+        [JsonPropertyName("more_ready")]
+        public bool MoreReady { get; set; }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/PublishEntry.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/PublishEntry.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>A single item in a publish signal batch.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed class PublishEntry
+    {
+        private string topic = string.Empty;
+        private string data = string.Empty;
+
+        /// <summary>Gets or sets the topic. A wire-level null is normalized to an empty string.</summary>
+        [JsonPropertyName("topic")]
+        public string Topic
+        {
+            get => topic;
+            set => topic = value ?? string.Empty;
+        }
+
+        /// <summary>Gets or sets the base64-encoded serialized Temporal payload.</summary>
+        [JsonPropertyName("data")]
+        public string Data
+        {
+            get => data;
+            set => data = value ?? string.Empty;
+        }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/PublishInput.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/PublishInput.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>The cross-language signal input for publishing a batch.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed class PublishInput
+    {
+        private IReadOnlyCollection<PublishEntry> items = Array.Empty<PublishEntry>();
+        private string publisherId = string.Empty;
+
+        /// <summary>Gets or sets the entries in the batch.</summary>
+        [JsonPropertyName("items")]
+        public IReadOnlyCollection<PublishEntry> Items
+        {
+            get => items;
+            set => items = value ?? Array.Empty<PublishEntry>();
+        }
+
+        /// <summary>Gets or sets the stable publisher identifier used for deduplication.</summary>
+        [JsonPropertyName("publisher_id")]
+        public string PublisherId
+        {
+            get => publisherId;
+            set => publisherId = value ?? string.Empty;
+        }
+
+        /// <summary>Gets or sets the publisher-local batch sequence.</summary>
+        [JsonPropertyName("sequence")]
+        public long Sequence { get; set; }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/README.md
+++ b/src/Temporalio.Extensions.WorkflowStreams/README.md
@@ -1,0 +1,173 @@
+# Temporal .NET Workflow Streams
+
+> [!WARNING]
+> Workflow Streams is experimental. Its API and wire protocol may change before it is declared
+> stable.
+
+`Temporalio.Extensions.WorkflowStreams` provides a durable, offset-addressed, multi-topic log
+hosted by a Temporal Workflow. External publishers append batches with a Signal, subscribers
+long-poll with an Update, and a Query reports the current global offset. The implementation includes
+publisher deduplication, topic filtering, truncation, response paging, and continue-as-new state
+handoff.
+
+This is intended for durable progress, event, and incremental-result streams. Each poll is a
+Temporal Update round trip, so it is not intended for ultra-low-latency media or token streaming.
+
+## Install
+
+```shell
+dotnet add package Temporalio.Extensions.WorkflowStreams
+```
+
+The package targets `netstandard2.0`.
+
+## Host a stream in a Workflow
+
+Create the stream while the Workflow instance is constructed. This ensures its dynamically
+registered Signal, Update, and Query handlers exist before the first handler can be dispatched,
+including on a continue-as-new successor run.
+
+```csharp
+using Temporalio.Extensions.WorkflowStreams;
+using Temporalio.Workflows;
+
+public record OrderInput(int CompletedSteps, WorkflowStreamState? StreamState = null);
+
+[Workflow]
+public class OrderWorkflow
+{
+    private readonly WorkflowStream stream;
+    private bool finished;
+
+    [WorkflowInit]
+    public OrderWorkflow(OrderInput input)
+    {
+        stream = new(input.StreamState);
+    }
+
+    [WorkflowRun]
+    public async Task RunAsync(OrderInput input)
+    {
+        stream.Topic("status").Publish(new { State = "started" });
+
+        await Workflow.WaitConditionAsync(() => finished || Workflow.ContinueAsNewSuggested);
+        if (Workflow.ContinueAsNewSuggested)
+        {
+            await stream.ContinueAsNewAsync(state =>
+                Workflow.CreateContinueAsNewException(
+                    (OrderWorkflow workflow) => workflow.RunAsync(
+                        input with { StreamState = state })));
+        }
+    }
+
+    [WorkflowSignal]
+    public Task FinishAsync()
+    {
+        finished = true;
+        return Task.CompletedTask;
+    }
+}
+```
+
+`ContinueAsNewAsync` first detaches admitted pollers, waits until all handlers finish, and only then
+captures `WorkflowStreamState` and invokes the callback. Thread that state through the next run's
+input as shown above. For custom continue-as-new options, perform the same sequence explicitly:
+call `DetachPollers()`, wait for `Workflow.AllHandlersFinished`, call `GetState()`, and create the
+continue-as-new exception yourself.
+
+The log is retained until the Workflow calls `Truncate(offset)`. Offsets are global across every
+topic. A subscriber that falls behind truncation automatically resumes at the beginning of the
+retained log.
+
+## Publish from a client or Activity
+
+Use one asynchronously disposed client per target Workflow ID. Values are converted to Temporal
+`Payload`s when `Publish` is called, then buffered until the two-second interval, the configured
+batch size, a force flush, an explicit flush, or asynchronous disposal.
+
+```csharp
+await using var streams = new WorkflowStreamClient(temporalClient, workflowId);
+var status = streams.Topic("status");
+
+status.Publish(new { State = "working" });
+status.Publish(new { State = "done" }, forceFlush: true);
+await streams.FlushAsync(cancellationToken);
+```
+
+`FlushAsync` is a barrier for everything buffered before the call. Failed or timed-out Signal RPCs
+retain the same publisher ID and sequence for retry, allowing the Workflow to deduplicate ambiguous
+delivery. If the retry window expires, `FlushTimeoutException` is thrown and that ambiguous batch is
+dropped locally: it may already be present in the Workflow log, or it may be lost. Later batches use
+a new sequence.
+
+Inside an Activity, `FromActivity` obtains the Temporal client, parent Workflow ID, and payload
+converter from the current Activity context:
+
+```csharp
+[Activity]
+public async Task ReportAsync(IEnumerable<Progress> values)
+{
+    await using var streams = WorkflowStreamClient.FromActivity();
+    foreach (var value in values)
+    {
+        streams.Topic("progress").Publish(value);
+    }
+}
+```
+
+Always use `await using` or call `DisposeAsync` so the final buffer is drained and publisher resources
+are released. Publication after disposal throws `ObjectDisposedException`.
+
+## Subscribe
+
+Subscriptions yield raw Temporal `Payload`s so consumers can choose a result type per topic. The
+returned `IAsyncEnumerable<WorkflowStreamItem>` is reusable: each enumeration starts with its own
+offset and polling state.
+
+```csharp
+var subscription = streams.SubscribeAsync(new()
+{
+    Topics = new[] { "status", "progress" },
+    FromOffset = 0,
+});
+
+await foreach (var item in subscription.WithCancellation(cancellationToken))
+{
+    var value = matchingPayloadConverter.ToValue(item.Payload, typeof(MyEvent));
+    Console.WriteLine($"{item.Offset} {item.Topic}: {value}");
+}
+```
+
+For one topic, use `streams.Topic("status").SubscribeAsync(fromOffset)`. An empty topic collection
+subscribes to every topic; the empty string is the cross-SDK no-topic value. Consumer cancellation
+cancels the in-flight RPC and throws `OperationCanceledException`. Disposing the owning client ends
+its active enumerations cleanly. Enumerations also end cleanly when the Workflow reaches a terminal
+state and automatically follow continue-as-new chains.
+
+## Data conversion and interoperability
+
+The fixed protocol handlers are:
+
+- Signal `__temporal_workflow_stream_publish`
+- Update `__temporal_workflow_stream_poll`
+- Query `__temporal_workflow_stream_offset`
+
+The public wire DTOs use the protocol's exact snake-case JSON names. Each item's `data` is standard
+padded base64 containing a serialized `temporal.api.common.v1.Payload` protobuf. This preserves its
+encoding metadata and makes .NET publishers, Workflow hosts, and subscribers interoperable with the
+official Workflow Streams implementations in other Temporal SDKs.
+
+Only payload conversion is applied to an individual item. A client's payload codec chain, if any,
+is applied once to the Signal or Update envelope rather than once per item, avoiding double encoding.
+The envelope itself must use JSON-compatible conversion for cross-language interoperability.
+
+## Operational limits
+
+- Every waiting subscription uses an admitted Workflow Update. Account for concurrent and total
+  Update limits when choosing subscriber counts and continue-as-new frequency.
+- Poll results are paged at an estimated one megabyte and immediately repolled while another page is
+  ready. An individual item must fit in one page.
+- The Workflow log has no automatic retention policy. Truncate items once all required consumers have
+  advanced, and carry only the retained state through continue-as-new.
+- Publishing uses Signals, so malformed or oversized externally supplied wire entries cannot return
+  errors to their sender. The Workflow skips them and emits a replay-safe warning.

--- a/src/Temporalio.Extensions.WorkflowStreams/StreamPublisher.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/StreamPublisher.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Temporalio.Api.Common.V1;
+using Temporalio.Converters;
+using Temporalio.Exceptions;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>Owns serialized client publication state and its single timer.</summary>
+    internal sealed class StreamPublisher : IAsyncDisposable
+    {
+        private readonly object stateLock = new();
+        private readonly Func<PublishInput, CancellationToken, Task> signalAsync;
+        private readonly IPayloadConverter payloadConverter;
+        private readonly TimeSpan batchInterval;
+        private readonly TimeSpan maxRetryDuration;
+        private readonly int maxBatchSize;
+        private readonly string publisherId = Guid.NewGuid().ToString("N").Substring(0, 16);
+        private readonly SemaphoreSlim flushGate = new(1, 1);
+        private readonly SemaphoreSlim wakeSignal = new(0, 1);
+        private readonly CancellationTokenSource stopSource = new();
+        private List<PublishEntry> buffer = new();
+        private IReadOnlyCollection<PublishEntry>? pending;
+        private long sequence;
+        private long pendingSequence;
+        private long pendingStartedAt;
+        private Timer? timer;
+        private Task? backgroundTask;
+        private Task? disposeTask;
+        private bool disposing;
+        private FlushTimeoutException? deferredError;
+
+        /// <summary>Initializes a new instance of the <see cref="StreamPublisher"/> class.</summary>
+        /// <param name="signalAsync">Injected workflow signal operation.</param>
+        /// <param name="payloadConverter">Converter applied synchronously during publication.</param>
+        /// <param name="options">Snapshotted client options.</param>
+        internal StreamPublisher(
+            Func<PublishInput, CancellationToken, Task> signalAsync,
+            IPayloadConverter payloadConverter,
+            WorkflowStreamClientOptions options)
+        {
+            this.signalAsync = signalAsync;
+            this.payloadConverter = payloadConverter;
+            batchInterval = options.BatchInterval;
+            maxBatchSize = options.MaxBatchSize;
+            maxRetryDuration = options.MaxRetryDuration;
+        }
+
+        /// <summary>Gets a value indicating whether this publisher owns a live timer.</summary>
+        internal bool HasLiveTimer
+        {
+            get
+            {
+                lock (stateLock)
+                {
+                    return timer != null;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public ValueTask DisposeAsync() => new(DisposeTaskAsync());
+
+        /// <summary>Converts before enqueueing so one bad value cannot poison later batches.</summary>
+        /// <param name="topic">Normalized topic name.</param>
+        /// <param name="value">Value or raw payload to publish.</param>
+        /// <param name="forceFlush">Whether to wake the flusher immediately.</param>
+        internal void Publish(string topic, object? value, bool forceFlush)
+        {
+            var wake = false;
+            lock (stateLock)
+            {
+                if (disposing)
+                {
+                    throw new ObjectDisposedException(nameof(WorkflowStreamClient));
+                }
+                var payload = value as Payload ?? payloadConverter.ToPayload(value);
+                var encoded = PayloadWire.Encode(payload);
+                if (PayloadWire.EstimateSize(encoded, topic) >
+                    WorkflowStreamConstants.MaxPollResponseBytes)
+                {
+                    throw new ArgumentException(
+                        "The Workflow Stream item is too large to fit in a poll response",
+                        nameof(value));
+                }
+                buffer.Add(new() { Topic = topic, Data = encoded });
+                EnsureStartedLocked();
+                wake = forceFlush || (maxBatchSize > 0 && buffer.Count >= maxBatchSize);
+            }
+            if (wake)
+            {
+                Wake();
+            }
+        }
+
+        /// <summary>Implements a sequence-based barrier over all items present at entry.</summary>
+        /// <param name="cancellationToken">Cancellation token for signal attempts.</param>
+        /// <returns>A task that completes after the barrier is acknowledged.</returns>
+        internal async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            ThrowDeferredError();
+            long targetSequence;
+            lock (stateLock)
+            {
+                if (pending == null && buffer.Count == 0)
+                {
+                    return;
+                }
+                var baseSequence = pending == null ? sequence : pendingSequence;
+                targetSequence = buffer.Count == 0 ? baseSequence : baseSequence + 1;
+            }
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                lock (stateLock)
+                {
+                    if (sequence >= targetSequence)
+                    {
+                        break;
+                    }
+                }
+                await FlushOnceAsync(cancellationToken).ConfigureAwait(false);
+            }
+            ThrowDeferredError();
+        }
+
+        /// <summary>Returns the task shared by all terminal operations.</summary>
+        /// <returns>The shared terminal task.</returns>
+        internal Task DisposeTaskAsync()
+        {
+            lock (stateLock)
+            {
+                if (disposeTask != null)
+                {
+                    return disposeTask;
+                }
+                disposing = true;
+                timer?.Dispose();
+                timer = null;
+                stopSource.Cancel();
+                Wake();
+                disposeTask = DisposeCoreAsync();
+                return disposeTask;
+            }
+        }
+
+        private void EnsureStartedLocked()
+        {
+            if (backgroundTask != null)
+            {
+                return;
+            }
+            timer = new Timer(
+                state => ((StreamPublisher)state!).Wake(),
+                this,
+                batchInterval,
+                batchInterval);
+            backgroundTask = Task.Run(RunBackgroundAsync);
+        }
+
+        private void Wake()
+        {
+            try
+            {
+                wakeSignal.Release();
+            }
+            catch (SemaphoreFullException)
+            {
+                // One pending wake is enough even when timer and publication callbacks race.
+            }
+            catch (ObjectDisposedException)
+            {
+                // A racing timer callback has no work once terminal disposal has completed.
+            }
+        }
+
+        private async Task RunBackgroundAsync()
+        {
+            while (true)
+            {
+                try
+                {
+                    await wakeSignal.WaitAsync(stopSource.Token).ConfigureAwait(false);
+                    await FlushOnceAsync(stopSource.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (stopSource.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (FlushTimeoutException err)
+                {
+                    lock (stateLock)
+                    {
+                        deferredError ??= err;
+                    }
+                }
+                catch (TemporalException)
+                {
+                    // The pending batch stays intact and the single timer retries it next interval.
+                }
+                catch (InvalidOperationException)
+                {
+                    // The pending batch stays intact and the single timer retries it next interval.
+                }
+            }
+        }
+
+        private async Task FlushOnceAsync(CancellationToken cancellationToken)
+        {
+            await flushGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                IReadOnlyCollection<PublishEntry> batch;
+                long batchSequence;
+                lock (stateLock)
+                {
+                    if (pending != null)
+                    {
+                        var elapsed = TimeSpan.FromSeconds(
+                            (Stopwatch.GetTimestamp() - pendingStartedAt) /
+                            (double)Stopwatch.Frequency);
+                        if (elapsed > maxRetryDuration)
+                        {
+                            sequence = pendingSequence;
+                            pending = null;
+                            pendingSequence = 0;
+                            pendingStartedAt = 0;
+                            throw new FlushTimeoutException(
+                                $"Workflow Stream flush retry exceeded {maxRetryDuration}; " +
+                                "the ambiguous batch was dropped");
+                        }
+                        batch = pending;
+                        batchSequence = pendingSequence;
+                    }
+                    else if (buffer.Count > 0)
+                    {
+                        batch = buffer;
+                        buffer = new();
+                        batchSequence = sequence + 1;
+                        pending = batch;
+                        pendingSequence = batchSequence;
+                        pendingStartedAt = Stopwatch.GetTimestamp();
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+
+                await signalAsync(
+                    new()
+                    {
+                        Items = batch,
+                        PublisherId = publisherId,
+                        Sequence = batchSequence,
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                lock (stateLock)
+                {
+                    sequence = batchSequence;
+                    pending = null;
+                    pendingSequence = 0;
+                    pendingStartedAt = 0;
+                }
+            }
+            finally
+            {
+                flushGate.Release();
+            }
+        }
+
+        private async Task DisposeCoreAsync()
+        {
+            await Task.Yield();
+            Exception? firstError = null;
+            try
+            {
+                var task = backgroundTask;
+                if (task != null)
+                {
+                    try
+                    {
+                        await task.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (stopSource.IsCancellationRequested)
+                    {
+                    }
+                }
+
+                lock (stateLock)
+                {
+                    firstError = deferredError;
+                    deferredError = null;
+                }
+                while (HasWork())
+                {
+                    try
+                    {
+                        await FlushOnceAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch (FlushTimeoutException err)
+                    {
+                        firstError ??= err;
+                    }
+                    catch (TemporalException err)
+                    {
+                        firstError ??= err;
+                        break;
+                    }
+                    catch (InvalidOperationException err)
+                    {
+                        firstError ??= err;
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                stopSource.Dispose();
+                flushGate.Dispose();
+                wakeSignal.Dispose();
+            }
+
+            if (firstError != null)
+            {
+                throw firstError;
+            }
+        }
+
+        private bool HasWork()
+        {
+            lock (stateLock)
+            {
+                return pending != null || buffer.Count > 0;
+            }
+        }
+
+        private void ThrowDeferredError()
+        {
+            FlushTimeoutException? error;
+            lock (stateLock)
+            {
+                error = deferredError;
+                deferredError = null;
+            }
+            if (error != null)
+            {
+                throw error;
+            }
+        }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/Temporalio.Extensions.WorkflowStreams.csproj
+++ b/src/Temporalio.Extensions.WorkflowStreams/Temporalio.Extensions.WorkflowStreams.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Experimental Workflow Streams extension for the Temporal .NET SDK</Description>
+    <IncludeSymbols>true</IncludeSymbols>
+    <LangVersion>9.0</LangVersion>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <!--
+      This package has no published baseline yet, so there is nothing for package
+      validation to compare against. Remove this override after the first release.
+    -->
+    <PackageValidationBaselineVersion></PackageValidationBaselineVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Temporalio\Temporalio.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Temporalio.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/src/Temporalio.Extensions.WorkflowStreams/TopicHandle.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/TopicHandle.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>A client-side handle bound to one topic.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed class TopicHandle
+    {
+        private readonly WorkflowStreamClient client;
+
+        /// <summary>Initializes a new instance of the <see cref="TopicHandle"/> class.</summary>
+        /// <param name="client">Client whose publisher and lifecycle the handle shares.</param>
+        /// <param name="name">Normalized topic name.</param>
+        internal TopicHandle(WorkflowStreamClient client, string name)
+        {
+            this.client = client;
+            Name = name ?? string.Empty;
+        }
+
+        /// <summary>Gets the topic name.</summary>
+        public string Name { get; }
+
+        /// <summary>Converts and buffers a value for publication on this topic.</summary>
+        /// <param name="value">The value or pre-built Temporal payload to publish.</param>
+        /// <param name="forceFlush">Whether to wake the asynchronous flusher immediately.</param>
+        public void Publish(object? value, bool forceFlush = false) =>
+            client.Publish(Name, value, forceFlush);
+
+        /// <summary>Creates a reusable subscription to this topic.</summary>
+        /// <param name="fromOffset">The global offset at which to begin.</param>
+        /// <returns>A reusable asynchronous stream.</returns>
+        public IAsyncEnumerable<WorkflowStreamItem> SubscribeAsync(long fromOffset = 0) =>
+            client.SubscribeAsync(new()
+            {
+                Topics = new[] { Name },
+                FromOffset = fromOffset,
+            });
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WireItem.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WireItem.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>A stream item in the cross-language JSON envelope.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed class WireItem
+    {
+        private string topic = string.Empty;
+        private string data = string.Empty;
+
+        /// <summary>Gets or sets the topic. A wire-level null is normalized to an empty string.</summary>
+        [JsonPropertyName("topic")]
+        public string Topic
+        {
+            get => topic;
+            set => topic = value ?? string.Empty;
+        }
+
+        /// <summary>Gets or sets the base64-encoded serialized Temporal payload.</summary>
+        [JsonPropertyName("data")]
+        public string Data
+        {
+            get => data;
+            set => data = value ?? string.Empty;
+        }
+
+        /// <summary>Gets or sets the item's global offset.</summary>
+        [JsonPropertyName("offset")]
+        public long Offset { get; set; }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowStream.workflow.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowStream.workflow.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+using Temporalio.Api.Common.V1;
+using Temporalio.Exceptions;
+using Temporalio.Workflows;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>
+    /// A durable, offset-addressed, multi-topic log hosted inside a Temporal workflow.
+    /// </summary>
+    /// <remarks>
+    /// Construct one instance during workflow initialization. WARNING: Workflow Streams is
+    /// experimental and may change.
+    /// </remarks>
+    public sealed class WorkflowStream
+    {
+        private readonly List<LogEntry> log = new();
+        private readonly SortedDictionary<string, long> publisherSequences = new();
+        private readonly SortedDictionary<string, double> publisherLastSeen = new();
+        private readonly Dictionary<string, WorkflowTopicHandle> topicHandles = new();
+        private readonly WorkflowStreamOptions options;
+        private long baseOffset;
+        private bool draining;
+
+        /// <summary>Initializes a new instance of the <see cref="WorkflowStream"/> class.</summary>
+        public WorkflowStream()
+            : this(null, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="WorkflowStream"/> class.</summary>
+        /// <param name="state">State captured before continue-as-new, or null for a new stream.</param>
+        public WorkflowStream(WorkflowStreamState? state)
+            : this(state, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="WorkflowStream"/> class.</summary>
+        /// <param name="state">State captured before continue-as-new, or null for a new stream.</param>
+        /// <param name="options">Stream options, snapshotted by this constructor.</param>
+        public WorkflowStream(WorkflowStreamState? state, WorkflowStreamOptions? options)
+        {
+            this.options = (WorkflowStreamOptions)(options ?? new WorkflowStreamOptions()).Clone();
+            if (this.options.PublisherTtl <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options), "PublisherTtl must be greater than zero");
+            }
+            Restore(state);
+            Workflow.Signals[WorkflowStreamConstants.PublishSignalName] =
+                WorkflowSignalDefinition.CreateWithoutAttribute(
+                    WorkflowStreamConstants.PublishSignalName,
+                    (Func<PublishInput, Task>)HandlePublishAsync,
+                    HandlerUnfinishedPolicy.Abandon);
+            Workflow.Updates[WorkflowStreamConstants.PollUpdateName] =
+                WorkflowUpdateDefinition.CreateWithoutAttribute(
+                    WorkflowStreamConstants.PollUpdateName,
+                    (Func<PollInput, Task<PollResult>>)HandlePollAsync,
+                    (Action<PollInput>)ValidatePoll,
+                    HandlerUnfinishedPolicy.Abandon);
+            Workflow.Queries[WorkflowStreamConstants.OffsetQueryName] =
+                WorkflowQueryDefinition.CreateWithoutAttribute(
+                    WorkflowStreamConstants.OffsetQueryName,
+                    (Func<long>)(() => baseOffset + log.Count));
+        }
+
+        /// <summary>Gets a workflow-side publisher for a topic.</summary>
+        /// <param name="name">Topic name. Null is represented by the empty topic.</param>
+        /// <returns>A memoized topic handle.</returns>
+        public WorkflowTopicHandle Topic(string? name)
+        {
+            name ??= string.Empty;
+            if (!topicHandles.TryGetValue(name, out var handle))
+            {
+                handle = new(this, name);
+                topicHandles.Add(name, handle);
+            }
+            return handle;
+        }
+
+        /// <summary>Unblocks admitted pollers and rejects new polls during continue-as-new.</summary>
+        public void DetachPollers() => draining = true;
+
+        /// <summary>Captures retained state using the configured publisher time-to-live.</summary>
+        /// <returns>A cross-language state snapshot.</returns>
+        public WorkflowStreamState GetState() => GetState(options.PublisherTtl);
+
+        /// <summary>Captures retained state with a specific publisher time-to-live.</summary>
+        /// <param name="publisherTtl">Age after which publisher deduplication state is omitted.</param>
+        /// <returns>A cross-language state snapshot.</returns>
+        public WorkflowStreamState GetState(TimeSpan publisherTtl)
+        {
+            if (publisherTtl <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(publisherTtl), "Publisher TTL must be greater than zero");
+            }
+
+            var now = new DateTimeOffset(
+                DateTime.SpecifyKind(Workflow.UtcNow, DateTimeKind.Utc)).ToUnixTimeMilliseconds() /
+                1000d;
+            var sequences = new Dictionary<string, long>();
+            var lastSeen = new Dictionary<string, double>();
+            foreach (var pair in publisherSequences)
+            {
+                if (publisherLastSeen.TryGetValue(pair.Key, out var seen) &&
+                    now - seen < publisherTtl.TotalSeconds)
+                {
+                    sequences.Add(pair.Key, pair.Value);
+                    lastSeen.Add(pair.Key, seen);
+                }
+            }
+
+            return new()
+            {
+                BaseOffset = baseOffset,
+                Log = log.Select(entry => new WireItem
+                {
+                    Topic = entry.Topic,
+                    Data = PayloadWire.Encode(entry.Payload),
+                    Offset = 0,
+                }).ToArray(),
+                PublisherSequences = sequences,
+                PublisherLastSeen = lastSeen,
+            };
+        }
+
+        /// <summary>
+        /// Detaches pollers, waits for handlers, captures state, and continues as new.
+        /// </summary>
+        /// <param name="createException">
+        /// Callback that creates the SDK continue-as-new exception from the captured state.
+        /// </param>
+        /// <returns>A task that does not complete normally.</returns>
+        public async Task ContinueAsNewAsync(
+            Func<WorkflowStreamState, ContinueAsNewException> createException)
+        {
+            DetachPollers();
+            await Workflow.WaitConditionAsync(() => Workflow.AllHandlersFinished);
+            throw createException(GetState());
+        }
+
+        /// <summary>Discards entries before a global offset.</summary>
+        /// <param name="upToOffset">The first offset to retain.</param>
+        public void Truncate(long upToOffset)
+        {
+            var removeCount = upToOffset - baseOffset;
+            if (removeCount <= 0)
+            {
+                return;
+            }
+            if (removeCount > log.Count)
+            {
+                throw new ApplicationFailureException(
+                    $"Cannot truncate to offset {upToOffset}; the stream ends at " +
+                    $"{baseOffset + log.Count}",
+                    WorkflowStreamConstants.TruncateOutOfRangeErrorType,
+                    nonRetryable: true);
+            }
+            log.RemoveRange(0, (int)removeCount);
+            baseOffset = upToOffset;
+        }
+
+        /// <summary>Keeps workflow-side publications on the same converter and log path.</summary>
+        /// <param name="topic">Normalized topic name.</param>
+        /// <param name="value">Value or raw payload to append.</param>
+        internal void Publish(string topic, object? value)
+        {
+            var payload = value as Payload ?? Workflow.PayloadConverter.ToPayload(value);
+            var encoded = PayloadWire.Encode(payload);
+            if (PayloadWire.EstimateSize(encoded, topic) >
+                WorkflowStreamConstants.MaxPollResponseBytes)
+            {
+                throw new ApplicationFailureException(
+                    "Workflow Stream item is too large to fit in a poll response",
+                    WorkflowStreamConstants.OversizedItemErrorType,
+                    nonRetryable: true);
+            }
+            log.Add(new(topic, payload));
+        }
+
+        private void Restore(WorkflowStreamState? state)
+        {
+            static ApplicationFailureException InvalidState(string message, Exception? inner) =>
+                new(
+                    message,
+                    inner,
+                    WorkflowStreamConstants.InvalidStateErrorType,
+                    nonRetryable: true);
+
+            if (state == null)
+            {
+                return;
+            }
+            if (state.BaseOffset < 0)
+            {
+                throw InvalidState("The base offset cannot be negative", null);
+            }
+            baseOffset = state.BaseOffset;
+            foreach (var item in state.Log ?? Array.Empty<WireItem>())
+            {
+                try
+                {
+                    var topic = item?.Topic ?? string.Empty;
+                    var payload = PayloadWire.Decode(item?.Data ?? string.Empty);
+                    if (PayloadWire.EstimateSize(PayloadWire.Encode(payload), topic) >
+                        WorkflowStreamConstants.MaxPollResponseBytes)
+                    {
+                        throw InvalidState("A retained item is too large", null);
+                    }
+                    log.Add(new(topic, payload));
+                }
+                catch (ApplicationFailureException)
+                {
+                    throw;
+                }
+                catch (Exception err) when (
+                    err is FormatException || err is InvalidProtocolBufferException)
+                {
+                    throw InvalidState("A retained item is malformed", err);
+                }
+            }
+            foreach (var pair in state.PublisherSequences ?? new Dictionary<string, long>())
+            {
+                publisherSequences[pair.Key] = pair.Value;
+            }
+            foreach (var pair in state.PublisherLastSeen ?? new Dictionary<string, double>())
+            {
+                publisherLastSeen[pair.Key] = pair.Value;
+            }
+        }
+
+        private void ValidatePoll(PollInput input)
+        {
+            if (draining)
+            {
+                throw new ApplicationFailureException(
+                    "Workflow Stream is draining for continue-as-new",
+                    WorkflowStreamConstants.StreamDrainingErrorType,
+                    nonRetryable: true);
+            }
+        }
+
+        private Task HandlePublishAsync(PublishInput input)
+        {
+            if (input == null)
+            {
+                Workflow.Logger.LogWarning("Ignoring a malformed Workflow Stream publish signal");
+                return Task.CompletedTask;
+            }
+            if (input.PublisherId.Length > 0)
+            {
+                if (publisherSequences.TryGetValue(input.PublisherId, out var sequence) &&
+                    input.Sequence <= sequence)
+                {
+                    return Task.CompletedTask;
+                }
+                publisherSequences[input.PublisherId] = input.Sequence;
+                publisherLastSeen[input.PublisherId] = new DateTimeOffset(
+                    DateTime.SpecifyKind(
+                        Workflow.UtcNow,
+                        DateTimeKind.Utc)).ToUnixTimeMilliseconds() / 1000d;
+            }
+
+            foreach (var item in input.Items ?? Array.Empty<PublishEntry>())
+            {
+                var topic = item?.Topic ?? string.Empty;
+                var data = item?.Data ?? string.Empty;
+                if (PayloadWire.EstimateSize(data, topic) >
+                    WorkflowStreamConstants.MaxPollResponseBytes)
+                {
+                    Workflow.Logger.LogWarning(
+                        "Ignoring an oversized Workflow Stream signal item on topic {Topic}",
+                        topic);
+                    continue;
+                }
+                try
+                {
+                    log.Add(new(topic, PayloadWire.Decode(data)));
+                }
+                catch (Exception err) when (
+                    err is FormatException || err is InvalidProtocolBufferException)
+                {
+                    Workflow.Logger.LogWarning(
+                        err,
+                        "Ignoring a malformed Workflow Stream signal item on topic {Topic}",
+                        topic);
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        private async Task<PollResult> HandlePollAsync(PollInput input)
+        {
+            input ??= new PollInput();
+            await Workflow.WaitConditionAsync(() =>
+                draining ||
+                (input.FromOffset != 0 && input.FromOffset < baseOffset) ||
+                log.Count > Math.Max(input.FromOffset - baseOffset, 0));
+
+            if (input.FromOffset != 0 && input.FromOffset < baseOffset)
+            {
+                throw new ApplicationFailureException(
+                    $"Requested offset {input.FromOffset} has been truncated; current base " +
+                    $"offset is {baseOffset}",
+                    WorkflowStreamConstants.TruncatedOffsetErrorType,
+                    nonRetryable: true);
+            }
+
+            var requestedIndex = Math.Max(input.FromOffset - baseOffset, 0);
+            var startIndex = requestedIndex > log.Count ? log.Count : (int)requestedIndex;
+            HashSet<string>? topicFilter = null;
+            if (input.Topics.Count > 0)
+            {
+                topicFilter = new(input.Topics.Select(topic => topic ?? string.Empty));
+            }
+
+            var items = new List<WireItem>();
+            var size = 0;
+            var moreReady = false;
+            var nextOffset = baseOffset + log.Count;
+            for (var index = startIndex; index < log.Count; index++)
+            {
+                var entry = log[index];
+                if (topicFilter != null && !topicFilter.Contains(entry.Topic))
+                {
+                    continue;
+                }
+                var encoded = PayloadWire.Encode(entry.Payload);
+                var itemSize = PayloadWire.EstimateSize(encoded, entry.Topic);
+                var offset = baseOffset + index;
+                if (size + itemSize > WorkflowStreamConstants.MaxPollResponseBytes &&
+                    items.Count > 0)
+                {
+                    nextOffset = offset;
+                    moreReady = true;
+                    break;
+                }
+                size += itemSize;
+                items.Add(new()
+                {
+                    Topic = entry.Topic,
+                    Data = encoded,
+                    Offset = offset,
+                });
+            }
+
+            return new()
+            {
+                Items = items,
+                NextOffset = nextOffset,
+                MoreReady = moreReady,
+            };
+        }
+
+        private sealed class LogEntry
+        {
+            internal LogEntry(string topic, Payload payload)
+            {
+                Topic = topic;
+                Payload = payload;
+            }
+
+            internal string Topic { get; }
+
+            internal Payload Payload { get; }
+        }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamClient.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamClient.cs
@@ -1,0 +1,505 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Temporalio.Activities;
+using Temporalio.Api.Enums.V1;
+using Temporalio.Client;
+using Temporalio.Converters;
+using Temporalio.Exceptions;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>External publisher and subscriber for a workflow-hosted stream.</summary>
+    /// <remarks>
+    /// Dispose asynchronously to drain buffered publications and stop subscriptions owned by this
+    /// client. WARNING: Workflow Streams is experimental and may change.
+    /// </remarks>
+    public sealed class WorkflowStreamClient : IAsyncDisposable
+    {
+        private readonly object stateLock = new();
+        private readonly ITemporalClient client;
+        private readonly string workflowId;
+        private readonly WorkflowHandle workflowHandle;
+        private readonly WorkflowStreamClientOptions options;
+        private readonly StreamPublisher publisher;
+        private readonly Dictionary<string, TopicHandle> topicHandles = new();
+        private readonly CancellationTokenSource disposeSource = new();
+        private readonly CancellationToken disposeToken;
+        private Task? disposeTask;
+
+        /// <summary>Initializes a new instance of the <see cref="WorkflowStreamClient"/> class.</summary>
+        /// <param name="client">Temporal client used for signals, updates, and queries.</param>
+        /// <param name="workflowId">Target workflow ID.</param>
+        /// <param name="options">Client options, snapshotted by this constructor.</param>
+        public WorkflowStreamClient(
+            ITemporalClient client,
+            string workflowId,
+            WorkflowStreamClientOptions? options = null)
+            : this(client, workflowId, options, null)
+        {
+        }
+
+        private WorkflowStreamClient(
+            ITemporalClient client,
+            string workflowId,
+            WorkflowStreamClientOptions? options,
+            IPayloadConverter? payloadConverter)
+        {
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+            this.workflowId = workflowId ?? throw new ArgumentNullException(nameof(workflowId));
+            this.options = (WorkflowStreamClientOptions)(options ??
+                new WorkflowStreamClientOptions()).Clone();
+            if (this.options.BatchInterval <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options), "BatchInterval must be greater than zero");
+            }
+            if (this.options.MaxBatchSize < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options), "MaxBatchSize cannot be negative");
+            }
+            if (this.options.MaxRetryDuration <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options), "MaxRetryDuration must be greater than zero");
+            }
+            if (this.options.RpcTimeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options), "The RPC timeout must be greater than zero");
+            }
+            workflowHandle = client.GetWorkflowHandle(workflowId);
+            disposeToken = disposeSource.Token;
+            payloadConverter ??= client.Options.DataConverter.WithSerializationContext(
+                new ISerializationContext.Workflow(client.Options.Namespace, workflowId)).PayloadConverter;
+            publisher = new(SignalAsync, payloadConverter, this.options);
+        }
+
+        /// <summary>Gets a value indicating whether the publisher owns a live timer.</summary>
+        internal bool HasLivePublisherTimer => publisher.HasLiveTimer;
+
+        /// <summary>Creates a stream client targeting the current activity's parent workflow.</summary>
+        /// <param name="options">Client options.</param>
+        /// <returns>A client for the activity's parent workflow.</returns>
+        public static WorkflowStreamClient FromActivity(WorkflowStreamClientOptions? options = null)
+        {
+            var context = ActivityExecutionContext.Current;
+            var id = context.Info.WorkflowId ?? throw new InvalidOperationException(
+                "WorkflowStreamClient.FromActivity requires a workflow activity");
+            return new(context.TemporalClient, id, options, context.PayloadConverter);
+        }
+
+        /// <summary>Gets a memoized handle for a topic.</summary>
+        /// <param name="name">Topic name. Null is represented by the empty topic.</param>
+        /// <returns>A topic handle.</returns>
+        public TopicHandle Topic(string? name)
+        {
+            name ??= string.Empty;
+            lock (stateLock)
+            {
+                if (!topicHandles.TryGetValue(name, out var handle))
+                {
+                    handle = new(this, name);
+                    topicHandles.Add(name, handle);
+                }
+                return handle;
+            }
+        }
+
+        /// <summary>Creates a reusable subscription with independent state per enumeration.</summary>
+        /// <param name="options">Subscription options, snapshotted by this call.</param>
+        /// <returns>A reusable asynchronous stream of raw Temporal payloads.</returns>
+        public IAsyncEnumerable<WorkflowStreamItem> SubscribeAsync(
+            WorkflowStreamSubscribeOptions? options = null)
+        {
+            var snapshot = (WorkflowStreamSubscribeOptions)(options ??
+                new WorkflowStreamSubscribeOptions()).Clone();
+            if (snapshot.FromOffset < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options), "FromOffset cannot be negative");
+            }
+            if (snapshot.PollCooldown < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options), "PollCooldown cannot be negative");
+            }
+            snapshot.Topics = snapshot.Topics.Select(topic => topic ?? string.Empty).ToArray();
+            return SubscribeCoreAsync(snapshot);
+        }
+
+        /// <summary>Flushes publications buffered before this call and waits for acknowledgement.</summary>
+        /// <param name="cancellationToken">Cancellation token for the flush operation.</param>
+        /// <returns>A task that completes when the flush barrier is acknowledged.</returns>
+        public Task FlushAsync(CancellationToken cancellationToken = default) =>
+            publisher.FlushAsync(cancellationToken);
+
+        /// <summary>Queries the current global offset.</summary>
+        /// <param name="cancellationToken">Cancellation token for the query.</param>
+        /// <returns>The offset immediately after the last retained item.</returns>
+        public async Task<long> GetOffsetAsync(CancellationToken cancellationToken = default)
+        {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                disposeToken, cancellationToken);
+            return await workflowHandle.QueryAsync<long>(
+                WorkflowStreamConstants.OffsetQueryName,
+                Array.Empty<object?>(),
+                new()
+                {
+                    Rpc = new() { CancellationToken = linked.Token },
+                }).ConfigureAwait(false);
+        }
+
+        /// <summary>Stops owned subscriptions and drains buffered publications.</summary>
+        /// <returns>A value task shared by concurrent disposal calls.</returns>
+        public ValueTask DisposeAsync()
+        {
+            lock (stateLock)
+            {
+                if (disposeTask == null)
+                {
+                    disposeSource.Cancel();
+                    disposeTask = DisposeCoreAsync(publisher.DisposeAsync().AsTask());
+                }
+                return new(disposeTask);
+            }
+        }
+
+        /// <summary>Keeps topic handles on the publisher's single conversion and batching path.</summary>
+        /// <param name="topic">Normalized topic name.</param>
+        /// <param name="value">Value or raw payload to publish.</param>
+        /// <param name="forceFlush">Whether to flush the pending batch immediately.</param>
+        internal void Publish(string topic, object? value, bool forceFlush) =>
+            publisher.Publish(topic, value, forceFlush);
+
+        private Task SignalAsync(PublishInput input, CancellationToken cancellationToken) =>
+            workflowHandle.SignalAsync(
+                WorkflowStreamConstants.PublishSignalName,
+                new object?[] { input },
+                new()
+                {
+                    Rpc = new() { CancellationToken = cancellationToken },
+                });
+
+        private async Task DisposeCoreAsync(Task publisherDisposeTask)
+        {
+            await Task.Yield();
+            try
+            {
+#pragma warning disable VSTHRD003 // This is the publisher's shared terminal task.
+                await publisherDisposeTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+            }
+            finally
+            {
+                disposeSource.Dispose();
+            }
+        }
+
+        private async IAsyncEnumerable<WorkflowStreamItem> SubscribeCoreAsync(
+            WorkflowStreamSubscribeOptions options,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            static ApplicationFailureException? FindApplicationFailure(Exception error)
+            {
+                for (Exception? current = error; current != null; current = current.InnerException)
+                {
+                    if (current is ApplicationFailureException failure)
+                    {
+                        return failure;
+                    }
+                }
+                return null;
+            }
+
+            static bool IsTerminal(WorkflowExecutionStatus status) =>
+                status == WorkflowExecutionStatus.Completed ||
+                status == WorkflowExecutionStatus.Failed ||
+                status == WorkflowExecutionStatus.Canceled ||
+                status == WorkflowExecutionStatus.Terminated ||
+                status == WorkflowExecutionStatus.TimedOut;
+
+            using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
+                disposeToken, cancellationToken);
+            var rpcToken = linkedSource.Token;
+            var offset = options.FromOffset;
+
+            while (true)
+            {
+                if (disposeToken.IsCancellationRequested)
+                {
+                    yield break;
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+
+                PollAttempt? attempt = null;
+                Exception? pollError = null;
+                var clientDisposed = false;
+                try
+                {
+                    attempt = await PollOnceAsync(
+                        options.Topics, offset, cancellationToken, rpcToken).ConfigureAwait(false);
+                    pollError = attempt.Error;
+                }
+                catch (OperationCanceledException)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (disposeToken.IsCancellationRequested)
+                    {
+                        clientDisposed = true;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                if (clientDisposed)
+                {
+                    yield break;
+                }
+                if (pollError != null)
+                {
+                    var failure = FindApplicationFailure(pollError);
+                    if (failure?.ErrorType == WorkflowStreamConstants.TruncatedOffsetErrorType)
+                    {
+                        offset = 0;
+                        continue;
+                    }
+                    if (failure?.ErrorType == WorkflowStreamConstants.StreamDrainingErrorType)
+                    {
+                        if (!await DelayAsync(
+                            options.PollCooldown, cancellationToken, rpcToken).ConfigureAwait(false))
+                        {
+                            yield break;
+                        }
+                        continue;
+                    }
+
+                    WorkflowExecutionStatus status = WorkflowExecutionStatus.Unspecified;
+                    var describeCanceledByDispose = false;
+                    try
+                    {
+                        status = await DescribeStatusAsync(
+                            attempt?.RunId, cancellationToken, rpcToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (disposeToken.IsCancellationRequested)
+                        {
+                            describeCanceledByDispose = true;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                    if (describeCanceledByDispose)
+                    {
+                        yield break;
+                    }
+                    if (status == WorkflowExecutionStatus.ContinuedAsNew)
+                    {
+                        continue;
+                    }
+                    if (IsTerminal(status))
+                    {
+                        yield break;
+                    }
+                    throw pollError;
+                }
+
+                foreach (var item in attempt!.Result!.Items)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (disposeToken.IsCancellationRequested)
+                    {
+                        yield break;
+                    }
+                    yield return new(
+                        item.Topic ?? string.Empty,
+                        PayloadWire.Decode(item.Data),
+                        item.Offset);
+                }
+                offset = attempt!.Result!.NextOffset;
+                if (!attempt.Result.MoreReady &&
+                    !await DelayAsync(
+                        options.PollCooldown, cancellationToken, rpcToken).ConfigureAwait(false))
+                {
+                    yield break;
+                }
+            }
+        }
+
+        private async Task<PollAttempt> PollOnceAsync(
+            IReadOnlyCollection<string> topics,
+            long offset,
+            CancellationToken cancellationToken,
+            CancellationToken rpcToken)
+        {
+            var updateId = Guid.NewGuid().ToString("N");
+            WorkflowUpdateHandle<PollResult> updateHandle;
+            while (true)
+            {
+                try
+                {
+                    updateHandle = await workflowHandle.StartUpdateAsync<PollResult>(
+                        WorkflowStreamConstants.PollUpdateName,
+                        new object?[]
+                        {
+                            new PollInput { Topics = topics, FromOffset = offset },
+                        },
+                        new(WorkflowUpdateStage.Accepted)
+                        {
+                            Id = updateId,
+                            Rpc = new()
+                            {
+                                CancellationToken = rpcToken,
+                                Timeout = options.RpcTimeout,
+                            },
+                        }).ConfigureAwait(false);
+                    break;
+                }
+                catch (WorkflowUpdateRpcTimeoutOrCanceledException)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (disposeToken.IsCancellationRequested)
+                    {
+                        disposeToken.ThrowIfCancellationRequested();
+                    }
+                }
+                catch (TemporalException err)
+                {
+                    return new(null, null, err);
+                }
+                catch (InvalidOperationException err)
+                {
+                    return new(null, null, err);
+                }
+            }
+
+            var runId = updateHandle.WorkflowRunId;
+            while (true)
+            {
+                try
+                {
+                    var result = await updateHandle.GetResultAsync(new()
+                    {
+                        CancellationToken = rpcToken,
+                        Timeout = options.RpcTimeout,
+                    }).ConfigureAwait(false);
+                    return new(result, runId, null);
+                }
+                catch (WorkflowUpdateRpcTimeoutOrCanceledException)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (disposeToken.IsCancellationRequested)
+                    {
+                        disposeToken.ThrowIfCancellationRequested();
+                    }
+                }
+                catch (TemporalException err)
+                {
+                    return new(null, runId, err);
+                }
+                catch (InvalidOperationException err)
+                {
+                    return new(null, runId, err);
+                }
+            }
+        }
+
+        private async Task<WorkflowExecutionStatus> DescribeStatusAsync(
+            string? runId,
+            CancellationToken cancellationToken,
+            CancellationToken rpcToken)
+        {
+            try
+            {
+                var description = await client.GetWorkflowHandle(workflowId, runId).DescribeAsync(
+                    new()
+                    {
+                        Rpc = new()
+                        {
+                            CancellationToken = rpcToken,
+                            Timeout = options.RpcTimeout,
+                        },
+                    }).ConfigureAwait(false);
+                return description.Status;
+            }
+            catch (OperationCanceledException)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (disposeToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                return WorkflowExecutionStatus.Unspecified;
+            }
+            catch (RpcException err) when (
+                err.Code == RpcException.StatusCode.DeadlineExceeded ||
+                err.Code == RpcException.StatusCode.Cancelled)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (disposeToken.IsCancellationRequested)
+                {
+                    disposeToken.ThrowIfCancellationRequested();
+                }
+                return WorkflowExecutionStatus.Unspecified;
+            }
+        }
+
+        private async Task<bool> DelayAsync(
+            TimeSpan delay,
+            CancellationToken cancellationToken,
+            CancellationToken rpcToken)
+        {
+            try
+            {
+                if (delay > TimeSpan.Zero)
+                {
+                    await Task.Delay(delay, rpcToken).ConfigureAwait(false);
+                }
+                return !disposeToken.IsCancellationRequested;
+            }
+            catch (OperationCanceledException)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (disposeToken.IsCancellationRequested)
+                {
+                    return false;
+                }
+                throw;
+            }
+        }
+
+        private sealed class PollAttempt
+        {
+            private readonly PollResult? result;
+
+            /// <summary>Initializes a new instance of the <see cref="PollAttempt"/> class.</summary>
+            /// <param name="result">Successful result, if present.</param>
+            /// <param name="runId">Admitted workflow run ID, if known.</param>
+            /// <param name="error">Poll error, if present.</param>
+            internal PollAttempt(PollResult? result, string? runId, Exception? error)
+            {
+                this.result = result;
+                RunId = runId;
+                Error = error;
+            }
+
+            /// <summary>Gets the successful result, if present.</summary>
+            internal PollResult? Result => result;
+
+            /// <summary>Gets the admitted workflow run ID, if known.</summary>
+            internal string? RunId { get; }
+
+            /// <summary>Gets the poll error, if present.</summary>
+            internal Exception? Error { get; }
+        }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamClientOptions.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamClientOptions.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>Options for constructing a <see cref="WorkflowStreamClient"/>.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public class WorkflowStreamClientOptions : ICloneable
+    {
+        /// <summary>Gets or sets the interval between automatic flush attempts.</summary>
+        public TimeSpan BatchInterval { get; set; } = WorkflowStreamConstants.DefaultBatchInterval;
+
+        /// <summary>
+        /// Gets or sets the item count that triggers a flush. Zero disables size-based flushing.
+        /// </summary>
+        public int MaxBatchSize { get; set; }
+
+        /// <summary>Gets or sets how long an ambiguous batch is retained for retry.</summary>
+        public TimeSpan MaxRetryDuration { get; set; } =
+            WorkflowStreamConstants.DefaultMaxRetryDuration;
+
+        /// <summary>Gets or sets the test override for the bounded transport attempt.</summary>
+        internal TimeSpan RpcTimeout { get; set; } = WorkflowStreamConstants.DefaultRpcTimeout;
+
+        /// <summary>Creates a copy of these options.</summary>
+        /// <returns>A copied options instance.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamConstants.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamConstants.cs
@@ -1,0 +1,51 @@
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>
+    /// Fixed handler names and application-failure types in the Workflow Streams wire protocol.
+    /// </summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public static class WorkflowStreamConstants
+    {
+        /// <summary>Signal used to append an external publisher's batch.</summary>
+        public const string PublishSignalName = "__temporal_workflow_stream_publish";
+
+        /// <summary>Update used to long-poll for stream items.</summary>
+        public const string PollUpdateName = "__temporal_workflow_stream_poll";
+
+        /// <summary>Query used to read the current global offset.</summary>
+        public const string OffsetQueryName = "__temporal_workflow_stream_offset";
+
+        /// <summary>Failure type returned when a requested offset has been truncated.</summary>
+        public const string TruncatedOffsetErrorType = "TruncatedOffset";
+
+        /// <summary>Failure type returned when truncation is requested past the end of the log.</summary>
+        public const string TruncateOutOfRangeErrorType = "TruncateOutOfRange";
+
+        /// <summary>Failure type returned while pollers are detaching for continue-as-new.</summary>
+        public const string StreamDrainingErrorType = "StreamDraining";
+
+        /// <summary>Keeps each update result comfortably below server payload limits.</summary>
+        internal const int MaxPollResponseBytes = 1_000_000;
+
+        /// <summary>Identifies items that cannot be delivered by the paging protocol.</summary>
+        internal const string OversizedItemErrorType = "WorkflowStreamItemTooLarge";
+
+        /// <summary>Prevents corrupt retained state from retrying its workflow task forever.</summary>
+        internal const string InvalidStateErrorType = "WorkflowStreamInvalidState";
+
+        /// <summary>Matches the batching cadence shared with other SDK implementations.</summary>
+        internal static readonly System.TimeSpan DefaultBatchInterval = System.TimeSpan.FromSeconds(2);
+
+        /// <summary>Stays below the default publisher TTL to preserve deduplication.</summary>
+        internal static readonly System.TimeSpan DefaultMaxRetryDuration = System.TimeSpan.FromMinutes(10);
+
+        /// <summary>Avoids tight polling while keeping interactive latency low.</summary>
+        internal static readonly System.TimeSpan DefaultPollCooldown = System.TimeSpan.FromMilliseconds(100);
+
+        /// <summary>Bounds deduplication metadata carried through continue-as-new.</summary>
+        internal static readonly System.TimeSpan DefaultPublisherTtl = System.TimeSpan.FromMinutes(15);
+
+        /// <summary>Bounds each transport attempt while retaining the accepted update handle.</summary>
+        internal static readonly System.TimeSpan DefaultRpcTimeout = System.TimeSpan.FromSeconds(30);
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamItem.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamItem.cs
@@ -1,0 +1,11 @@
+using Temporalio.Api.Common.V1;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>A decoded item yielded by a Workflow Streams subscription.</summary>
+    /// <param name="Topic">The item's topic, or an empty string for no topic.</param>
+    /// <param name="Payload">The raw Temporal payload.</param>
+    /// <param name="Offset">The item's global offset.</param>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed record WorkflowStreamItem(string Topic, Payload Payload, long Offset);
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamOptions.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamOptions.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>Options for constructing a workflow-side stream.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public class WorkflowStreamOptions : ICloneable
+    {
+        /// <summary>
+        /// Gets or sets how long publisher deduplication state is retained in snapshots.
+        /// </summary>
+        public TimeSpan PublisherTtl { get; set; } = WorkflowStreamConstants.DefaultPublisherTtl;
+
+        /// <summary>Creates a copy of these options.</summary>
+        /// <returns>A copied options instance.</returns>
+        public virtual object Clone() => MemberwiseClone();
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamState.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamState.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>Serializable Workflow Streams state for continue-as-new.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed class WorkflowStreamState
+    {
+        private IReadOnlyCollection<WireItem> log = Array.Empty<WireItem>();
+        private IReadOnlyDictionary<string, long> publisherSequences =
+            new Dictionary<string, long>();
+
+        private IReadOnlyDictionary<string, double> publisherLastSeen =
+            new Dictionary<string, double>();
+
+        /// <summary>Gets or sets the retained stream log.</summary>
+        [JsonPropertyName("log")]
+        public IReadOnlyCollection<WireItem> Log
+        {
+            get => log;
+            set => log = value ?? Array.Empty<WireItem>();
+        }
+
+        /// <summary>Gets or sets the global offset represented by the start of <see cref="Log"/>.</summary>
+        [JsonPropertyName("base_offset")]
+        public long BaseOffset { get; set; }
+
+        /// <summary>Gets or sets the most recently observed sequence for each publisher.</summary>
+        [JsonPropertyName("publisher_sequences")]
+        public IReadOnlyDictionary<string, long> PublisherSequences
+        {
+            get => publisherSequences;
+            set => publisherSequences = value ?? new Dictionary<string, long>();
+        }
+
+        /// <summary>Gets or sets each publisher's last-seen Unix timestamp in seconds.</summary>
+        [JsonPropertyName("publisher_last_seen")]
+        public IReadOnlyDictionary<string, double> PublisherLastSeen
+        {
+            get => publisherLastSeen;
+            set => publisherLastSeen = value ?? new Dictionary<string, double>();
+        }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamSubscribeOptions.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowStreamSubscribeOptions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>Options for a Workflow Streams subscription.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public class WorkflowStreamSubscribeOptions : ICloneable
+    {
+        private IReadOnlyCollection<string> topics = Array.Empty<string>();
+
+        /// <summary>Gets or sets the topic filter. Empty means all topics.</summary>
+        public IReadOnlyCollection<string> Topics
+        {
+            get => topics;
+            set => topics = value?.Select(topic => topic ?? string.Empty).ToArray() ??
+                Array.Empty<string>();
+        }
+
+        /// <summary>Gets or sets the global offset at which the subscription begins.</summary>
+        public long FromOffset { get; set; }
+
+        /// <summary>Gets or sets the delay between polls when no page is immediately ready.</summary>
+        public TimeSpan PollCooldown { get; set; } = WorkflowStreamConstants.DefaultPollCooldown;
+
+        /// <summary>Creates a copy of these options, including the topic collection.</summary>
+        /// <returns>A copied options instance.</returns>
+        public virtual object Clone()
+        {
+            var copy = (WorkflowStreamSubscribeOptions)MemberwiseClone();
+            copy.topics = topics.ToArray();
+            return copy;
+        }
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/WorkflowTopicHandle.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/WorkflowTopicHandle.cs
@@ -1,0 +1,25 @@
+namespace Temporalio.Extensions.WorkflowStreams
+{
+    /// <summary>A workflow-side handle bound to one topic.</summary>
+    /// <remarks>WARNING: Workflow Streams is experimental and may change.</remarks>
+    public sealed class WorkflowTopicHandle
+    {
+        private readonly WorkflowStream stream;
+
+        /// <summary>Initializes a new instance of the <see cref="WorkflowTopicHandle"/> class.</summary>
+        /// <param name="stream">Workflow stream whose global log receives publications.</param>
+        /// <param name="name">Normalized topic name.</param>
+        internal WorkflowTopicHandle(WorkflowStream stream, string name)
+        {
+            this.stream = stream;
+            Name = name ?? string.Empty;
+        }
+
+        /// <summary>Gets the topic name.</summary>
+        public string Name { get; }
+
+        /// <summary>Appends a value to the workflow's durable stream log.</summary>
+        /// <param name="value">The value or pre-built Temporal payload to append.</param>
+        public void Publish(object? value) => stream.Publish(Name, value);
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/_LanguageHelpers.cs
+++ b/src/Temporalio.Extensions.WorkflowStreams/_LanguageHelpers.cs
@@ -1,0 +1,9 @@
+#pragma warning disable SA1649
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Required for record support on the package's target framework.</summary>
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/src/Temporalio.Extensions.WorkflowStreams/packages.lock.json
+++ b/src/Temporalio.Extensions.WorkflowStreams/packages.lock.json
@@ -2,11 +2,14 @@
   "version": 2,
   "dependencies": {
     ".NETStandard,Version=v2.0": {
-      "Amazon.Lambda.Core": {
+      "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Direct",
-        "requested": "[3.1.0, )",
-        "resolved": "3.1.0",
-        "contentHash": "uZZ2k5lMoB9OzPTmKkkEKpyFcnLxcb7FxtxrA3+HBg/sooTzu402iCcSk5r+N62Qokhwr4Q9cbaVJSM6Dln3aA=="
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -30,6 +33,21 @@
         "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
         "dependencies": {
           "StyleCop.Analyzers.Unstable": "1.2.0.435"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Direct",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "pYtmpcO6R3Ef1XilZEHgXP2xBPVORbYEzRP7dl0IAAbN8Dm+kfwio8aCKle97rAWXOExr292MuxWYurIuwN62g==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.4",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.4",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -115,15 +133,6 @@
           "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "CentralTransitive",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.Bcl.HashCode": {
         "type": "CentralTransitive",
         "requested": "[6.0.0, )",
@@ -143,21 +152,6 @@
         "contentHash": "2cdRtmwT/vskWqJvojODvR7CpRhLWAnCeVT5Z8sPdRDX8P/Ywpw48T2lqgqhxM8JROfoflHzhSiXo4h1ln3/MQ==",
         "dependencies": {
           "Microsoft.Bcl.HashCode": "6.0.0"
-        }
-      },
-      "System.Text.Json": {
-        "type": "CentralTransitive",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "pYtmpcO6R3Ef1XilZEHgXP2xBPVORbYEzRP7dl0IAAbN8Dm+kfwio8aCKle97rAWXOExr292MuxWYurIuwN62g==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
-          "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.4",
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.4",
-          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       }
     }

--- a/src/Temporalio/Runtime/TemporalRuntime.cs
+++ b/src/Temporalio/Runtime/TemporalRuntime.cs
@@ -18,6 +18,15 @@ namespace Temporalio.Runtime
         /// </summary>
         internal const string ReservedNamePrefix = "__temporal";
 
+        /// <summary>Allowed despite the reserved prefix for cross-SDK stream interoperability.</summary>
+        internal const string WorkflowStreamOffsetQueryName = "__temporal_workflow_stream_offset";
+
+        /// <summary>Allowed despite the reserved prefix for cross-SDK stream interoperability.</summary>
+        internal const string WorkflowStreamPollUpdateName = "__temporal_workflow_stream_poll";
+
+        /// <summary>Allowed despite the reserved prefix for cross-SDK stream interoperability.</summary>
+        internal const string WorkflowStreamPublishSignalName = "__temporal_workflow_stream_publish";
+
         private static readonly Lazy<TemporalRuntime> LazyDefault =
             new(() => new TemporalRuntime(new TemporalRuntimeOptions()));
 

--- a/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowQueryDefinition.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Temporalio.Runtime;
@@ -12,13 +11,6 @@ namespace Temporalio.Workflows
     /// </summary>
     public class WorkflowQueryDefinition
     {
-        private static readonly string[] ReservedQueryHandlerPrefixes =
-        {
-            TemporalRuntime.ReservedNamePrefix,
-            "__stack_trace",
-            "__enhanced_stack_trace",
-        };
-
         private static readonly ConcurrentDictionary<MethodInfo, WorkflowQueryDefinition> MethodDefinitions = new();
         private static readonly ConcurrentDictionary<PropertyInfo, WorkflowQueryDefinition> PropertyDefinitions = new();
 
@@ -26,10 +18,21 @@ namespace Temporalio.Workflows
         {
             if (name != null)
             {
-                var reservedQ = ReservedQueryHandlerPrefixes.FirstOrDefault(p => name.StartsWith(p));
-                if (!string.IsNullOrEmpty(reservedQ))
+                if (name.StartsWith("__stack_trace"))
                 {
-                    throw new ArgumentException($"Query handler name {name} cannot start with {reservedQ}");
+                    throw new ArgumentException(
+                        $"Query handler name {name} cannot start with __stack_trace");
+                }
+                if (name.StartsWith("__enhanced_stack_trace"))
+                {
+                    throw new ArgumentException(
+                        $"Query handler name {name} cannot start with __enhanced_stack_trace");
+                }
+                if (name.StartsWith(TemporalRuntime.ReservedNamePrefix) &&
+                    name != TemporalRuntime.WorkflowStreamOffsetQueryName)
+                {
+                    throw new ArgumentException(
+                        $"Query handler name {name} cannot start with {TemporalRuntime.ReservedNamePrefix}");
                 }
             }
             Name = name;

--- a/src/Temporalio/Workflows/WorkflowSignalDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowSignalDefinition.cs
@@ -20,7 +20,9 @@ namespace Temporalio.Workflows
             Delegate? del,
             HandlerUnfinishedPolicy unfinishedPolicy)
         {
-            if (name != null && name.StartsWith(TemporalRuntime.ReservedNamePrefix))
+            if (name != null &&
+                name.StartsWith(TemporalRuntime.ReservedNamePrefix) &&
+                name != TemporalRuntime.WorkflowStreamPublishSignalName)
             {
                 throw new ArgumentException($"Signal handler name {name} cannot start with {TemporalRuntime.ReservedNamePrefix}");
             }

--- a/src/Temporalio/Workflows/WorkflowUpdateDefinition.cs
+++ b/src/Temporalio/Workflows/WorkflowUpdateDefinition.cs
@@ -23,7 +23,9 @@ namespace Temporalio.Workflows
             Delegate? validatorDel,
             HandlerUnfinishedPolicy unfinishedPolicy)
         {
-            if (name != null && name.StartsWith(TemporalRuntime.ReservedNamePrefix))
+            if (name != null &&
+                name.StartsWith(TemporalRuntime.ReservedNamePrefix) &&
+                name != TemporalRuntime.WorkflowStreamPollUpdateName)
             {
                 throw new ArgumentException($"Update handler name {name} cannot start with {TemporalRuntime.ReservedNamePrefix}");
             }

--- a/src/Temporalio/packages.lock.json
+++ b/src/Temporalio/packages.lock.json
@@ -157,14 +157,6 @@
           "System.ValueTuple": "4.5.0"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -242,6 +234,15 @@
         "type": "Transitive",
         "resolved": "4.6.1",
         "contentHash": "+RJT4qaekpZ7DDLhf+LTjq+E48jieKiY9ulJ+BoxKmZblIJfIJT8Ufcaa/clQqnYvWs8jugfGSMu8ylS0caG0w=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
       }
     },
     ".NETStandard,Version=v2.0": {
@@ -325,14 +326,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -404,6 +397,15 @@
         "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       }
     }

--- a/tests/Temporalio.Tests/Extensions/WorkflowStreams/StreamPublisherTests.cs
+++ b/tests/Temporalio.Tests/Extensions/WorkflowStreams/StreamPublisherTests.cs
@@ -1,0 +1,188 @@
+namespace Temporalio.Tests.Extensions.WorkflowStreams;
+
+using Temporalio.Converters;
+using Temporalio.Extensions.WorkflowStreams;
+using Xunit;
+
+public class StreamPublisherTests
+{
+    private static readonly WorkflowStreamClientOptions SlowBatchOptions = new()
+    {
+        BatchInterval = TimeSpan.FromHours(1),
+        MaxRetryDuration = TimeSpan.FromMinutes(1),
+    };
+
+    [Fact]
+    public async Task FlushAsync_BatchesAndAdvancesSequence()
+    {
+        var sent = new List<PublishInput>();
+        await using var publisher = new StreamPublisher(
+            (input, _) =>
+            {
+                sent.Add(input);
+                return Task.CompletedTask;
+            },
+            DataConverter.Default.PayloadConverter,
+            SlowBatchOptions);
+
+        publisher.Publish("one", "first", false);
+        publisher.Publish("two", "second", false);
+        await publisher.FlushAsync(default);
+        publisher.Publish("one", "third", false);
+        await publisher.FlushAsync(default);
+
+        Assert.Equal(2, sent.Count);
+        Assert.Equal(new long[] { 1, 2 }, sent.Select(input => input.Sequence));
+        Assert.Equal(sent[0].PublisherId, sent[1].PublisherId);
+        Assert.Equal(new[] { "one", "two" }, sent[0].Items.Select(item => item.Topic));
+        var payload = PayloadWire.Decode(sent[0].Items.First().Data);
+        Assert.Equal("first", DataConverter.Default.PayloadConverter.ToValue(payload, typeof(string)));
+    }
+
+    [Fact]
+    public async Task FlushAsync_RetriesAmbiguousBatchWithSameIdentity()
+    {
+        var attempts = new List<PublishInput>();
+        await using var publisher = new StreamPublisher(
+            (input, _) =>
+            {
+                attempts.Add(input);
+                return attempts.Count == 1 ?
+                    Task.FromException(new InvalidOperationException("ambiguous")) :
+                    Task.CompletedTask;
+            },
+            DataConverter.Default.PayloadConverter,
+            SlowBatchOptions);
+        publisher.Publish(string.Empty, "value", false);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => publisher.FlushAsync(default));
+        await publisher.FlushAsync(default);
+
+        Assert.Equal(2, attempts.Count);
+        Assert.Equal(attempts[0].PublisherId, attempts[1].PublisherId);
+        Assert.Equal(attempts[0].Sequence, attempts[1].Sequence);
+        Assert.Same(attempts[0].Items, attempts[1].Items);
+    }
+
+    [Fact]
+    public async Task FlushTimeout_DropsAmbiguousBatchWithoutReusingSequence()
+    {
+        var attempts = new List<PublishInput>();
+        var options = (WorkflowStreamClientOptions)SlowBatchOptions.Clone();
+        options.MaxRetryDuration = TimeSpan.FromTicks(1);
+        await using var publisher = new StreamPublisher(
+            (input, _) =>
+            {
+                attempts.Add(input);
+                return input.Sequence == 1 ?
+                    Task.FromException(new InvalidOperationException("ambiguous")) :
+                    Task.CompletedTask;
+            },
+            DataConverter.Default.PayloadConverter,
+            options);
+
+        publisher.Publish(string.Empty, "lost-or-delivered", false);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => publisher.FlushAsync(default));
+        await Assert.ThrowsAsync<FlushTimeoutException>(() => publisher.FlushAsync(default));
+
+        publisher.Publish(string.Empty, "later", false);
+        await publisher.FlushAsync(default);
+
+        Assert.Equal(new long[] { 1, 2 }, attempts.Select(input => input.Sequence));
+    }
+
+    [Fact]
+    public async Task BackgroundFlusher_ContinuesAfterTimeout()
+    {
+        var attempts = new List<long>();
+        var firstAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var laterDelivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        StreamPublisher? disposedPublisher = null;
+        await Assert.ThrowsAsync<FlushTimeoutException>(async () =>
+        {
+            await using var publisher = new StreamPublisher(
+                (input, _) =>
+                {
+                    attempts.Add(input.Sequence);
+                    if (input.Sequence == 1)
+                    {
+                        firstAttempt.TrySetResult();
+                        return Task.FromException(new InvalidOperationException("ambiguous"));
+                    }
+                    laterDelivered.TrySetResult();
+                    return Task.CompletedTask;
+                },
+                DataConverter.Default.PayloadConverter,
+                new()
+                {
+                    BatchInterval = TimeSpan.FromMilliseconds(10),
+                    MaxRetryDuration = TimeSpan.FromTicks(1),
+                });
+            disposedPublisher = publisher;
+
+            publisher.Publish(string.Empty, "ambiguous", true);
+            await firstAttempt.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            publisher.Publish(string.Empty, "later", true);
+            await laterDelivered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(new long[] { 1, 2 }, attempts);
+        });
+        Assert.False(disposedPublisher!.HasLiveTimer);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsSharedDrainsAndRejectsLaterPublication()
+    {
+        var signalStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var publisher = new StreamPublisher(
+            async (_, _) =>
+            {
+                signalStarted.TrySetResult();
+                await releaseSignal.Task;
+            },
+            DataConverter.Default.PayloadConverter,
+            SlowBatchOptions);
+        publisher.Publish(string.Empty, "value", false);
+
+        var firstDispose = publisher.DisposeAsync().AsTask();
+        var secondDispose = publisher.DisposeAsync().AsTask();
+        Assert.Same(firstDispose, secondDispose);
+        await signalStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(publisher.HasLiveTimer);
+        Assert.Throws<ObjectDisposedException>(() =>
+            publisher.Publish(string.Empty, "later", false));
+
+        releaseSignal.SetResult();
+        await firstDispose;
+        await secondDispose;
+    }
+
+    [Fact]
+    public async Task FlushAsync_ConsumerCancellationLeavesBatchRetryable()
+    {
+        var attempt = 0;
+        var signalStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var publisher = new StreamPublisher(
+            async (_, cancellationToken) =>
+            {
+                attempt++;
+                if (attempt == 1)
+                {
+                    signalStarted.SetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+            },
+            DataConverter.Default.PayloadConverter,
+            SlowBatchOptions);
+        publisher.Publish(string.Empty, "value", false);
+        using var cancellationSource = new CancellationTokenSource();
+
+        var flushTask = publisher.FlushAsync(cancellationSource.Token);
+        await signalStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await cancellationSource.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => flushTask);
+        await publisher.FlushAsync(default);
+
+        Assert.Equal(2, attempt);
+    }
+}

--- a/tests/Temporalio.Tests/Extensions/WorkflowStreams/WorkflowStreamTests.cs
+++ b/tests/Temporalio.Tests/Extensions/WorkflowStreams/WorkflowStreamTests.cs
@@ -1,0 +1,286 @@
+namespace Temporalio.Tests.Extensions.WorkflowStreams;
+
+using Temporalio.Converters;
+using Temporalio.Extensions.WorkflowStreams;
+using Temporalio.Worker;
+using Temporalio.Workflows;
+using Xunit;
+using Xunit.Abstractions;
+
+public class WorkflowStreamTests : WorkflowEnvironmentTestBase
+{
+    public WorkflowStreamTests(ITestOutputHelper output, WorkflowEnvironment env)
+        : base(output, env)
+    {
+    }
+
+    [Fact]
+    public async Task PublishSubscribe_IsReusableFilteredAndCancelable()
+    {
+        using var worker = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").AddWorkflow<HostedStreamWorkflow>());
+        await worker.ExecuteAsync(async () =>
+        {
+            var handle = await Client.StartWorkflowAsync(
+                (HostedStreamWorkflow workflow) => workflow.RunAsync(),
+                new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+            await using var client = new WorkflowStreamClient(
+                Client,
+                handle.Id,
+                new() { BatchInterval = TimeSpan.FromHours(1) });
+            var orders = client.Topic("orders").SubscribeAsync();
+
+            client.Topic("orders").Publish("first");
+            client.Topic("audit").Publish("ignored");
+            await client.FlushAsync(default);
+
+            await using var first = orders.GetAsyncEnumerator();
+            await using var second = orders.GetAsyncEnumerator();
+            Assert.True(await first.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(15)));
+            Assert.True(await second.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(15)));
+            Assert.Equal("first", DecodeString(first.Current));
+            Assert.Equal("first", DecodeString(second.Current));
+            Assert.Equal(0, first.Current.Offset);
+            Assert.Equal(0, second.Current.Offset);
+
+            using var cancellationSource = new CancellationTokenSource();
+            await using var canceled = client.SubscribeAsync(new() { FromOffset = 2 }).
+                WithCancellation(cancellationSource.Token).GetAsyncEnumerator();
+            var canceledMove = Task.Run(async () => await canceled.MoveNextAsync());
+            await cancellationSource.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => canceledMove.WaitAsync(TimeSpan.FromSeconds(15)));
+
+            var disposedClient = new WorkflowStreamClient(Client, handle.Id);
+            await using var disposedEnumerator = disposedClient.SubscribeAsync(
+                new() { FromOffset = 2 }).GetAsyncEnumerator();
+            var disposedMove = disposedEnumerator.MoveNextAsync().AsTask();
+            await disposedClient.DisposeAsync();
+            Assert.False(await disposedMove.WaitAsync(TimeSpan.FromSeconds(15)));
+
+            await using var terminal = client.SubscribeAsync(
+                new() { FromOffset = 2 }).GetAsyncEnumerator();
+            var terminalMove = terminal.MoveNextAsync().AsTask();
+            await handle.SignalAsync(workflow => workflow.FinishAsync());
+            Assert.False(await terminalMove.WaitAsync(TimeSpan.FromSeconds(15)));
+            await handle.GetResultAsync();
+        });
+    }
+
+    [Fact]
+    public async Task Truncate_ResetsFallenBehindSubscriptionToRetainedBeginning()
+    {
+        using var worker = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").AddWorkflow<HostedStreamWorkflow>());
+        await worker.ExecuteAsync(async () =>
+        {
+            var handle = await Client.StartWorkflowAsync(
+                (HostedStreamWorkflow workflow) => workflow.RunAsync(),
+                new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+            await using var client = new WorkflowStreamClient(
+                Client,
+                handle.Id,
+                new() { BatchInterval = TimeSpan.FromHours(1) });
+            client.Topic(string.Empty).Publish("zero");
+            client.Topic(string.Empty).Publish("one");
+            client.Topic(string.Empty).Publish("two");
+            await client.FlushAsync(default);
+            Assert.Equal(3, await client.GetOffsetAsync(default));
+
+            await handle.SignalAsync(workflow => workflow.TruncateAsync(2));
+            Assert.Equal(2, await handle.QueryAsync(workflow => workflow.BaseOffset()));
+            await using var enumerator = client.SubscribeAsync(
+                new() { FromOffset = 1 }).GetAsyncEnumerator();
+            Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(15)));
+            Assert.Equal("two", DecodeString(enumerator.Current));
+            Assert.Equal(2, enumerator.Current.Offset);
+
+            await handle.SignalAsync(workflow => workflow.FinishAsync());
+            await handle.GetResultAsync();
+        });
+    }
+
+    [Fact]
+    public async Task PublishSignal_DeduplicatesAndSkipsMalformedEntries()
+    {
+        using var worker = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").AddWorkflow<HostedStreamWorkflow>());
+        await worker.ExecuteAsync(async () =>
+        {
+            var handle = await Client.StartWorkflowAsync(
+                (HostedStreamWorkflow workflow) => workflow.RunAsync(),
+                new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+            var converter = DataConverter.Default.PayloadConverter;
+            var first = new PublishInput
+            {
+                PublisherId = "publisher",
+                Sequence = 1,
+                Items = new[]
+                {
+                    new PublishEntry
+                    {
+                        Topic = "events",
+                        Data = PayloadWire.Encode(converter.ToPayload("accepted")),
+                    },
+                },
+            };
+            var duplicate = new PublishInput
+            {
+                PublisherId = "publisher",
+                Sequence = 1,
+                Items = new[]
+                {
+                    new PublishEntry
+                    {
+                        Topic = "events",
+                        Data = PayloadWire.Encode(converter.ToPayload("duplicate")),
+                    },
+                },
+            };
+            var malformed = new PublishInput
+            {
+                PublisherId = "publisher",
+                Sequence = 2,
+                Items = new[]
+                {
+                    new PublishEntry { Topic = "events", Data = "not base64" },
+                },
+            };
+
+            await handle.SignalAsync(
+                WorkflowStreamConstants.PublishSignalName, new object?[] { first });
+            await handle.SignalAsync(
+                WorkflowStreamConstants.PublishSignalName, new object?[] { duplicate });
+            await handle.SignalAsync(
+                WorkflowStreamConstants.PublishSignalName, new object?[] { malformed });
+            await using var client = new WorkflowStreamClient(Client, handle.Id);
+            Assert.Equal(1, await client.GetOffsetAsync(default));
+            await using var enumerator = client.Topic("events").SubscribeAsync().GetAsyncEnumerator();
+            Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(15)));
+            Assert.Equal("accepted", DecodeString(enumerator.Current));
+
+            await handle.SignalAsync(workflow => workflow.FinishAsync());
+            await handle.GetResultAsync();
+        });
+    }
+
+    [Fact]
+    public async Task Subscription_FollowsContinueAsNewWithStateAndWaitingPoll()
+    {
+        using var worker = new TemporalWorker(
+            Client,
+            new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").AddWorkflow<ContinuingStreamWorkflow>());
+        await worker.ExecuteAsync(async () =>
+        {
+            var handle = await Client.StartWorkflowAsync(
+                (ContinuingStreamWorkflow workflow) => workflow.RunAsync(null, true),
+                new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+            var initialRunId = handle.FirstExecutionRunId;
+            await using var client = new WorkflowStreamClient(
+                Client,
+                handle.Id,
+                new() { BatchInterval = TimeSpan.FromHours(1) });
+            await using var enumerator = client.SubscribeAsync().GetAsyncEnumerator();
+
+            client.Topic("events").Publish("before");
+            await client.FlushAsync(default);
+            Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(15)));
+            Assert.Equal("before", DecodeString(enumerator.Current));
+
+            var waitingMove = enumerator.MoveNextAsync().AsTask();
+            await handle.SignalAsync(workflow => workflow.ContinueAsync());
+            await AssertMore.EventuallyAsync(async () =>
+            {
+                var description = await handle.DescribeAsync();
+                Assert.NotEqual(initialRunId, description.RunId);
+            });
+
+            client.Topic("events").Publish("after");
+            await client.FlushAsync(default);
+            Assert.True(await waitingMove.WaitAsync(TimeSpan.FromSeconds(15)));
+            Assert.Equal("after", DecodeString(enumerator.Current));
+            Assert.Equal(1, enumerator.Current.Offset);
+
+            await handle.SignalAsync(workflow => workflow.FinishAsync());
+            await handle.GetResultAsync();
+        });
+    }
+
+    private static string DecodeString(WorkflowStreamItem item) =>
+        (string)DataConverter.Default.PayloadConverter.ToValue(item.Payload, typeof(string))!;
+
+    [Workflow]
+    public class HostedStreamWorkflow
+    {
+        private readonly WorkflowStream stream = new();
+        private bool finished;
+
+        [WorkflowRun]
+        public async Task RunAsync()
+        {
+            await Workflow.WaitConditionAsync(() => finished);
+        }
+
+        [WorkflowSignal]
+        public Task FinishAsync()
+        {
+            finished = true;
+            return Task.CompletedTask;
+        }
+
+        [WorkflowSignal]
+        public Task TruncateAsync(long offset)
+        {
+            stream.Truncate(offset);
+            return Task.CompletedTask;
+        }
+
+        [WorkflowQuery]
+        public long BaseOffset() => stream.GetState().BaseOffset;
+    }
+
+    [Workflow]
+    public class ContinuingStreamWorkflow
+    {
+        private readonly WorkflowStream stream;
+        private bool continueRequested;
+        private bool finished;
+
+        [WorkflowInit]
+        public ContinuingStreamWorkflow(WorkflowStreamState? state, bool continueOnce)
+        {
+            stream = new(state);
+        }
+
+        [WorkflowRun]
+        public async Task RunAsync(WorkflowStreamState? state, bool continueOnce)
+        {
+            if (continueOnce)
+            {
+                await Workflow.WaitConditionAsync(() => continueRequested);
+                await stream.ContinueAsNewAsync(nextState =>
+                    Workflow.CreateContinueAsNewException(
+                        (ContinuingStreamWorkflow workflow) =>
+                            workflow.RunAsync(nextState, false)));
+            }
+            await Workflow.WaitConditionAsync(() => finished);
+        }
+
+        [WorkflowSignal]
+        public Task ContinueAsync()
+        {
+            continueRequested = true;
+            return Task.CompletedTask;
+        }
+
+        [WorkflowSignal]
+        public Task FinishAsync()
+        {
+            finished = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Temporalio.Tests/Extensions/WorkflowStreams/WorkflowStreamWireTests.cs
+++ b/tests/Temporalio.Tests/Extensions/WorkflowStreams/WorkflowStreamWireTests.cs
@@ -1,0 +1,104 @@
+namespace Temporalio.Tests.Extensions.WorkflowStreams;
+
+using System.Text.Json;
+using Google.Protobuf;
+using Temporalio.Api.Common.V1;
+using Temporalio.Extensions.WorkflowStreams;
+using Xunit;
+
+public class WorkflowStreamWireTests
+{
+    [Fact]
+    public void PayloadWire_DefaultJsonString_MatchesCrossSdkFixture()
+    {
+        var payload = new Payload
+        {
+            Data = ByteString.CopyFromUtf8("\"hello\""),
+        };
+        payload.Metadata.Add("encoding", ByteString.CopyFromUtf8("json/plain"));
+
+        const string Wire = "ChYKCGVuY29kaW5nEgpqc29uL3BsYWluEgciaGVsbG8i";
+        Assert.Equal(Wire, PayloadWire.Encode(payload));
+
+        var decoded = PayloadWire.Decode(Wire);
+        Assert.Equal("json/plain", decoded.Metadata["encoding"].ToStringUtf8());
+        Assert.Equal("\"hello\"", decoded.Data.ToStringUtf8());
+    }
+
+    [Fact]
+    public void WireDtos_UseExactSnakeCaseNames()
+    {
+        var state = new WorkflowStreamState
+        {
+            Log = new[]
+            {
+                new WireItem { Topic = "orders", Data = "cGF5bG9hZA==", Offset = 3 },
+            },
+            BaseOffset = 3,
+            PublisherSequences = new Dictionary<string, long> { ["publisher"] = 7 },
+            PublisherLastSeen = new Dictionary<string, double> { ["publisher"] = 12.5 },
+        };
+        var publish = new PublishInput
+        {
+            Items = new[] { new PublishEntry { Topic = "orders", Data = "cGF5bG9hZA==" } },
+            PublisherId = "publisher",
+            Sequence = 7,
+        };
+        var poll = new PollInput { Topics = new[] { "orders" }, FromOffset = 3 };
+        var result = new PollResult
+        {
+            Items = state.Log,
+            NextOffset = 4,
+            MoreReady = true,
+        };
+
+        AssertMore.JsonEqual(
+            """
+            {"items":[{"topic":"orders","data":"cGF5bG9hZA=="}],"publisher_id":"publisher","sequence":7}
+            """,
+            JsonSerializer.Serialize(publish));
+        AssertMore.JsonEqual(
+            """{"topics":["orders"],"from_offset":3}""",
+            JsonSerializer.Serialize(poll));
+        AssertMore.JsonEqual(
+            """
+            {"items":[{"topic":"orders","data":"cGF5bG9hZA==","offset":3}],"next_offset":4,"more_ready":true}
+            """,
+            JsonSerializer.Serialize(result));
+        AssertMore.JsonEqual(
+            """
+            {"log":[{"topic":"orders","data":"cGF5bG9hZA==","offset":3}],"base_offset":3,"publisher_sequences":{"publisher":7},"publisher_last_seen":{"publisher":12.5}}
+            """,
+            JsonSerializer.Serialize(state));
+    }
+
+    [Fact]
+    public void WireDtos_NormalizeNullTopics()
+    {
+        var entry = JsonSerializer.Deserialize<PublishEntry>("""{"topic":null,"data":""}""");
+        var item = JsonSerializer.Deserialize<WireItem>(
+            """{"topic":null,"data":"","offset":0}""");
+        var poll = JsonSerializer.Deserialize<PollInput>(
+            """{"topics":[null,"orders"],"from_offset":0}""");
+
+        Assert.Equal(string.Empty, entry!.Topic);
+        Assert.Equal(string.Empty, item!.Topic);
+        Assert.Equal(new[] { string.Empty, "orders" }, poll!.Topics);
+    }
+
+    [Fact]
+    public void Options_CloneSnapshotsTopicCollections()
+    {
+        var topics = new List<string> { "one" };
+        var options = new WorkflowStreamSubscribeOptions { Topics = topics };
+        var clone = (WorkflowStreamSubscribeOptions)options.Clone();
+        topics.Add("two");
+
+        Assert.Equal(new[] { "one" }, clone.Topics);
+        Assert.NotSame(options.Topics, clone.Topics);
+        options.Topics = new string[] { null! };
+        Assert.Equal(new[] { string.Empty }, options.Topics);
+        Assert.IsAssignableFrom<ICloneable>(new WorkflowStreamOptions());
+        Assert.IsAssignableFrom<ICloneable>(new WorkflowStreamClientOptions());
+    }
+}

--- a/tests/Temporalio.Tests/Temporalio.Tests.csproj
+++ b/tests/Temporalio.Tests/Temporalio.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\src\Temporalio.Extensions.Gcp.CloudRun.OpenTelemetry\Temporalio.Extensions.Gcp.CloudRun.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\Temporalio.Extensions.Hosting\Temporalio.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Temporalio.Extensions.OpenTelemetry\Temporalio.Extensions.OpenTelemetry.csproj" />
+    <ProjectReference Include="..\..\src\Temporalio.Extensions.WorkflowStreams\Temporalio.Extensions.WorkflowStreams.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Temporalio.Tests/Workflows/WorkflowDefinitionTests.cs
+++ b/tests/Temporalio.Tests/Workflows/WorkflowDefinitionTests.cs
@@ -247,6 +247,24 @@ public class WorkflowDefinitionTests
     }
 
     [Fact]
+    public void WorkflowStream_Handler_Names_Are_Allowlisted_By_Kind()
+    {
+        var definition = AssertGood<Good.WorkflowStreamHandlerNames>();
+        Assert.Contains("__temporal_workflow_stream_publish", definition.Signals.Keys);
+        Assert.Contains("__temporal_workflow_stream_poll", definition.Updates.Keys);
+        Assert.Contains("__temporal_workflow_stream_offset", definition.Queries.Keys);
+
+        AssertBad<Bad.MismatchedWorkflowStreamHandlerNames>(
+            "Signal handler name __temporal_workflow_stream_poll cannot start with __temporal");
+        AssertBad<Bad.MismatchedWorkflowStreamHandlerNames>(
+            "Update handler name __temporal_workflow_stream_publish cannot start with __temporal");
+        AssertBad<Bad.MismatchedWorkflowStreamHandlerNames>(
+            "Query handler name __temporal_workflow_stream_publish cannot start with __temporal");
+        AssertBad<Bad.MismatchedWorkflowStreamHandlerNames>(
+            "Query handler name __temporal_workflow_stream_offset_extra cannot start with __temporal");
+    }
+
+    [Fact]
     public void NoDynamicOptionsOnNonDynamicWorkflow() =>
         AssertBad<Bad.DynamicOptionsOnNonDynamicWorkflow>("can only be used in dynamic workflows");
 
@@ -575,6 +593,25 @@ public class WorkflowDefinitionTests
         }
 
         [Workflow]
+        public class MismatchedWorkflowStreamHandlerNames
+        {
+            [WorkflowRun]
+            public Task RunAsync() => Task.CompletedTask;
+
+            [WorkflowSignal("__temporal_workflow_stream_poll")]
+            public Task PollSignalAsync() => Task.CompletedTask;
+
+            [WorkflowUpdate("__temporal_workflow_stream_publish")]
+            public Task PublishUpdateAsync() => Task.CompletedTask;
+
+            [WorkflowQuery("__temporal_workflow_stream_publish")]
+            public long PublishQuery() => 0;
+
+            [WorkflowQuery("__temporal_workflow_stream_offset_extra")]
+            public long SuffixedOffsetQuery() => 0;
+        }
+
+        [Workflow]
         public class DynamicOptionsOnNonDynamicWorkflow
         {
             [WorkflowRun]
@@ -609,6 +646,22 @@ public class WorkflowDefinitionTests
 
     public static class Good
     {
+        [Workflow]
+        public class WorkflowStreamHandlerNames
+        {
+            [WorkflowRun]
+            public Task RunAsync() => Task.CompletedTask;
+
+            [WorkflowSignal("__temporal_workflow_stream_publish")]
+            public Task PublishAsync() => Task.CompletedTask;
+
+            [WorkflowUpdate("__temporal_workflow_stream_poll")]
+            public Task PollAsync() => Task.CompletedTask;
+
+            [WorkflowQuery("__temporal_workflow_stream_offset")]
+            public long Offset() => 0;
+        }
+
         [Workflow]
         public interface IWf1
         {

--- a/tests/Temporalio.Tests/packages.lock.json
+++ b/tests/Temporalio.Tests/packages.lock.json
@@ -499,6 +499,13 @@
           "Temporalio": "[1.18.0, )"
         }
       },
+      "temporalio.extensions.workflowstreams": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "[9.0.4, )",
+          "Temporalio": "[1.18.0, )"
+        }
+      },
       "Amazon.Lambda.Core": {
         "type": "CentralTransitive",
         "requested": "[3.1.0, )",
@@ -510,6 +517,12 @@
         "requested": "[3.26.1, )",
         "resolved": "3.26.1",
         "contentHash": "CHZX8zXqhF/fdUtd+AYzew8T2HFkAoe5c7lbGxZY/qryAlQXckDvM5BfOJjXlMS7kyICqQTMszj4w1bX5uBJ/w=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

- add an experimental netstandard2.0 Workflow Streams package with durable, offset-based, multi-topic publish/subscribe
- implement the cross-SDK wire protocol, deterministic workflow host, publisher state machine, reusable subscriptions, and exact reserved-handler allowlisting
- add independent tests, package documentation, solution/DocFX/NuGet integration, ownership, and changelog entries

This implementation was derived from the official TypeScript, Go, and Java Workflow Streams protocol.

## Validation

- focused Workflow Streams and reserved-handler tests: 15 passed
- dotnet format --verify-no-changes: passed
- dotnet pack -c Debug: passed
- mise run docs: passed with 0 warnings
- full dotnet test: 801 passed, 13 skipped, 1 unrelated reproducible failure in WorkflowWorkerTests.ExecuteWorkflowAsync_LocalActivityIncludeArgumentsInMarker_OnlyRecordsWhenEnabled