### PR TITLE
Fix System Nexus codec serialization context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ to docs, or any other relevant information.
 
 - Fixed workflow-side `SignalWithStartWorkflowAsync` to participate in outbound workflow
   interception, propagate tracing headers, and apply the target workflow serialization context.
+- Fixed workflow-side `SignalWithStartWorkflowAsync` payload codecs to apply the target workflow
+  serialization context to System Nexus request payloads.
 - Worker shutdown now drains activity completions that are still flushing their result to the
   server before finishing. Previously such a completion — typically one whose final heartbeat RPC
   was still in flight — could be permanently stranded by shutdown, so the activity's result was

--- a/src/Temporalio.SystemNexus.Generator/Program.cs
+++ b/src/Temporalio.SystemNexus.Generator/Program.cs
@@ -8,6 +8,7 @@ var projectDir = Path.GetFullPath(Path.Join(currFile, "../../../"));
 var generatorDir = Path.Join(projectDir, "src/Temporalio.SystemNexus.Generator");
 var protoDir = Path.Join(projectDir, "src/Temporalio/Bridge/sdk-core/crates/protos/protos");
 var apiProtoDir = Path.Join(protoDir, "api_upstream");
+var workflowServiceWitPath = Path.Join(apiProtoDir, "nexus/workflow-service.wit");
 var descriptorPath = Path.Join(generatorDir, "obj/SystemNexus/temporal_api.bin");
 var stagingOutputDir = Path.Join(generatorDir, "obj/SystemNexus/Generated");
 var workflowsGeneratedDir = Path.Join(projectDir, "src/Temporalio/Workflows/Generated");
@@ -18,7 +19,7 @@ EnsureNexGen();
 BuildDescriptor();
 GenerateNexusApi();
 PostProcessGeneratedNexusApi();
-GeneratePayloadVisitor(descriptorPath, workerGeneratedDir);
+GeneratePayloadVisitor(descriptorPath, workflowServiceWitPath, workerGeneratedDir);
 return 0;
 
 void EnsureNexGen()
@@ -126,10 +127,12 @@ static void RecreateDirectory(string path)
 
 static void GeneratePayloadVisitor(
     string descriptorPath,
+    string witPath,
     string outputDir)
 {
     var messages = LoadMessages(descriptorPath);
     var operationMessages = LoadWorkflowServiceOperationMessages(descriptorPath, messages);
+    var systemNexusMessages = LoadSystemNexusMessages(witPath, messages);
     var containsPayloadMemo = new Dictionary<string, bool>();
     var emittedVisitors = new HashSet<string>();
     var emittedMethods = new HashSet<string>();
@@ -160,8 +163,19 @@ static void GeneratePayloadVisitor(
         EmitEnvelopeVisitor(builder, operation.Input, messages, containsPayloadMemo, emittedVisitors);
         EmitEnvelopeVisitor(builder, operation.Output, messages, containsPayloadMemo, emittedVisitors);
     }
+    foreach (var message in systemNexusMessages.Where(message =>
+        !ContainsPayload(message, messages, containsPayloadMemo)))
+    {
+        EmitEnvelopeVisitor(
+            builder, message, messages, containsPayloadMemo, emittedVisitors, force: true);
+    }
 
     builder.AppendLine("            };");
+    builder.AppendLine();
+    builder.AppendLine("        private static Task VisitNoPayloadEnvelopeAsync<T>(");
+    builder.AppendLine("            T value,");
+    builder.AppendLine("            PayloadVisitor visitPayload,");
+    builder.AppendLine("            PayloadsVisitor visitPayloads) => Task.CompletedTask;");
     builder.AppendLine();
     builder.AppendLine("        internal static async Task<bool> TryVisitAsync(");
     builder.AppendLine("            Payload payload,");
@@ -189,7 +203,6 @@ static void GeneratePayloadVisitor(
         EmitVisitMethod(builder, operation.Input, messages, containsPayloadMemo, emittedMethods);
         EmitVisitMethod(builder, operation.Output, messages, containsPayloadMemo, emittedMethods);
     }
-
     builder.AppendLine("    }");
     builder.AppendLine("}");
 
@@ -239,6 +252,14 @@ static IReadOnlyList<OperationMessages> LoadWorkflowServiceOperationMessages(
     return operationMessages;
 }
 
+static IReadOnlyList<MessageInfo> LoadSystemNexusMessages(
+    string witPath,
+    IReadOnlyDictionary<string, MessageInfo> messages) =>
+    Regex.Matches(File.ReadAllText(witPath), "@nexus\\.proto\\s+\\\"(?<message>[^\\\"]+)\\\"")
+        .Select(match => GetMessage(messages, match.Groups["message"].Value))
+        .DistinctBy(message => message.FullName)
+        .ToList();
+
 static void AddMessage(
     Dictionary<string, MessageInfo> messages,
     string protoPrefix,
@@ -273,18 +294,22 @@ static void EmitEnvelopeVisitor(
     MessageInfo message,
     IReadOnlyDictionary<string, MessageInfo> messages,
     Dictionary<string, bool> containsPayloadMemo,
-    HashSet<string> emittedVisitors)
+    HashSet<string> emittedVisitors,
+    bool force = false)
 {
-    if (!ContainsPayload(message, messages, containsPayloadMemo) ||
+    if ((!force && !ContainsPayload(message, messages, containsPayloadMemo)) ||
         !emittedVisitors.Add(message.FullName))
     {
         return;
     }
 
+    var visitMethod = ContainsPayload(message, messages, containsPayloadMemo) ?
+        VisitMethodName(message) :
+        "VisitNoPayloadEnvelopeAsync";
     builder.AppendLine($"                [\"{message.FullName}\"] = (payload, visitPayload, visitPayloads) =>");
     builder.AppendLine($"                    VisitEnvelopeAsync<{message.CsharpType}>(");
     builder.AppendLine("                        payload,");
-    builder.AppendLine($"                        {VisitMethodName(message)},");
+    builder.AppendLine($"                        {visitMethod},");
     builder.AppendLine("                        visitPayload,");
     builder.AppendLine("                        visitPayloads),");
 }
@@ -633,6 +658,6 @@ static int RunNexGen(IEnumerable<string> arguments, bool ignoreExitCode = false)
 static string UniqueLocalName(MessageInfo message, FieldDescriptorProto field, string prefix) =>
     $"{prefix}_{Regex.Replace(message.FullName, @"[^A-Za-z0-9_]", "_")}_{field.Number}";
 
-internal sealed record OperationMessages(MessageInfo Input, MessageInfo Output);
 
 internal sealed record MessageInfo(string FullName, string CsharpType, DescriptorProto Descriptor);
+internal sealed record OperationMessages(MessageInfo Input, MessageInfo Output);

--- a/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
@@ -413,7 +413,18 @@ namespace Temporalio.Worker
                         Visit_temporal_api_workflowservice_v1_CountNexusOperationExecutionsResponse,
                         visitPayload,
                         visitPayloads),
+                ["temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse"] = (payload, visitPayload, visitPayloads) =>
+                    VisitEnvelopeAsync<global::Temporalio.Api.WorkflowService.V1.SignalWithStartWorkflowExecutionResponse>(
+                        payload,
+                        VisitNoPayloadEnvelopeAsync,
+                        visitPayload,
+                        visitPayloads),
             };
+
+        private static Task VisitNoPayloadEnvelopeAsync<T>(
+            T value,
+            PayloadVisitor visitPayload,
+            PayloadsVisitor visitPayloads) => Task.CompletedTask;
 
         internal static async Task<bool> TryVisitAsync(
             Payload payload,

--- a/src/Temporalio/Worker/IWorkflowCodecHelperInstance.cs
+++ b/src/Temporalio/Worker/IWorkflowCodecHelperInstance.cs
@@ -40,5 +40,12 @@ namespace Temporalio.Worker
         /// <param name="seq">Sequence.</param>
         /// <returns>Context.</returns>
         ISerializationContext.Workflow? GetPendingExternalSignalSerializationContext(uint seq);
+
+        /// <summary>
+        /// Gets the pending Nexus operation serialization context for the given sequence.
+        /// </summary>
+        /// <param name="seq">Sequence.</param>
+        /// <returns>Context.</returns>
+        ISerializationContext? GetPendingNexusOperationSerializationContext(uint seq);
     }
 }

--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -118,8 +118,13 @@ namespace Temporalio.Worker
                         }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.ResolveNexusOperation:
-                        // TODO(cretz): Support Nexus serialization context
                         var nexusCodec = context.CodecNoContext;
+                        if (nexusCodec is IWithSerializationContext<IPayloadCodec> withNexus &&
+                            context.Instance?.GetPendingNexusOperationSerializationContext(
+                                job.ResolveNexusOperation.Seq) is { } nexusContext)
+                        {
+                            nexusCodec = withNexus.WithSerializationContext(nexusContext);
+                        }
                         if (nexusCodec == null)
                         {
                             break;
@@ -150,11 +155,16 @@ namespace Temporalio.Worker
                         }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.ResolveNexusOperationStart:
-                        // TODO(cretz): Support Nexus serialization context
-                        if (job.ResolveNexusOperationStart.Failed != null
-                            && context.CodecNoContext != null)
+                        var nexusStartCodec = context.CodecNoContext;
+                        if (nexusStartCodec is IWithSerializationContext<IPayloadCodec> withNexusStart &&
+                            context.Instance?.GetPendingNexusOperationSerializationContext(
+                                job.ResolveNexusOperationStart.Seq) is { } nexusStartContext)
                         {
-                            await context.CodecNoContext.DecodeFailureAsync(
+                            nexusStartCodec = withNexusStart.WithSerializationContext(nexusStartContext);
+                        }
+                        if (job.ResolveNexusOperationStart.Failed != null && nexusStartCodec != null)
+                        {
+                            await nexusStartCodec.DecodeFailureAsync(
                                 job.ResolveNexusOperationStart.Failed).
                                 ConfigureAwait(false);
                         }
@@ -342,8 +352,13 @@ namespace Temporalio.Worker
                     }
                     break;
                 case WorkflowCommand.VariantOneofCase.ScheduleNexusOperation:
-                    // TODO(cretz): Support Nexus serialization context
                     codec = context.CodecNoContext;
+                    if (codec is IWithSerializationContext<IPayloadCodec> withNexus &&
+                        context.Instance?.GetPendingNexusOperationSerializationContext(
+                            cmd.ScheduleNexusOperation.Seq) is { } nexusContext)
+                    {
+                        codec = withNexus.WithSerializationContext(nexusContext);
+                    }
                     if (cmd.ScheduleNexusOperation.Input != null && codec != null)
                     {
                         await EncodeAsync(codec, cmd.ScheduleNexusOperation.Input).ConfigureAwait(false);

--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -899,6 +899,13 @@ namespace Temporalio.Worker
         }
 
         /// <inheritdoc/>
+        public ISerializationContext? GetPendingNexusOperationSerializationContext(uint seq)
+        {
+            nexusOperationsPending.TryGetValue(seq, out var pending);
+            return pending?.SerializationContext;
+        }
+
+        /// <inheritdoc/>
         protected override IEnumerable<Task>? GetScheduledTasks() => scheduledTasks;
 
         /// <inheritdoc/>
@@ -2750,6 +2757,7 @@ namespace Temporalio.Worker
 
                 var handleSource = new TaskCompletionSource<NexusWorkflowOperationHandle<TResult>>();
                 var pending = new PendingNexusOperationInfo(
+                    SerializationContext: serializationContext,
                     StartCompletionSource: new(),
                     ResultCompletionSource: new());
                 instance.nexusOperationsPending[seq] = pending;
@@ -3236,6 +3244,7 @@ namespace Temporalio.Worker
             TaskCompletionSource<ResolveRequestCancelExternalWorkflow> CompletionSource);
 
         private record PendingNexusOperationInfo(
+            ISerializationContext? SerializationContext,
             TaskCompletionSource<ResolveNexusOperationStart> StartCompletionSource,
             TaskCompletionSource<NexusOperationResult> ResultCompletionSource);
 

--- a/tests/Temporalio.Tests/Worker/SystemNexusTests.cs
+++ b/tests/Temporalio.Tests/Worker/SystemNexusTests.cs
@@ -134,6 +134,52 @@ public class SystemNexusTests : WorkflowEnvironmentTestBase
     [CloudTestExclusion(
         CloudTestExclusionReason.RequiresLocalServer,
         "Requires local dynamic configuration to enable signal with start from a workflow.")]
+    public async Task ExecuteWorkflowAsync_SignalWithStart_ReplayRehydratesCodecSerializationContext()
+    {
+        var clientOptions = (TemporalClientOptions)Client.Options.Clone();
+        clientOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadCodec = new RecordingContextPayloadCodec(),
+        };
+        var client = new TemporalClient(Client.Connection, clientOptions);
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddWorkflow<SystemNexusContextTargetWorkflow>();
+
+        await ExecuteWorkerAsync<SystemNexusContextCallerWorkflow>(
+            async worker =>
+            {
+                var targetId = $"workflow-{Guid.NewGuid()}";
+                var handle = await client.StartWorkflowAsync(
+                    (SystemNexusContextCallerWorkflow workflow) =>
+                        workflow.RunAsync(targetId, worker.Options.TaskQueue!),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+                await handle.GetResultAsync();
+
+                var replayCodec = new RecordingContextPayloadCodec();
+                var replayOptions = new WorkflowReplayerOptions
+                {
+                    DataConverter = DataConverter.Default with { PayloadCodec = replayCodec },
+                }.AddWorkflow<SystemNexusContextCallerWorkflow>();
+                var replayTaskCount = 0;
+                replayOptions.WorkflowTaskStarting += (_, _) => replayTaskCount++;
+                var replay = await new WorkflowReplayer(replayOptions).ReplayWorkflowAsync(
+                    await handle.FetchHistoryAsync());
+
+                Assert.Null(replay.ReplayFailure);
+                Assert.True(replayTaskCount >= 2);
+                var context = await replayCodec.Context.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.NotNull(context);
+                Assert.True(context.Workflow);
+                Assert.Equal(targetId, context.WorkflowId);
+            },
+            workerOptions,
+            client);
+    }
+
+    [Fact]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresLocalServer,
+        "Requires local dynamic configuration to enable signal with start from a workflow.")]
     public async Task ExecuteWorkflowAsync_SignalWithStart_DoesNotUseNormalNexusInterceptor()
     {
         var interceptor = new NormalNexusOperationInterceptor();

--- a/tests/Temporalio.Tests/Worker/SystemNexusTests.cs
+++ b/tests/Temporalio.Tests/Worker/SystemNexusTests.cs
@@ -100,6 +100,40 @@ public class SystemNexusTests : WorkflowEnvironmentTestBase
     [CloudTestExclusion(
         CloudTestExclusionReason.RequiresLocalServer,
         "Requires local dynamic configuration to enable signal with start from a workflow.")]
+    public async Task ExecuteWorkflowAsync_SignalWithStart_CodecUsesTargetSerializationContext()
+    {
+        var codec = new RecordingContextPayloadCodec();
+        var clientOptions = (TemporalClientOptions)Client.Options.Clone();
+        clientOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadCodec = codec,
+        };
+        var client = new TemporalClient(Client.Connection, clientOptions);
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}").
+            AddWorkflow<SystemNexusContextTargetWorkflow>();
+
+        await ExecuteWorkerAsync<SystemNexusContextCallerWorkflow>(
+            async worker =>
+            {
+                var targetId = $"workflow-{Guid.NewGuid()}";
+                var handle = await client.StartWorkflowAsync(
+                    (SystemNexusContextCallerWorkflow workflow) =>
+                        workflow.RunAsync(targetId, worker.Options.TaskQueue!),
+                    new(id: $"workflow-{Guid.NewGuid()}", taskQueue: worker.Options.TaskQueue!));
+                var context = await codec.Context.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.NotNull(context);
+                Assert.True(context.Workflow);
+                Assert.Equal(targetId, context.WorkflowId);
+                await handle.GetResultAsync();
+            },
+            workerOptions,
+            client);
+    }
+
+    [Fact]
+    [CloudTestExclusion(
+        CloudTestExclusionReason.RequiresLocalServer,
+        "Requires local dynamic configuration to enable signal with start from a workflow.")]
     public async Task ExecuteWorkflowAsync_SignalWithStart_DoesNotUseNormalNexusInterceptor()
     {
         var interceptor = new NormalNexusOperationInterceptor();
@@ -295,6 +329,50 @@ public class SystemNexusTests : WorkflowEnvironmentTestBase
             }
             return base.TryToPayload(value, out payload);
         }
+    }
+
+    private sealed class RecordingContextPayloadCodec : IPayloadCodec,
+        IWithSerializationContext<IPayloadCodec>
+    {
+        private readonly WorkflowWorkerTests.ContextInfo? context;
+
+        internal RecordingContextPayloadCodec()
+            : this(new())
+        {
+        }
+
+        private RecordingContextPayloadCodec(
+            TaskCompletionSource<WorkflowWorkerTests.ContextInfo?> contextSource,
+            WorkflowWorkerTests.ContextInfo? context = null)
+        {
+            Context = contextSource.Task;
+            this.context = context;
+            ContextSource = contextSource;
+        }
+
+        internal Task<WorkflowWorkerTests.ContextInfo?> Context { get; }
+
+        private TaskCompletionSource<WorkflowWorkerTests.ContextInfo?> ContextSource { get; }
+
+        public Task<IReadOnlyCollection<Temporalio.Api.Common.V1.Payload>> EncodeAsync(
+            IReadOnlyCollection<Temporalio.Api.Common.V1.Payload> payloads)
+        {
+            if (payloads.Any(payload => payload.Data.ToStringUtf8().Contains(
+                "context-workflow", StringComparison.Ordinal)))
+            {
+                ContextSource.TrySetResult(context);
+            }
+            return Task.FromResult(payloads);
+        }
+
+        public Task<IReadOnlyCollection<Temporalio.Api.Common.V1.Payload>> DecodeAsync(
+            IReadOnlyCollection<Temporalio.Api.Common.V1.Payload> payloads) =>
+            Task.FromResult(payloads);
+
+        public IPayloadCodec WithSerializationContext(ISerializationContext context) =>
+            new RecordingContextPayloadCodec(
+                ContextSource,
+                WorkflowWorkerTests.ContextInfo.Create(context));
     }
 
     private sealed class NormalNexusOperationInterceptor : IWorkerInterceptor


### PR DESCRIPTION
## Summary
- retain operation-derived serialization context for pending System Nexus operations
- apply that context to scheduled command codec processing and Nexus resolution payload/failure decoding
- recognize WIT-declared no-payload System Nexus envelopes, including signal-with-start responses

## Testing
- mise run gen:nexus
- dotnet build tests/Temporalio.Tests --no-restore
- dotnet test tests/Temporalio.Tests --no-restore --filter "FullyQualifiedName=Temporalio.Tests.Worker.SystemNexusTests.ExecuteWorkflowAsync_SignalWithStart_CodecUsesTargetSerializationContext"

Full dotnet format --verify-no-changes is currently blocked by pre-existing IDE0005 errors in tests/Temporalio.SimpleBench/Program.cs.