### PR TITLE
fix: apply serialization context to Nexus operation summary

### DIFF
--- a/src/Temporalio/Worker/WorkflowInstance.cs
+++ b/src/Temporalio/Worker/WorkflowInstance.cs
@@ -2743,7 +2743,7 @@ namespace Temporalio.Worker
                 {
                     workflowCommand.UserMetadata = new()
                     {
-                        Summary = instance.payloadConverterNoContext.ToPayload(summary),
+                        Summary = payloadConverter.ToPayload(summary),
                     };
                 }
                 instance.AddCommand(workflowCommand);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix summary conversion for Nexus operations to use user-defined payload converter.

## Why?

The .NET SDK uniformly applies the user-defined payload converter with the related serialization context to user metadata summaries. However, this was changed in #846 to use the payload converter without the serialization context. This is not a problem today because (1) System Nexus Operations do not specify a summary, and (2) there is no serialization context for user-defined Nexus Operations (yet).

Fixing this now before it is forgotten. This cannot be tested in any meaningful way today because there is no scenario that encounters it.