### PR TITLE
ci: use latest from features repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,4 +224,3 @@ jobs:
       dotnet-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
-      features-repo-ref: standalone-activities-dotnet


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

No longer pin to dedicated branch in features repo.

## Why?

Use latest tests from features repo.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: CI