### PR TITLE
Handle System Nexus payloads in Nexus Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Nexus workers now decode marked Temporal System Nexus operation inputs with the System Nexus converter.
+- NexusPayloadSerializer now preserves marked System Nexus envelopes while applying payload codecs only to their embedded user payloads.
 - Added operation-specific outbound workflow interceptors for Temporal System Nexus operations.
   `SignalWithStartWorkflowAsync` can now be intercepted before the existing
   `ScheduleSystemNexusOperationAsync` hook.
@@ -54,7 +56,7 @@ to docs, or any other relevant information.
   non-retryable `BadRequest` handler exception (with the application failure as its cause) instead of
   an `Internal` one. This lets a data converter signal that the input itself is invalid. The handler
   exception is reported as `Invalid operation input`, which is distinct from the `failed to decode
-  Nexus operation input` message used when decoding itself fails. Application failures of any other
+Nexus operation input` message used when decoding itself fails. Application failures of any other
   error type, and retryable `PayloadValidationError` failures, keep their existing behavior.
 
 ### Fixed
@@ -197,6 +199,7 @@ to docs, or any other relevant information.
 - Fixed `ClientEnvConfig` TLS-disabled profiles to preserve disabled TLS in connection options.
 - OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic metric reader reports an export error.
 - Worker heartbeat now samples host CPU/memory at the heartbeat interval (only when enabled) rather than every 100ms.
+
 ### Added
 
 - Added the `[TemporalOperation]` attribute for declaring a Temporal-backed Nexus operation start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ to docs, or any other relevant information.
   non-retryable `BadRequest` handler exception (with the application failure as its cause) instead of
   an `Internal` one. This lets a data converter signal that the input itself is invalid. The handler
   exception is reported as `Invalid operation input`, which is distinct from the `failed to decode
-Nexus operation input` message used when decoding itself fails. Application failures of any other
+- Nexus operation input` message used when decoding itself fails. Application failures of any other
   error type, and retryable `PayloadValidationError` failures, keep their existing behavior.
 
 ### Fixed
@@ -212,7 +212,6 @@ Nexus operation input` message used when decoding itself fails. Application fail
 - Fixed `ClientEnvConfig` TLS-disabled profiles to preserve disabled TLS in connection options.
 - OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic metric reader reports an export error.
 - Worker heartbeat now samples host CPU/memory at the heartbeat interval (only when enabled) rather than every 100ms.
-
 ### Added
 
 - Added the `[TemporalOperation]` attribute for declaring a Temporal-backed Nexus operation start

--- a/src/Temporalio.SystemNexus.Generator/Program.cs
+++ b/src/Temporalio.SystemNexus.Generator/Program.cs
@@ -163,27 +163,6 @@ static void GeneratePayloadVisitor(
 
     builder.AppendLine("            };");
     builder.AppendLine();
-    builder.AppendLine("        internal static async Task<bool> TryVisitAsync(");
-    builder.AppendLine("            Payload payload,");
-    builder.AppendLine("            PayloadVisitor visitPayload,");
-    builder.AppendLine("            PayloadsVisitor visitPayloads)");
-    builder.AppendLine("        {");
-    builder.AppendLine("            if (!IsSystemPayload(payload))");
-    builder.AppendLine("            {");
-    builder.AppendLine("                return false;");
-    builder.AppendLine("            }");
-    builder.AppendLine();
-    builder.AppendLine("            if (!payload.Metadata.TryGetValue(\"messageType\", out var messageType) ||");
-    builder.AppendLine("                !EnvelopeVisitors.TryGetValue(messageType.ToStringUtf8(), out var visit))");
-    builder.AppendLine("            {");
-    builder.AppendLine("                throw new InvalidOperationException(");
-    builder.AppendLine("                    $\"Unrecognized marked System Nexus envelope message type: {messageType?.ToStringUtf8() ?? \"<missing>\"}\");");
-    builder.AppendLine("            }");
-    builder.AppendLine();
-    builder.AppendLine("            await visit(payload, visitPayload, visitPayloads).ConfigureAwait(false);");
-    builder.AppendLine("            return true;");
-    builder.AppendLine("        }");
-    builder.AppendLine();
     foreach (var operation in operationMessages)
     {
         EmitVisitMethod(builder, operation.Input, messages, containsPayloadMemo, emittedMethods);

--- a/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/Generated/SystemNexusPayloadVisitor.cs
@@ -415,27 +415,6 @@ namespace Temporalio.Worker
                         visitPayloads),
             };
 
-        internal static async Task<bool> TryVisitAsync(
-            Payload payload,
-            PayloadVisitor visitPayload,
-            PayloadsVisitor visitPayloads)
-        {
-            if (!IsSystemPayload(payload))
-            {
-                return false;
-            }
-
-            if (!payload.Metadata.TryGetValue("messageType", out var messageType) ||
-                !EnvelopeVisitors.TryGetValue(messageType.ToStringUtf8(), out var visit))
-            {
-                throw new InvalidOperationException(
-                    $"Unrecognized marked System Nexus envelope message type: {messageType?.ToStringUtf8() ?? "<missing>"}");
-            }
-
-            await visit(payload, visitPayload, visitPayloads).ConfigureAwait(false);
-            return true;
-        }
-
         private static async Task Visit_temporal_api_common_v1_Memo(
             global::Temporalio.Api.Common.V1.Memo value,
             PayloadVisitor visitPayload,

--- a/src/Temporalio/Worker/NexusPayloadSerializer.cs
+++ b/src/Temporalio/Worker/NexusPayloadSerializer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using NexusRpc;
@@ -7,6 +6,7 @@ using NexusRpc.Handlers;
 using Temporalio.Api.Common.V1;
 using Temporalio.Converters;
 using Temporalio.Exceptions;
+using Temporalio.Nexus;
 
 namespace Temporalio.Worker
 {
@@ -62,13 +62,8 @@ namespace Temporalio.Worker
             {
                 try
                 {
-                    var decoded = await dataConverter.PayloadCodec.DecodeAsync(
-                        new Payload[] { payload }).ConfigureAwait(false);
-                    if (decoded.Count != 1)
-                    {
-                        throw new ArgumentException($"Expected 1 payload, found {decoded.Count}");
-                    }
-                    payload = decoded.First();
+                    await PayloadCodecHelper.DecodeAsync(
+                        dataConverter.PayloadCodec, payload).ConfigureAwait(false);
                 }
                 catch (Exception e) when (PayloadValidationError.IsException(e))
                 {
@@ -97,7 +92,11 @@ namespace Temporalio.Worker
             object? result;
             try
             {
-                result = dataConverter.PayloadConverter.ToValue(payload, type);
+                var payloadConverter = SystemNexusPayloadVisitor.IsSystemPayload(payload) ?
+                    new SystemNexusPayloadConverter(
+                        dataConverter.PayloadConverter, dataConverter.FailureConverter) :
+                    dataConverter.PayloadConverter;
+                result = payloadConverter.ToValue(payload, type);
             }
             catch (Exception e) when (PayloadValidationError.IsException(e))
             {

--- a/src/Temporalio/Worker/NexusPayloadSerializer.cs
+++ b/src/Temporalio/Worker/NexusPayloadSerializer.cs
@@ -51,6 +51,16 @@ namespace Temporalio.Worker
             }
 
             var payload = Payload.Parser.ParseFrom(content.Data);
+            var isSystemPayload = SystemNexusPayloadVisitor.IsSystemPayload(payload);
+
+            if (isSystemPayload &&
+                !SystemNexusPayloadVisitor.TryGetVisitor(payload, out var messageType, out _))
+            {
+                throw new HandlerException(
+                    HandlerErrorType.Internal,
+                    $"Unrecognized System Nexus envelope message type: {messageType}",
+                    errorRetryBehavior: HandlerErrorRetryBehavior.Retryable);
+            }
 
             // Decode with payload codec if configured. Codec failures are treated as
             // retryable INTERNAL errors since they are typically transient (e.g. a remote
@@ -92,7 +102,7 @@ namespace Temporalio.Worker
             object? result;
             try
             {
-                var payloadConverter = SystemNexusPayloadVisitor.IsSystemPayload(payload) ?
+                var payloadConverter = isSystemPayload ?
                     new SystemNexusPayloadConverter(
                         dataConverter.PayloadConverter, dataConverter.FailureConverter) :
                     dataConverter.PayloadConverter;

--- a/src/Temporalio/Worker/PayloadCodecHelper.cs
+++ b/src/Temporalio/Worker/PayloadCodecHelper.cs
@@ -1,0 +1,128 @@
+#pragma warning disable SA1600 // Internal implementation plumbing.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Temporalio.Api.Common.V1;
+using Temporalio.Converters;
+
+namespace Temporalio.Worker
+{
+    internal static class PayloadCodecHelper
+    {
+        internal static async Task EncodeAsync(
+            IPayloadCodec codec, RepeatedField<Payload> payloads)
+        {
+            if (payloads.Count == 0)
+            {
+                return;
+            }
+            var newPayloads = new List<Payload>();
+            var codecPayloads = new List<Payload>();
+            foreach (var payload in payloads)
+            {
+                if (!await SystemNexusPayloadVisitor.TryVisitAsync(
+                        payload,
+                        payload => EncodeAsync(codec, payload),
+                        nestedPayloads => EncodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
+                {
+                    codecPayloads.Add(payload);
+                    continue;
+                }
+
+                if (codecPayloads.Count > 0)
+                {
+                    newPayloads.AddRange(await codec.EncodeAsync(codecPayloads).ConfigureAwait(false));
+                    codecPayloads.Clear();
+                }
+                newPayloads.Add(payload);
+            }
+            if (codecPayloads.Count > 0)
+            {
+                newPayloads.AddRange(await codec.EncodeAsync(codecPayloads).ConfigureAwait(false));
+            }
+            payloads.Clear();
+            payloads.AddRange(newPayloads);
+        }
+
+        internal static async Task EncodeAsync(IPayloadCodec codec, Payload payload)
+        {
+            if (await SystemNexusPayloadVisitor.TryVisitAsync(
+                    payload,
+                    nestedPayload => EncodeAsync(codec, nestedPayload),
+                    nestedPayloads => EncodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
+            {
+                return;
+            }
+            // We are gonna require a single result here. It is important that we do Single() call
+            // before clearing out payload to merge with since underlying enumerable may be lazy.
+            // If the returned payload is literally the same object as the one sent to the codec,
+            // we leave it alone.
+            var encodedList = await codec.EncodeAsync(new Payload[] { payload }).ConfigureAwait(false);
+            var encoded = encodedList.Single();
+            if (!ReferenceEquals(encoded, payload))
+            {
+                payload.Metadata.Clear();
+                payload.Data = ByteString.Empty;
+                payload.MergeFrom(encoded);
+            }
+        }
+
+        internal static async Task DecodeAsync(IPayloadCodec codec, RepeatedField<Payload> payloads)
+        {
+            if (payloads.Count == 0)
+            {
+                return;
+            }
+            var newPayloads = new List<Payload>();
+            var codecPayloads = new List<Payload>();
+            foreach (var payload in payloads)
+            {
+                if (!await SystemNexusPayloadVisitor.TryVisitAsync(
+                        payload,
+                        payload => DecodeAsync(codec, payload),
+                        nestedPayloads => DecodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
+                {
+                    codecPayloads.Add(payload);
+                    continue;
+                }
+
+                if (codecPayloads.Count > 0)
+                {
+                    newPayloads.AddRange(await codec.DecodeAsync(codecPayloads).ConfigureAwait(false));
+                    codecPayloads.Clear();
+                }
+                newPayloads.Add(payload);
+            }
+            if (codecPayloads.Count > 0)
+            {
+                newPayloads.AddRange(await codec.DecodeAsync(codecPayloads).ConfigureAwait(false));
+            }
+            payloads.Clear();
+            payloads.AddRange(newPayloads);
+        }
+
+        internal static async Task DecodeAsync(IPayloadCodec codec, Payload payload)
+        {
+            if (await SystemNexusPayloadVisitor.TryVisitAsync(
+                    payload,
+                    nestedPayload => DecodeAsync(codec, nestedPayload),
+                    nestedPayloads => DecodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
+            {
+                return;
+            }
+            // We are gonna require a single result here.
+            // Similarly with encode, we leave the payload alone if it's exactly the same object as the original.
+            var decoded = await codec.DecodeAsync(new Payload[] { payload }).ConfigureAwait(false);
+            var decodedPayload = decoded.Single();
+            if (!ReferenceEquals(decodedPayload, payload))
+            {
+                payload.Metadata.Clear();
+                payload.Data = ByteString.Empty;
+                payload.MergeFrom(decodedPayload);
+            }
+        }
+    }
+}

--- a/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
@@ -30,6 +30,46 @@ namespace Temporalio.Worker
             payload.Metadata.TryGetValue(SystemPayloadMetadataKey, out var value) &&
             value.Equals(SystemPayloadMetadataValue);
 
+        internal static bool TryGetVisitor(Payload payload, out string messageType, out Func<Payload, PayloadVisitor, PayloadsVisitor, Task>? visit)
+        {
+            if (!payload.Metadata.TryGetValue("messageType", out var messageByteString))
+            {
+                visit = null;
+                messageType = "<missing>";
+                return false;
+            }
+
+            messageType = messageByteString.ToStringUtf8();
+
+            if (!EnvelopeVisitors.TryGetValue(messageType, out visit))
+            {
+                visit = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        internal static async Task<bool> TryVisitAsync(
+            Payload payload,
+            PayloadVisitor visitPayload,
+            PayloadsVisitor visitPayloads)
+        {
+            if (!IsSystemPayload(payload))
+            {
+                return false;
+            }
+
+            if (!TryGetVisitor(payload, out var messageType, out var visit))
+            {
+                throw new InvalidOperationException(
+                    $"Unrecognized marked System Nexus envelope message type: {messageType}");
+            }
+
+            await visit!(payload, visitPayload, visitPayloads).ConfigureAwait(false);
+            return true;
+        }
+
         private static async Task VisitEnvelopeAsync<T>(
             Payload payload,
             Func<T, PayloadVisitor, PayloadsVisitor, Task> visitMessage,

--- a/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
+++ b/src/Temporalio/Worker/SystemNexusPayloadVisitor.cs
@@ -26,6 +26,10 @@ namespace Temporalio.Worker
         internal static void MarkSystemPayload(Payload payload) =>
             payload.Metadata[SystemPayloadMetadataKey] = SystemPayloadMetadataValue;
 
+        internal static bool IsSystemPayload(Payload payload) =>
+            payload.Metadata.TryGetValue(SystemPayloadMetadataKey, out var value) &&
+            value.Equals(SystemPayloadMetadataValue);
+
         private static async Task VisitEnvelopeAsync<T>(
             Payload payload,
             Func<T, PayloadVisitor, PayloadsVisitor, Task> visitMessage,
@@ -43,9 +47,5 @@ namespace Temporalio.Worker
             MarkSystemPayload(payload);
             payload.Data = message.ToByteString();
         }
-
-        private static bool IsSystemPayload(Payload payload) =>
-            payload.Metadata.TryGetValue(SystemPayloadMetadataKey, out var value) &&
-            value.Equals(SystemPayloadMetadataValue);
     }
 }

--- a/src/Temporalio/Worker/WorkflowCodecHelper.cs
+++ b/src/Temporalio/Worker/WorkflowCodecHelper.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Temporalio.Api.Common.V1;
 using Temporalio.Bridge.Api.ActivityResult;
@@ -61,13 +58,15 @@ namespace Temporalio.Worker
                         if (context.CodecWorkflowContext != null)
                         {
                             await DecodeAsync(context.CodecWorkflowContext, job.DoUpdate.Headers).ConfigureAwait(false);
-                            await DecodeAsync(context.CodecWorkflowContext, job.DoUpdate.Input).ConfigureAwait(false);
+                            await PayloadCodecHelper.DecodeAsync(
+                                context.CodecWorkflowContext, job.DoUpdate.Input).ConfigureAwait(false);
                         }
                         break;
                     case WorkflowActivationJob.VariantOneofCase.QueryWorkflow:
                         if (context.CodecWorkflowContext != null)
                         {
-                            await DecodeAsync(context.CodecWorkflowContext, job.QueryWorkflow.Arguments).ConfigureAwait(false);
+                            await PayloadCodecHelper.DecodeAsync(
+                                context.CodecWorkflowContext, job.QueryWorkflow.Arguments).ConfigureAwait(false);
                             await DecodeAsync(context.CodecWorkflowContext, job.QueryWorkflow.Headers).ConfigureAwait(false);
                         }
                         break;
@@ -126,7 +125,7 @@ namespace Temporalio.Worker
                         }
                         if (job.ResolveNexusOperation.Result.Completed != null)
                         {
-                            await DecodeAsync(
+                            await PayloadCodecHelper.DecodeAsync(
                                 nexusCodec, job.ResolveNexusOperation.Result.Completed).
                                 ConfigureAwait(false);
                         }
@@ -198,7 +197,8 @@ namespace Temporalio.Worker
                     case WorkflowActivationJob.VariantOneofCase.SignalWorkflow:
                         if (context.CodecWorkflowContext != null)
                         {
-                            await DecodeAsync(context.CodecWorkflowContext, job.SignalWorkflow.Input).ConfigureAwait(false);
+                            await PayloadCodecHelper.DecodeAsync(
+                                context.CodecWorkflowContext, job.SignalWorkflow.Input).ConfigureAwait(false);
                             await DecodeAsync(context.CodecWorkflowContext, job.SignalWorkflow.Headers).ConfigureAwait(false);
                         }
                         break;
@@ -222,7 +222,7 @@ namespace Temporalio.Worker
                     codec = context.CodecWorkflowContext;
                     if (cmd.CancelWorkflowExecution.Details != null && codec != null)
                     {
-                        await EncodeAsync(
+                        await PayloadCodecHelper.EncodeAsync(
                             codec,
                             cmd.CancelWorkflowExecution.Details.Payloads_).ConfigureAwait(false);
                     }
@@ -231,7 +231,7 @@ namespace Temporalio.Worker
                     codec = context.CodecWorkflowContext;
                     if (cmd.CompleteWorkflowExecution.Result != null && codec != null)
                     {
-                        await EncodeAsync(
+                        await PayloadCodecHelper.EncodeAsync(
                             codec, cmd.CompleteWorkflowExecution.Result).ConfigureAwait(false);
                     }
                     break;
@@ -239,7 +239,7 @@ namespace Temporalio.Worker
                     codec = context.CodecWorkflowContext;
                     if (codec != null)
                     {
-                        await EncodeAsync(
+                        await PayloadCodecHelper.EncodeAsync(
                                 codec, cmd.ContinueAsNewWorkflowExecution.Arguments).ConfigureAwait(false);
                         await EncodeAsync(
                             codec, cmd.ContinueAsNewWorkflowExecution.Memo).ConfigureAwait(false);
@@ -272,7 +272,7 @@ namespace Temporalio.Worker
                     }
                     else if (cmd.RespondToQuery.Succeeded?.Response != null && codec != null)
                     {
-                        await EncodeAsync(
+                        await PayloadCodecHelper.EncodeAsync(
                             codec, cmd.RespondToQuery.Succeeded.Response).ConfigureAwait(false);
                     }
                     break;
@@ -293,7 +293,8 @@ namespace Temporalio.Worker
                     }
                     if (codec != null)
                     {
-                        await EncodeAsync(codec, cmd.ScheduleActivity.Arguments).ConfigureAwait(false);
+                        await PayloadCodecHelper.EncodeAsync(
+                            codec, cmd.ScheduleActivity.Arguments).ConfigureAwait(false);
                         await EncodeAsync(codec, cmd.ScheduleActivity.Headers).ConfigureAwait(false);
                     }
                     break;
@@ -314,7 +315,7 @@ namespace Temporalio.Worker
                     }
                     if (codec != null)
                     {
-                        await EncodeAsync(
+                        await PayloadCodecHelper.EncodeAsync(
                             codec, cmd.ScheduleLocalActivity.Arguments).ConfigureAwait(false);
                         await EncodeAsync(
                             codec, cmd.ScheduleLocalActivity.Headers).ConfigureAwait(false);
@@ -335,7 +336,7 @@ namespace Temporalio.Worker
                     }
                     if (codec != null)
                     {
-                        await EncodeAsync(
+                        await PayloadCodecHelper.EncodeAsync(
                             codec, cmd.SignalExternalWorkflowExecution.Args).ConfigureAwait(false);
                         await EncodeAsync(
                             codec, cmd.SignalExternalWorkflowExecution.Headers).ConfigureAwait(false);
@@ -346,7 +347,8 @@ namespace Temporalio.Worker
                     codec = context.CodecNoContext;
                     if (cmd.ScheduleNexusOperation.Input != null && codec != null)
                     {
-                        await EncodeAsync(codec, cmd.ScheduleNexusOperation.Input).ConfigureAwait(false);
+                        await PayloadCodecHelper.EncodeAsync(
+                            codec, cmd.ScheduleNexusOperation.Input).ConfigureAwait(false);
                     }
                     break;
                 case WorkflowCommand.VariantOneofCase.StartChildWorkflowExecution:
@@ -361,7 +363,7 @@ namespace Temporalio.Worker
                     }
                     if (codec != null)
                     {
-                        await EncodeAsync(
+                        await PayloadCodecHelper.EncodeAsync(
                             codec, cmd.StartChildWorkflowExecution.Input).ConfigureAwait(false);
                         await EncodeAsync(
                             codec, cmd.StartChildWorkflowExecution.Memo).ConfigureAwait(false);
@@ -376,7 +378,7 @@ namespace Temporalio.Worker
                     codec = context.CodecWorkflowContext;
                     if (cmd.UpdateResponse.Completed is { } updateCompleted && codec != null)
                     {
-                        await EncodeAsync(codec, updateCompleted).ConfigureAwait(false);
+                        await PayloadCodecHelper.EncodeAsync(codec, updateCompleted).ConfigureAwait(false);
                     }
                     else if (cmd.UpdateResponse.Rejected is { } updateRejected && codec != null)
                     {
@@ -391,11 +393,13 @@ namespace Temporalio.Worker
             {
                 if (cmd.UserMetadata.Summary != null)
                 {
-                    await EncodeAsync(codec, cmd.UserMetadata.Summary).ConfigureAwait(false);
+                    await PayloadCodecHelper.EncodeAsync(
+                        codec, cmd.UserMetadata.Summary).ConfigureAwait(false);
                 }
                 if (cmd.UserMetadata.Details != null)
                 {
-                    await EncodeAsync(codec, cmd.UserMetadata.Details).ConfigureAwait(false);
+                    await PayloadCodecHelper.EncodeAsync(
+                        codec, cmd.UserMetadata.Details).ConfigureAwait(false);
                 }
             }
             if (codec != null)
@@ -404,7 +408,7 @@ namespace Temporalio.Worker
                 {
                     if (marker.Label?.Label_ is { } markerLabel)
                     {
-                        await EncodeAsync(codec, markerLabel).ConfigureAwait(false);
+                        await PayloadCodecHelper.EncodeAsync(codec, markerLabel).ConfigureAwait(false);
                     }
                 }
             }
@@ -417,66 +421,8 @@ namespace Temporalio.Worker
             {
                 if (val != null)
                 {
-                    await EncodeAsync(codec, val).ConfigureAwait(false);
+                    await PayloadCodecHelper.EncodeAsync(codec, val).ConfigureAwait(false);
                 }
-            }
-        }
-
-        private static async Task EncodeAsync(
-            IPayloadCodec codec, RepeatedField<Payload> payloads)
-        {
-            if (payloads.Count == 0)
-            {
-                return;
-            }
-            var newPayloads = new List<Payload>();
-            var codecPayloads = new List<Payload>();
-            foreach (var payload in payloads)
-            {
-                if (!await SystemNexusPayloadVisitor.TryVisitAsync(
-                        payload,
-                        payload => EncodeAsync(codec, payload),
-                        nestedPayloads => EncodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
-                {
-                    codecPayloads.Add(payload);
-                    continue;
-                }
-
-                if (codecPayloads.Count > 0)
-                {
-                    newPayloads.AddRange(await codec.EncodeAsync(codecPayloads).ConfigureAwait(false));
-                    codecPayloads.Clear();
-                }
-                newPayloads.Add(payload);
-            }
-            if (codecPayloads.Count > 0)
-            {
-                newPayloads.AddRange(await codec.EncodeAsync(codecPayloads).ConfigureAwait(false));
-            }
-            payloads.Clear();
-            payloads.AddRange(newPayloads);
-        }
-
-        private static async Task EncodeAsync(IPayloadCodec codec, Payload payload)
-        {
-            if (await SystemNexusPayloadVisitor.TryVisitAsync(
-                    payload,
-                    nestedPayload => EncodeAsync(codec, nestedPayload),
-                    nestedPayloads => EncodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
-            {
-                return;
-            }
-            // We are gonna require a single result here. It is important that we do Single() call
-            // before clearing out payload to merge with since underlying enumerable may be lazy.
-            // If the returned payload is literally the same object as the one sent to the codec,
-            // we leave it alone.
-            var encodedList = await codec.EncodeAsync(new Payload[] { payload }).ConfigureAwait(false);
-            var encoded = encodedList.Single();
-            if (!ReferenceEquals(encoded, payload))
-            {
-                payload.Metadata.Clear();
-                payload.Data = ByteString.Empty;
-                payload.MergeFrom(encoded);
             }
         }
 
@@ -493,7 +439,8 @@ namespace Temporalio.Worker
                 case ActivityResolution.StatusOneofCase.Completed:
                     if (res.Completed.Result != null)
                     {
-                        await DecodeAsync(codec, res.Completed.Result).ConfigureAwait(false);
+                        await PayloadCodecHelper.DecodeAsync(
+                            codec, res.Completed.Result).ConfigureAwait(false);
                     }
                     break;
                 case ActivityResolution.StatusOneofCase.Failed:
@@ -518,7 +465,8 @@ namespace Temporalio.Worker
                 case ChildWorkflowResult.StatusOneofCase.Completed:
                     if (res.Completed.Result != null)
                     {
-                        await DecodeAsync(codec, res.Completed.Result).ConfigureAwait(false);
+                        await PayloadCodecHelper.DecodeAsync(
+                            codec, res.Completed.Result).ConfigureAwait(false);
                     }
                     break;
                 case ChildWorkflowResult.StatusOneofCase.Failed:
@@ -532,7 +480,7 @@ namespace Temporalio.Worker
 
         private static async Task DecodeAsync(IPayloadCodec codec, InitializeWorkflow init)
         {
-            await DecodeAsync(codec, init.Arguments).ConfigureAwait(false);
+            await PayloadCodecHelper.DecodeAsync(codec, init.Arguments).ConfigureAwait(false);
             if (init.ContinuedFailure != null)
             {
                 await codec.DecodeFailureAsync(init.ContinuedFailure).ConfigureAwait(false);
@@ -544,7 +492,8 @@ namespace Temporalio.Worker
             await DecodeAsync(codec, init.Headers).ConfigureAwait(false);
             if (init.LastCompletionResult != null)
             {
-                await DecodeAsync(codec, init.LastCompletionResult.Payloads_).ConfigureAwait(false);
+                await PayloadCodecHelper.DecodeAsync(
+                    codec, init.LastCompletionResult.Payloads_).ConfigureAwait(false);
             }
         }
 
@@ -555,63 +504,8 @@ namespace Temporalio.Worker
             {
                 if (val != null)
                 {
-                    await DecodeAsync(codec, val).ConfigureAwait(false);
+                    await PayloadCodecHelper.DecodeAsync(codec, val).ConfigureAwait(false);
                 }
-            }
-        }
-
-        private static async Task DecodeAsync(IPayloadCodec codec, RepeatedField<Payload> payloads)
-        {
-            if (payloads.Count == 0)
-            {
-                return;
-            }
-            var newPayloads = new List<Payload>();
-            var codecPayloads = new List<Payload>();
-            foreach (var payload in payloads)
-            {
-                if (!await SystemNexusPayloadVisitor.TryVisitAsync(
-                        payload,
-                        payload => DecodeAsync(codec, payload),
-                        nestedPayloads => DecodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
-                {
-                    codecPayloads.Add(payload);
-                    continue;
-                }
-
-                if (codecPayloads.Count > 0)
-                {
-                    newPayloads.AddRange(await codec.DecodeAsync(codecPayloads).ConfigureAwait(false));
-                    codecPayloads.Clear();
-                }
-                newPayloads.Add(payload);
-            }
-            if (codecPayloads.Count > 0)
-            {
-                newPayloads.AddRange(await codec.DecodeAsync(codecPayloads).ConfigureAwait(false));
-            }
-            payloads.Clear();
-            payloads.AddRange(newPayloads);
-        }
-
-        private static async Task DecodeAsync(IPayloadCodec codec, Payload payload)
-        {
-            if (await SystemNexusPayloadVisitor.TryVisitAsync(
-                    payload,
-                    nestedPayload => DecodeAsync(codec, nestedPayload),
-                    nestedPayloads => DecodeAsync(codec, nestedPayloads)).ConfigureAwait(false))
-            {
-                return;
-            }
-            // We are gonna require a single result here.
-            // Similarly with encode, we leave the payload alone if it's exactly the same object as the original.
-            var decoded = await codec.DecodeAsync(new Payload[] { payload }).ConfigureAwait(false);
-            var decodedPayload = decoded.Single();
-            if (!ReferenceEquals(decodedPayload, payload))
-            {
-                payload.Metadata.Clear();
-                payload.Data = ByteString.Empty;
-                payload.MergeFrom(decodedPayload);
             }
         }
 

--- a/tests/Temporalio.Tests/Worker/NexusPayloadSerializerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusPayloadSerializerTests.cs
@@ -9,15 +9,132 @@ using NexusRpc.Handlers;
 using Temporalio.Api.Common.V1;
 using Temporalio.Converters;
 using Temporalio.Exceptions;
+using Temporalio.Nexus;
 using Temporalio.Worker;
+using Temporalio.Workflows;
 using Xunit;
 
 /// <summary>
-/// Server-independent unit tests for how <see cref="NexusPayloadSerializer"/> translates data
-/// converter failures into Nexus handler errors.
+/// Server-independent unit tests for Nexus payload decoding and converter failure translation.
 /// </summary>
 public class NexusPayloadSerializerTests
 {
+    [Fact]
+    public async Task DeserializeAsync_SystemPayload_UsesSystemConverter()
+    {
+        var dataConverter = DataConverter.Default;
+        var request = new SignalWithStartWorkflowRequest(
+            workflow: "test-workflow",
+            id: "target-workflow-id",
+            taskQueue: "target-task-queue",
+            signal: "test-signal",
+            @namespace: "target-namespace")
+        {
+            Args = new object?[] { "workflow-input" },
+        };
+        var payload = new SystemNexusPayloadConverter(
+            dataConverter.PayloadConverter, dataConverter.FailureConverter).ToPayload(request);
+        Assert.True(SystemNexusPayloadVisitor.IsSystemPayload(payload));
+
+        var result = Assert.IsType<SignalWithStartWorkflowRequest>(
+            await new NexusPayloadSerializer(dataConverter).DeserializeAsync(
+                new(payload.ToByteArray()), typeof(SignalWithStartWorkflowRequest)));
+
+        Assert.Equal("workflow-input", Assert.Single(result.Args!)?.ToString());
+    }
+
+    [Fact]
+    public async Task DeserializeAsync_SystemPayload_AppliesTransferTypeConverter()
+    {
+        var transferValue = new WorkflowType { Name = "test-value" };
+        Assert.True(new BinaryProtoConverter().TryToPayload(transferValue, out var payload));
+        SystemNexusPayloadVisitor.MarkSystemPayload(payload!);
+
+        var result = Assert.IsType<TestSystemRequest>(
+            await new NexusPayloadSerializer(DataConverter.Default).DeserializeAsync(
+                new(payload!.ToByteArray()), typeof(TestSystemRequest)));
+
+        Assert.Equal(new TestSystemRequest("test-value"), result);
+    }
+
+    [TemporalTransferTypeConverter(typeof(TestSystemRequestConverter))]
+    public sealed record TestSystemRequest(string Value);
+
+    public sealed class TestSystemRequestConverter : ITemporalTransferTypeConverter
+    {
+        public Type TransferType => typeof(WorkflowType);
+
+        public object ToTransferType(object? value) =>
+            new WorkflowType { Name = ((TestSystemRequest)value!).Value };
+
+        public object FromTransferType(object? transferType) =>
+            new TestSystemRequest(((WorkflowType)transferType!).Name);
+    }
+
+    [Fact]
+    public async Task DeserializeAsync_SystemPayloadWithCodec_DecodesNestedPayloads()
+    {
+        var codec = new ReplacingPayloadCodec();
+        var dataConverter = DataConverter.Default with { PayloadCodec = codec };
+        var request = new SignalWithStartWorkflowRequest(
+            workflow: "test-workflow",
+            id: "target-workflow-id",
+            taskQueue: "target-task-queue",
+            signal: "test-signal",
+            @namespace: "target-namespace")
+        {
+            Args = new object?[] { "workflow-input" },
+        };
+        var payload = new SystemNexusPayloadConverter(
+            dataConverter.PayloadConverter, dataConverter.FailureConverter).ToPayload(request);
+
+        var result = Assert.IsType<SignalWithStartWorkflowRequest>(
+            await new NexusPayloadSerializer(dataConverter).DeserializeAsync(
+                new(payload.ToByteArray()), typeof(SignalWithStartWorkflowRequest)));
+
+        Assert.Equal(1, codec.DecodeCount);
+        Assert.Equal(0, codec.EncodeCount);
+        Assert.Equal("decoded-input", Assert.Single(result.Args!)?.ToString());
+    }
+
+    private class ReplacingPayloadCodec : IPayloadCodec
+    {
+        public int DecodeCount { get; private set; }
+
+        public int EncodeCount { get; private set; }
+
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(
+            IReadOnlyCollection<Payload> payloads)
+        {
+            EncodeCount++;
+            return Task.FromResult(payloads);
+        }
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(
+            IReadOnlyCollection<Payload> payloads)
+        {
+            Assert.All(payloads, payload =>
+                Assert.False(SystemNexusPayloadVisitor.IsSystemPayload(payload)));
+            DecodeCount++;
+            return Task.FromResult<IReadOnlyCollection<Payload>>(new[]
+            {
+                DataConverter.Default.PayloadConverter.ToPayload("decoded-input"),
+            });
+        }
+    }
+
+    [Fact]
+    public async Task DeserializeAsync_UnmarkedPayload_UsesUserConverter()
+    {
+        var payload = DataConverter.Default.PayloadConverter.ToPayload("ordinary-input");
+        Assert.False(SystemNexusPayloadVisitor.IsSystemPayload(payload));
+
+        var result = await new NexusPayloadSerializer(DataConverter.Default).DeserializeAsync(
+            new(payload.ToByteArray()), typeof(string));
+
+        Assert.Equal("ordinary-input", result);
+    }
+
     [Fact]
     public async Task DeserializeAsync_ConverterPayloadValidationFailure_BecomesBadRequest()
     {

--- a/tests/Temporalio.Tests/Worker/NexusPayloadSerializerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusPayloadSerializerTests.cs
@@ -7,6 +7,7 @@ using Google.Protobuf;
 using NexusRpc;
 using NexusRpc.Handlers;
 using Temporalio.Api.Common.V1;
+using Temporalio.Api.WorkflowService.V1;
 using Temporalio.Converters;
 using Temporalio.Exceptions;
 using Temporalio.Nexus;
@@ -46,7 +47,7 @@ public class NexusPayloadSerializerTests
     [Fact]
     public async Task DeserializeAsync_SystemPayload_AppliesTransferTypeConverter()
     {
-        var transferValue = new WorkflowType { Name = "test-value" };
+        var transferValue = new SignalWithStartWorkflowExecutionRequest { Namespace = "test-value" };
         Assert.True(new BinaryProtoConverter().TryToPayload(transferValue, out var payload));
         SystemNexusPayloadVisitor.MarkSystemPayload(payload!);
 
@@ -62,13 +63,40 @@ public class NexusPayloadSerializerTests
 
     public sealed class TestSystemRequestConverter : ITemporalTransferTypeConverter
     {
-        public Type TransferType => typeof(WorkflowType);
+        public Type TransferType => typeof(SignalWithStartWorkflowExecutionRequest);
 
         public object ToTransferType(object? value) =>
-            new WorkflowType { Name = ((TestSystemRequest)value!).Value };
+            new SignalWithStartWorkflowExecutionRequest { Namespace = ((TestSystemRequest)value!).Value };
 
         public object FromTransferType(object? transferType) =>
-            new TestSystemRequest(((WorkflowType)transferType!).Name);
+            new TestSystemRequest(((SignalWithStartWorkflowExecutionRequest)transferType!).Namespace);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DeserializeAsync_UnknownSystemPayload_BecomesRetryableInternal(bool withCodec)
+    {
+        var codec = new CountingPayloadCodec();
+        var dataConverter = withCodec ?
+            DataConverter.Default with { PayloadCodec = codec } :
+            DataConverter.Default;
+        var payload = DataConverter.Default.PayloadConverter.ToPayload("ignored");
+        payload.Metadata["messageType"] = ByteString.CopyFromUtf8(
+            "temporal.api.workflowservice.v1.UnknownRequest");
+        SystemNexusPayloadVisitor.MarkSystemPayload(payload);
+
+        var exc = await Assert.ThrowsAsync<HandlerException>(() =>
+            new NexusPayloadSerializer(dataConverter).DeserializeAsync(
+                new(payload.ToByteArray()), typeof(string)));
+
+        Assert.Equal(HandlerErrorType.Internal, exc.ErrorType);
+        Assert.Equal(HandlerErrorRetryBehavior.Retryable, exc.ErrorRetryBehavior);
+        Assert.Equal(
+            "Unrecognized System Nexus envelope message type: " +
+            "temporal.api.workflowservice.v1.UnknownRequest",
+            exc.Message);
+        Assert.Equal(0, codec.DecodeCount);
     }
 
     [Fact]
@@ -120,6 +148,21 @@ public class NexusPayloadSerializerTests
             {
                 DataConverter.Default.PayloadConverter.ToPayload("decoded-input"),
             });
+        }
+    }
+
+    private class CountingPayloadCodec : IPayloadCodec
+    {
+        public int DecodeCount { get; private set; }
+
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(
+            IReadOnlyCollection<Payload> payloads) => Task.FromResult(payloads);
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(
+            IReadOnlyCollection<Payload> payloads)
+        {
+            DecodeCount++;
+            return Task.FromResult(payloads);
         }
     }
 

--- a/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
+++ b/tests/Temporalio.Tests/Worker/NexusWorkerTests.cs
@@ -1590,6 +1590,81 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             $"Expected at least 2 decode calls (confirming retry), got {codec.DecodeCallCount}");
     }
 
+    private class RejectSystemEnvelopeCodec : IPayloadCodec
+    {
+        private readonly Converters.Base64PayloadCodec inner = new();
+
+        public Task<IReadOnlyCollection<Payload>> EncodeAsync(
+            IReadOnlyCollection<Payload> payloads)
+        {
+            Assert.All(payloads, payload =>
+                Assert.False(SystemNexusPayloadVisitor.IsSystemPayload(payload)));
+            return inner.EncodeAsync(payloads);
+        }
+
+        public Task<IReadOnlyCollection<Payload>> DecodeAsync(
+            IReadOnlyCollection<Payload> payloads)
+        {
+            Assert.All(payloads, payload =>
+                Assert.False(SystemNexusPayloadVisitor.IsSystemPayload(payload)));
+            return inner.DecodeAsync(payloads);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteNexusOperationAsync_SystemPayloadWithCodec_DecodesNestedPayloads()
+    {
+        const string service = "system-payload-service";
+        const string operation = "decode";
+        var clientOptions = (TemporalClientOptions)Client.Options.Clone();
+        clientOptions.DataConverter = DataConverter.Default with
+        {
+            PayloadCodec = new RejectSystemEnvelopeCodec(),
+        };
+        var codecClient = new TemporalClient(Client.Connection, clientOptions);
+        var systemPayload = new SystemNexusPayloadConverter(
+            DataConverter.Default.PayloadConverter,
+            DataConverter.Default.FailureConverter).ToPayload(
+                new SignalWithStartWorkflowRequest(
+                    workflow: "test-workflow",
+                    id: "target-workflow-id",
+                    taskQueue: "target-task-queue",
+                    signal: "test-signal",
+                    @namespace: "target-namespace")
+                {
+                    Args = new object?[] { "workflow-input" },
+                });
+
+        var workerOptions = new TemporalWorkerOptions($"tq-{Guid.NewGuid()}");
+        workerOptions.NexusServices.Add(new ServiceHandlerInstance(
+            new ServiceDefinition(
+                service,
+                new Dictionary<string, OperationDefinition>
+                {
+                    [operation] = new(
+                        operation,
+                        typeof(SignalWithStartWorkflowRequest),
+                        typeof(string)),
+                }),
+            new Dictionary<string, IOperationHandler<object?, object?>>
+            {
+                [operation] = OperationHandler.Sync<object?, object?>((context, input) =>
+                {
+                    var request = Assert.IsType<SignalWithStartWorkflowRequest>(input);
+                    return Assert.Single(request.Args!)?.ToString();
+                }),
+            }));
+        var endpoint = await CreateNexusEndpointAsync(workerOptions.TaskQueue!);
+
+        await RunInWorkflowAsync(
+            workerOptions,
+            () => Workflow.CreateNexusWorkflowClient(service, endpoint).
+                ExecuteNexusOperationAsync<string>(operation, new RawValue(systemPayload.Clone())),
+            checkResultFunc: async handle =>
+                Assert.Equal("workflow-input", await handle.GetResultAsync()),
+            client: codecClient);
+    }
+
     [NexusService]
     public interface INoArgService
     {
@@ -2912,8 +2987,10 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
         Func<Task<TResult>> inWorkflowFunc,
         Func<WorkflowHandle<CustomFuncWorkflow, TResult>, Task>? beforeGetResultFunc = null,
         Func<WorkflowHandle<CustomFuncWorkflow, TResult>, Task>? checkResultFunc = null,
-        string? callerWorkflowId = null)
+        string? callerWorkflowId = null,
+        TemporalClient? client = null)
     {
+        client ??= (TemporalClient)Client;
         workerOptions = (TemporalWorkerOptions)workerOptions.Clone();
         // We want xUnit assertions to fail the workflow
         workerOptions.Interceptors = (workerOptions.Interceptors ?? Array.Empty<IWorkerInterceptor>()).
@@ -2922,14 +2999,14 @@ public class NexusWorkerTests : WorkflowEnvironmentTestBase
             typeof(CustomFuncWorkflow),
             null,
             _args => new CustomFuncWorkflow(async () => await inWorkflowFunc())));
-        using var worker = new TemporalWorker(Client, workerOptions);
+        using var worker = new TemporalWorker(client, workerOptions);
         return await worker.ExecuteAsync(async () =>
         {
-            var untypedHandle = await Client.StartWorkflowAsync(
+            var untypedHandle = await client.StartWorkflowAsync(
                 (CustomFuncWorkflow wf) => wf.RunAsync(),
                 new(callerWorkflowId ?? $"wf-{Guid.NewGuid()}", workerOptions.TaskQueue!));
             var handle = new WorkflowHandle<CustomFuncWorkflow, TResult>(
-                Client: Client,
+                Client: client,
                 Id: untypedHandle.Id,
                 RunId: untypedHandle.RunId,
                 ResultRunId: untypedHandle.ResultRunId,


### PR DESCRIPTION
## What was changed

- Detect marked Temporal System Nexus inputs in the Nexus worker and deserialize their outer envelope with the System Nexus payload converter.
- Apply payload codecs only to embedded user payloads while preserving the marked outer envelope.
- Move shared payload codec traversal into `PayloadCodecHelper` for use by workflow and Nexus worker paths.
- Add serializer and workflow-to-worker coverage for System Nexus conversion and nested codec application.

## Why?

System Nexus inputs are protobuf envelopes containing user payloads. The Nexus worker needs to handle these envelopes to support upcoming features.

## Checklist

1. How was this tested:
   - Added tests for new functionality
   - Existing tests

